### PR TITLE
手札に戻す

### DIFF
--- a/src/database/effects/cards/1-0-019.ts
+++ b/src/database/effects/cards/1-0-019.ts
@@ -1,0 +1,24 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard): Promise<void> => {
+    const owner = EffectHelper.owner(stack.core, stack.processing);
+    const opponent = EffectHelper.opponent(stack.core, stack.processing);
+    const isOnField = opponent.field.length > 0;
+
+    if (isOnField) {
+      await System.show(stack, 'ジャンプーダンス', '手札に戻す');
+      const [choice] = await System.prompt(stack, owner.id, {
+        title: '手札に戻すユニットを選択',
+        type: 'unit',
+        items: opponent.field,
+      });
+
+      const target = opponent.field.find(unit => unit.id === choice) ?? opponent.field[0];
+      if (!target) throw new Error('対戦相手のフィールドにユニットが存在しません');
+
+      Effect.bounce(stack, stack.processing, target, 'hand');
+    }
+  },
+};

--- a/src/database/effects/cards/2-0-008.ts
+++ b/src/database/effects/cards/2-0-008.ts
@@ -4,7 +4,7 @@ import type { CardEffects, StackWithCard } from '../classes/types';
 export const effects: CardEffects = {
   onOverclockSelf: async (stack: StackWithCard): Promise<void> => {
     await System.show(stack, 'ビッカーンッ！', '全てのユニットを手札に戻す');
-    [...stack.core.players.map(player => player.field).flat()].forEach(unit =>
+    [...stack.core.players.flatMap(player => player.field)].forEach(unit =>
       Effect.bounce(stack, stack.processing, unit, 'hand')
     );
   },

--- a/src/database/effects/cards/2-0-008.ts
+++ b/src/database/effects/cards/2-0-008.ts
@@ -1,0 +1,11 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  onOverclockSelf: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, 'ビッカーンッ！', '全てのユニットを手札に戻す');
+    [...stack.core.players.map(player => player.field).flat()].forEach(unit =>
+      Effect.bounce(stack, stack.processing, unit, 'hand')
+    );
+  },
+};

--- a/src/database/effects/classes/effect.ts
+++ b/src/database/effects/classes/effect.ts
@@ -75,9 +75,9 @@ export class Effect {
   }
 
   /**
-   * 対象を破壊する
+   * 対象を移動させる
    * @param source 効果の発動元
-   * @param target 破壊の対象
+   * @param target 移動の対象
    */
   static bounce(
     stack: Stack,

--- a/src/database/effects/classes/effect.ts
+++ b/src/database/effects/classes/effect.ts
@@ -75,6 +75,41 @@ export class Effect {
   }
 
   /**
+   * 対象を破壊する
+   * @param source 効果の発動元
+   * @param target 破壊の対象
+   */
+  static bounce(
+    stack: Stack,
+    source: Card,
+    target: Unit,
+    location: 'hand' | 'deck' | 'trigger' = 'hand'
+  ): void {
+    // 対象がフィールド上に存在するか確認
+    const exists = EffectHelper.owner(stack.core, target).find(target);
+    const isOnField =
+      exists.result && exists.place?.name === 'field' && target.destination !== location;
+
+    console.log(exists);
+    if (!isOnField) return;
+
+    console.log(
+      '[発動] %s の効果によって %s を %s に移動',
+      source.catalog().name,
+      target.catalog().name,
+      location
+    );
+
+    // TODO: 耐性持ちのチェックをここでやる
+    stack.addChildStack('bounce', source, target, {
+      type: 'bounce',
+      location,
+    });
+    target.destination = location;
+    stack.core.room.soundEffect('bang');
+  }
+
+  /**
    * 効果によって手札を捨てさせる
    * @param source 効果の発動元
    * @param target 破壊する手札

--- a/src/package/core/class/stack.ts
+++ b/src/package/core/class/stack.ts
@@ -8,6 +8,14 @@ import { Card, Unit } from './card';
 import { System } from '@/database/effects';
 import { Color } from '@/submodule/suit/constant/color';
 
+// PlayerのうちCard[]型であるプロパティ名から"called"を除外
+type CardArrayKeys = Exclude<
+  {
+    [K in keyof Player]: Player[K] extends Card[] ? K : never;
+  }[keyof Player],
+  'called'
+>;
+
 interface IStack {
   /**
    * @param type そのStackのタイプを示す
@@ -40,6 +48,10 @@ type StackOption =
       // 破壊
       type: 'break';
       cause: 'effect' | 'battle' | 'damage' | 'death';
+    }
+  | {
+      type: 'bounce';
+      location: 'hand' | 'deck' | 'trigger';
     }
   | {
       // ダメージ
@@ -184,28 +196,44 @@ export class Stack implements IStack {
 
     // Stackによって移動が約束されたユニットを移動させる
     if (this.children.length > 0) await new Promise(resolve => setTimeout(resolve, 500));
-    this.children.forEach(stack => {
+    const isProcessed = this.children.map(stack => {
+      const target = stack.target as Unit;
       switch (stack.type) {
-        case 'break': {
-          const broken: Unit = stack.target as Unit;
-          const owner = EffectHelper.owner(core, broken);
-
-          // ターゲットがフィールドに残留しているかチェック
-          const isOnField = owner.field.some(unit => unit.id === broken.id);
-          // 捨札に送る
-          if (isOnField) {
-            owner.field = owner.field.filter(unit => unit.id !== broken.id);
-            broken.lv = 1;
-            owner.trash.push(broken);
-            core.room.soundEffect('leave');
+        case 'break':
+          this.moveUnit(target, 'trash');
+          return true;
+        case 'bounce':
+          if (stack.option?.type === 'bounce') {
+            this.moveUnit(target, stack.option?.location, 'bounce');
           }
-          break;
-        }
+          return true;
       }
     });
 
     this.children = [];
     this.core.room.sync();
+
+    if (isProcessed.includes(true)) await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
+  private moveUnit(target: Unit, destination: CardArrayKeys, sound: string = 'leave') {
+    const owner = EffectHelper.owner(this.core, target);
+    // ターゲットがフィールドに残留しているかチェック
+    const isOnField = owner.field.some(unit => unit.id === target.id);
+
+    // destinationに送る
+    if (isOnField) {
+      console.log('%s を %s に移動', target.catalog().name, destination);
+      this.core.room.soundEffect(sound);
+      owner.field = owner.field.filter(unit => unit.id !== target.id);
+      target.lv = 1;
+
+      if (destination === 'hand' && owner.hand.length >= this.core.room.rule.player.max.hand) {
+        owner.trash.push(target);
+      } else {
+        owner[destination].push(target);
+      }
+    }
   }
 
   /**

--- a/src/package/core/class/stack.ts
+++ b/src/package/core/class/stack.ts
@@ -227,14 +227,16 @@ export class Stack implements IStack {
       this.core.room.soundEffect(sound);
       owner.field = owner.field.filter(unit => unit.id !== target.id);
       target.lv = 1;
+      target.destination = undefined;
+      target.bp.damage = 0;
+      target.bp.diff = 0;
+      target.overclocked = false;
 
       if (destination === 'hand' && owner.hand.length >= this.core.room.rule.player.max.hand) {
         owner.trash.push(target);
       } else {
         owner[destination].push(target);
       }
-
-      target.destination = undefined;
     }
   }
 

--- a/src/package/core/class/stack.ts
+++ b/src/package/core/class/stack.ts
@@ -233,6 +233,8 @@ export class Stack implements IStack {
       } else {
         owner[destination].push(target);
       }
+
+      target.destination = undefined;
     }
   }
 


### PR DESCRIPTION
ユニットを指定場所に移動する効果を実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 特定のカードが自分でドライブした際、相手フィールドのユニット1体を手札に戻す効果を追加しました。
  - 特定のカードがオーバークロックした際、全プレイヤーのフィールド上のユニットを手札に戻す効果を追加しました。

- **改善**
  - ユニットを手札・デッキ・トリガーに移動（バウンス）する処理を追加し、効果解決時の挙動が向上しました。
  - ユニット移動処理の内部構造を整理し、複数の移動パターンに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->