### PR TITLE
Feature/add cards

### DIFF
--- a/src/database/effects/cards/1-0-108.ts
+++ b/src/database/effects/cards/1-0-108.ts
@@ -1,0 +1,54 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■大天使の加護
+  // このユニットがフィールドに出た時、あなたの全てのユニットの行動権を回復する。
+  // ■サポーター／天使
+  // あなたの【天使】ユニットのBPを+1000する。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    await System.show(stack, '大天使の加護', '味方全体の行動権を回復\n【天使】のBPを+1000');
+
+    // 自分の全てのユニットの行動権を回復
+    for (const unit of owner.field) {
+      Effect.activate(stack, stack.processing, unit, true);
+    }
+  },
+
+  // フィールド効果：天使ユニットのBPを+1000する
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // 自分の天使ユニットを対象にする
+    owner.field.forEach(unit => {
+      // 天使ユニットか確認
+      if (unit.catalog.species?.includes('天使')) {
+        // 既にこのユニットが発行したDeltaが存在するか確認
+        const delta = unit.delta.find(
+          d => d.source?.unit === stack.processing.id && d.source?.effectCode === 'サポーター／天使'
+        );
+
+        if (delta && delta.effect.type === 'bp') {
+          // 既存のDeltaを更新
+          delta.effect.diff = 1000;
+        } else {
+          // 新しいDeltaを発行
+          Effect.modifyBP(stack, stack.processing, unit, 1000, {
+            source: { unit: stack.processing.id, effectCode: 'サポーター／天使' },
+          });
+        }
+      } else {
+        // 天使でなくなった場合、このユニットが付与したBP上昇を削除
+        unit.delta = unit.delta.filter(
+          d =>
+            !(d.source?.unit === stack.processing.id && d.source?.effectCode === 'サポーター／天使')
+        );
+      }
+    });
+  },
+};

--- a/src/database/effects/cards/1-1-011.ts
+++ b/src/database/effects/cards/1-1-011.ts
@@ -1,0 +1,94 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【加護】
+  // ■インフィニティーバースト
+  // このユニットがアタックした時、あなたのユニットを1体選ぶ。それの行動権を回復する。
+  // ■エンジェリックシールド
+  // あなたのライフが6以下の時、あなたの【天使】ユニットに【加護】を与える。
+
+  // 召喚時の効果：加護を付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(
+      stack,
+      'エンジェリックシールド＆加護',
+      '【加護】\n味方の【天使】に【加護】を付与'
+    );
+
+    // 加護を付与
+    Effect.keyword(stack, stack.processing, stack.processing, '加護');
+  },
+
+  // アタック時の効果
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分のユニットが存在するか確認
+    if (owner.field.length > 0) {
+      await System.show(stack, 'インフィニティーバースト', 'ユニットの行動権を回復');
+
+      // 対象を選択可能なユニットを取得
+      const targetCandidates = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === owner.id,
+        owner
+      );
+
+      if (targetCandidates.length > 0) {
+        // ユニットを1体選択
+        const [target] = await EffectHelper.selectUnit(
+          stack,
+          owner,
+          targetCandidates,
+          '行動権を回復するユニットを選択'
+        );
+
+        // 行動権を回復
+        Effect.activate(stack, stack.processing, target, true);
+      }
+    }
+  },
+
+  // フィールド効果：ライフが6以下の時、天使ユニットに加護を与える
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // ライフが6以下かチェック
+    const isLifeLow = owner.life.current <= 6;
+
+    // 自分のフィールドの天使ユニットを対象にする
+    owner.field.forEach(unit => {
+      // 天使ユニットか確認
+      if (unit.catalog.species?.includes('天使')) {
+        // 既にこのユニットが発行したDeltaが存在するか確認
+        const delta = unit.delta.find(
+          d =>
+            d.source?.unit === stack.processing.id &&
+            d.source?.effectCode === 'エンジェリックシールド'
+        );
+
+        if (isLifeLow) {
+          // ライフが6以下で、まだ加護を持っていなければ付与
+          if (!delta) {
+            Effect.keyword(stack, stack.processing, unit, '加護', {
+              source: { unit: stack.processing.id, effectCode: 'エンジェリックシールド' },
+            });
+          }
+        } else {
+          // ライフが7以上の場合、このユニットが付与した加護を削除
+          if (delta) {
+            unit.delta = unit.delta.filter(
+              d =>
+                !(
+                  d.source?.unit === stack.processing.id &&
+                  d.source?.effectCode === 'エンジェリックシールド'
+                )
+            );
+          }
+        }
+      }
+    });
+  },
+};

--- a/src/database/effects/cards/1-1-028.ts
+++ b/src/database/effects/cards/1-1-028.ts
@@ -1,0 +1,40 @@
+import { Unit } from '@/package/core/class/card';
+import { EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Color } from '@/submodule/suit/constant/color';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) => {
+    return stack.target instanceof Unit && stack.processing.owner.id === stack.target.owner.id;
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '天使の楽園', '【天使】を1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '天使' });
+  },
+
+  checkPlayerAttack: (stack: StackWithCard) => {
+    return stack.source instanceof Unit && stack.source.catalog.species?.includes('天使') === true;
+  },
+
+  onPlayerAttack: async (stack: StackWithCard) => {
+    await System.show(stack, '天使の楽園', '属性の異なる【天使】を2枚引く');
+    const colors = EffectHelper.shuffle([
+      Color.RED,
+      Color.YELLOW,
+      Color.BLUE,
+      Color.GREEN,
+      Color.PURPLE,
+    ]);
+    let count = 0;
+    for (const color of colors) {
+      count += EffectTemplate.reinforcements(stack, stack.processing.owner, {
+        species: '天使',
+        color,
+      })
+        ? 1
+        : 0;
+      if (count >= 2) break;
+    }
+  },
+};

--- a/src/database/effects/cards/1-1-058.ts
+++ b/src/database/effects/cards/1-1-058.ts
@@ -1,0 +1,33 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■暗黒街の武器商人
+  // あなたのターン終了時、あなたはカードを1枚引き、CPを+1する。
+  // NOTE: トリガーカードのチェッカーを実装
+  checkTurnEnd(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+    const turnPlayer = stack.core.getTurnPlayer();
+
+    // 自分のターン終了時に発動
+    return owner.id === turnPlayer.id;
+  },
+
+  async onTurnEnd(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+
+    await System.show(stack, '暗黒街の武器商人', 'カードを1枚引く\nCP+1');
+
+    // カードを1枚引く
+    if (owner.deck.length > 0 && owner.hand.length < stack.core.room.rule.player.max.hand) {
+      const cardToDraw = owner.deck[0];
+      if (cardToDraw) {
+        Effect.move(stack, stack.processing, cardToDraw, 'hand');
+      }
+    }
+
+    // CPを+1する
+    Effect.modifyCP(stack, stack.processing, owner, 1);
+  },
+};

--- a/src/database/effects/cards/1-1-058.ts
+++ b/src/database/effects/cards/1-1-058.ts
@@ -1,4 +1,4 @@
-import { Effect, System } from '..';
+import { Effect, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
 import { Unit } from '@/package/core/class/card';
 
@@ -18,14 +18,7 @@ export const effects: CardEffects = {
     const owner = stack.processing.owner;
 
     await System.show(stack, '暗黒街の武器商人', 'カードを1枚引く\nCP+1');
-
-    // カードを1枚引く
-    if (owner.deck.length > 0 && owner.hand.length < stack.core.room.rule.player.max.hand) {
-      const cardToDraw = owner.deck[0];
-      if (cardToDraw) {
-        Effect.move(stack, stack.processing, cardToDraw, 'hand');
-      }
-    }
+    EffectTemplate.draw(stack.processing.owner, stack.core);
 
     // CPを+1する
     Effect.modifyCP(stack, stack.processing, owner, 1);

--- a/src/database/effects/cards/1-1-092.ts
+++ b/src/database/effects/cards/1-1-092.ts
@@ -1,4 +1,4 @@
-import { Effect, EffectHelper, System } from '..';
+import { EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
 import { Unit } from '@/package/core/class/card';
 
@@ -10,14 +10,8 @@ export const effects: CardEffects = {
   },
 
   async onDrive(stack: StackWithCard) {
-    const owner = stack.processing.owner;
     await System.show(stack, 'トリックオアトリート', 'トリガーカードを1枚引く');
-    if (owner.trigger.length < stack.core.room.rule.player.max.trigger && owner.deck.length > 0) {
-      // デッキから1枚選んでトリガーゾーンにセット
-      EffectHelper.random(owner.deck, 1).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trigger')
-      );
-    }
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] });
   },
 
   // あなたのユニットがプレイヤーアタックに成功した時、カードを1枚引く。
@@ -26,13 +20,8 @@ export const effects: CardEffects = {
   },
 
   async onPlayerAttack(stack: StackWithCard) {
-    const owner = stack.processing.owner;
     await System.show(stack, 'トリックオアトリート', 'カードを1枚引く');
-    if (owner.hand.length < stack.core.room.rule.player.max.hand && owner.deck.length > 0) {
-      EffectHelper.random(owner.deck, 1).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'hand')
-      );
-    }
+    EffectTemplate.draw(stack.processing.owner, stack.core);
   },
 
   // あなたのユニットが戦闘によって対戦相手のユニットを破壊した時、インターセプトカードを1枚引く。
@@ -41,16 +30,7 @@ export const effects: CardEffects = {
   },
 
   async onWin(stack: StackWithCard) {
-    const owner = stack.processing.owner;
     await System.show(stack, 'トリックオアトリート', 'インターセプトカードを1枚引く');
-    if (owner.deck.length > 0) {
-      // インターセプトカードの定義はcatalog参照が必要だが、ここではcatalog.type === 'intercept' で判定
-      const intercepts = owner.deck.filter(card => card.catalog.type === 'intercept');
-      if (intercepts.length > 0 && owner.hand.length < stack.core.room.rule.player.max.hand) {
-        EffectHelper.random(intercepts, 1).forEach(card =>
-          Effect.move(stack, stack.processing, card, 'hand')
-        );
-      }
-    }
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['intercept'] });
   },
 };

--- a/src/database/effects/cards/1-2-004.ts
+++ b/src/database/effects/cards/1-2-004.ts
@@ -1,0 +1,58 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■ヒトデ爆弾
+  // このユニットがオーバークロックした時、対戦相手のユニットを2体まで選ぶ。それらに5000ダメージを与える。
+
+  // オーバークロック時の効果
+  onOverclock: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 相手のユニットが存在する場合のみ処理
+    if (opponent.field.length > 0) {
+      // 対象を選択可能なユニットを取得
+      const targetCandidates = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === opponent.id,
+        owner
+      );
+
+      if (targetCandidates.length > 0) {
+        await System.show(stack, 'ヒトデ爆弾', '5000ダメージ');
+
+        // 相手ユニットを最大2体選択
+        // 選択できるユニットが1体しかない場合は1体だけ選択
+        const count = Math.min(2, targetCandidates.length);
+
+        // 複数選択の場合
+        const targets: Unit[] = [];
+
+        for (let i = 0; i < count; i++) {
+          // 既に選択したユニットを除外した候補を作成
+          const remainingCandidates = targetCandidates.filter(
+            unit => !targets.some(selected => selected.id === unit.id)
+          );
+
+          if (remainingCandidates.length === 0) break;
+
+          const [target] = await EffectHelper.selectUnit(
+            stack,
+            owner,
+            remainingCandidates,
+            `5000ダメージを与えるユニットを選択`
+          );
+
+          targets.push(target);
+        }
+
+        // 選択したユニットに5000ダメージを与える
+        for (const target of targets) {
+          Effect.damage(stack, stack.processing, target, 5000);
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-006.ts
+++ b/src/database/effects/cards/1-2-006.ts
@@ -14,10 +14,8 @@ export const effects: CardEffects = {
     await System.show(stack, '伝説の大盗賊', '全ユニットをオーバークロック');
 
     // 全てのユニットをオーバークロック（レベル+2）
-    stack.core.players.forEach(player => {
-      player.field.forEach(unit => {
-        Effect.clock(stack, stack.processing, unit, 2);
-      });
-    });
+    stack.core.players
+      .flatMap(player => player.field)
+      .forEach(unit => Effect.clock(stack, stack.processing, unit, 2));
   },
 };

--- a/src/database/effects/cards/1-2-006.ts
+++ b/src/database/effects/cards/1-2-006.ts
@@ -1,0 +1,23 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【スピードムーブ】キーワード能力の付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'スピードムーブ', '行動制限の影響を受けない');
+    Effect.speedMove(stack, stack.processing);
+  },
+
+  // 伝説の大盗賊：プレイヤーアタックに成功した時、全てのユニットをオーバークロック
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '伝説の大盗賊', '全ユニットをオーバークロック');
+
+    // 全てのユニットをオーバークロック（レベル+2）
+    stack.core.players.forEach(player => {
+      player.field.forEach(unit => {
+        Effect.clock(stack, stack.processing, unit, 2);
+      });
+    });
+  },
+};

--- a/src/database/effects/cards/1-2-008.ts
+++ b/src/database/effects/cards/1-2-008.ts
@@ -25,11 +25,9 @@ export const effects: CardEffects = {
       await System.show(stack, '天地鳴動', '全ユニットに10000ダメージ');
 
       // 全てのユニットに10000ダメージを与える
-      stack.core.players.forEach(player => {
-        player.field.forEach(unit => {
-          Effect.damage(stack, stack.processing, unit, 10000);
-        });
-      });
+      stack.core.players
+        .flatMap(player => player.field)
+        .forEach(unit => Effect.damage(stack, stack.processing, unit, 10000, 'effect'));
     }
   },
 };

--- a/src/database/effects/cards/1-2-008.ts
+++ b/src/database/effects/cards/1-2-008.ts
@@ -1,0 +1,35 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【固着】キーワード能力付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '固着', '手札に戻らない');
+    Effect.keyword(stack, stack.processing, stack.processing, '固着');
+  },
+
+  // クロック・アップ：ターン開始時にレベル+1
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン開始時
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      await System.show(stack, 'クロック・アップ', 'レベル+1');
+      Effect.clock(stack, stack.processing, stack.processing, 1);
+    }
+  },
+
+  // 天地鳴動：レベル3にクロックアップした時
+  onClockupSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // フィールドにいて、レベル3になったかチェック
+    if (stack.processing.lv === 3) {
+      await System.show(stack, '天地鳴動', '全ユニットに10000ダメージ');
+
+      // 全てのユニットに10000ダメージを与える
+      stack.core.players.forEach(player => {
+        player.field.forEach(unit => {
+          Effect.damage(stack, stack.processing, unit, 10000);
+        });
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-011.ts
+++ b/src/database/effects/cards/1-2-011.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
+import { Color } from '@/submodule/suit/constant/color';
 
 export const effects: CardEffects = {
   // 【スピードムーブ】
@@ -23,7 +24,7 @@ export const effects: CardEffects = {
     const redUnits = owner.field.filter(
       unit =>
         unit.id !== stack.processing.id && // 自分以外
-        unit.catalog.color === 0 // 赤属性 (色は数値で指定)
+        unit.catalog.color === Color.RED
     );
 
     if (redUnits.length > 0) {

--- a/src/database/effects/cards/1-2-011.ts
+++ b/src/database/effects/cards/1-2-011.ts
@@ -1,0 +1,38 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【スピードムーブ】
+  // ■電光石火
+  // このユニットがオーバークロックした時、あなたの赤属性ユニットに【スピードムーブ】を与える。
+
+  // 召喚時の効果：スピードムーブを付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'スピードムーブ', '行動制限の影響を受けない');
+
+    // スピードムーブを付与
+    Effect.speedMove(stack, stack.processing);
+  },
+
+  // オーバークロック時の効果
+  onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 赤属性ユニットを取得（自分以外の赤属性ユニット）
+    const redUnits = owner.field.filter(
+      unit =>
+        unit.id !== stack.processing.id && // 自分以外
+        unit.catalog.color === 0 // 赤属性 (色は数値で指定)
+    );
+
+    if (redUnits.length > 0) {
+      await System.show(stack, '電光石火', '赤属性ユニットに【スピードムーブ】を付与');
+
+      // 各赤属性ユニットにスピードムーブを付与
+      for (const unit of redUnits) {
+        Effect.speedMove(stack, unit);
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-016.ts
+++ b/src/database/effects/cards/1-2-016.ts
@@ -1,0 +1,39 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '闘士／神', '【神】1体につきBP+4000');
+  },
+
+  // 闘士／神：フィールドの【神】1体につき+4000される
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    // すでに自身が発行したDeltaがあるか確認
+    const delta = stack.processing.delta.find(
+      delta => delta.source?.unit === stack.processing.id && delta.source?.effectCode === '闘士／神'
+    );
+
+    // フィールドにいる【神】ユニットの数をカウント
+    const godCount = stack.core.players
+      .map(p => p.field)
+      .flat()
+      .filter(unit => unit.catalog.species?.includes('神')).length;
+
+    // BP増加量を計算
+    const bpBoost = godCount * 4000;
+
+    if (delta && delta.effect.type === 'bp') {
+      // Deltaを更新
+      delta.effect.diff = bpBoost;
+    } else {
+      // 新規にDeltaを生成
+      Effect.modifyBP(stack, stack.processing, stack.processing, bpBoost, {
+        source: {
+          unit: stack.processing.id,
+          effectCode: '闘士／神',
+        },
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-020.ts
+++ b/src/database/effects/cards/1-2-020.ts
@@ -1,0 +1,41 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■女神の慈愛
+  // あなたのレベル1ユニットに【加護】を与える。
+
+  // 召喚時の効果表示
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '女神の慈愛', 'レベル1ユニットに【加護】を付与');
+  },
+
+  // フィールド効果：レベル1ユニットに加護を与える
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // 自分のフィールドにあるレベル1のユニットを対象にする
+    owner.field.forEach(unit => {
+      // レベル1のユニットか確認
+      if (unit.lv === 1) {
+        // 既にこのユニットが発行したDeltaが存在するか確認
+        const delta = unit.delta.find(
+          d => d.source?.unit === stack.processing.id && d.source?.effectCode === '女神の慈愛'
+        );
+
+        // 既にDeltaが存在しない場合のみ加護を付与
+        if (!delta) {
+          Effect.keyword(stack, stack.processing, unit, '加護', {
+            source: { unit: stack.processing.id, effectCode: '女神の慈愛' },
+          });
+        }
+      } else {
+        // レベル1でなくなった場合、このユニットが付与した加護を削除
+        unit.delta = unit.delta.filter(
+          d => !(d.source?.unit === stack.processing.id && d.source?.effectCode === '女神の慈愛')
+        );
+      }
+    });
+  },
+};

--- a/src/database/effects/cards/1-2-024.ts
+++ b/src/database/effects/cards/1-2-024.ts
@@ -1,0 +1,122 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■八咫鏡
+  // 様々なレベルに応じた効果を持つカード
+
+  // フィールド効果: レベル1の時に【加護】を与える
+  fieldEffect(stack: StackWithCard<Unit>) {
+    const self = stack.processing;
+
+    // 自身が与えた加護の効果があるか確認
+    const delta = self.delta.find(
+      delta => delta.source?.unit === self.id && delta.source?.effectCode === 'level1_protection'
+    );
+
+    if (self.lv === 1) {
+      // レベル1の時に【加護】を与える
+      if (!delta) {
+        Effect.keyword(stack, self, self, '加護', {
+          source: { unit: self.id, effectCode: 'level1_protection' },
+        });
+      }
+    } else if (delta) {
+      // レベル1以外では自身が与えた【加護】を除外
+      self.delta = self.delta.filter(
+        d => d.source?.unit !== self.id || d.source?.effectCode !== 'level1_protection'
+      );
+    }
+  },
+
+  onDriveself: async (stack: StackWithCard<Unit>) => {
+    await System.show(stack, '八咫鏡', 'レベル1の時【加護】を得る');
+  },
+
+  // プレイヤーアタックを受けた時の効果
+  async onPlayerAttack(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+
+    // 自分がプレイヤーアタックを受けた時のみ発動
+    if (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.opponent.id && // 相手のユニットがアタックしている
+      stack.source.id === owner.id // 自分がプレイヤーアタックを受けている
+    ) {
+      await System.show(stack, '八咫鏡', 'ユニットを消滅\nレベル+1');
+
+      // アタックしてきたユニットを消滅させる
+      Effect.delete(stack, stack.processing, stack.target);
+
+      // 自身のレベルを+1する
+      Effect.clock(stack, stack.processing, stack.processing, 1);
+    }
+  },
+
+  // ターン終了時の効果
+  async onTurnEndSelf(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+    const turnPlayer = stack.core.getTurnPlayer();
+
+    // 自分のターン終了時かつ自身がレベル1の場合に発動
+    if (owner.id === turnPlayer.id && stack.processing.lv === 1) {
+      const ownUnits = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === owner.id,
+        owner
+      );
+
+      const opponentUnits = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === owner.opponent.id,
+        owner
+      );
+
+      // お互いにユニットがいる場合のみ処理
+      if (ownUnits.length > 0 && opponentUnits.length > 0) {
+        await System.show(stack, '八咫鏡', 'お互いのユニットを消滅');
+
+        // 自分のユニットを1体選択
+        const [ownTarget] = await EffectHelper.selectUnit(
+          stack,
+          owner,
+          ownUnits,
+          '消滅させる自分のユニットを選択'
+        );
+
+        // 相手のユニットを1体選択
+        const [opponentTarget] = await EffectHelper.selectUnit(
+          stack,
+          owner,
+          opponentUnits,
+          '消滅させる相手のユニットを選択'
+        );
+
+        // 選択したユニットを消滅させる
+        Effect.delete(stack, stack.processing, ownTarget);
+        Effect.delete(stack, stack.processing, opponentTarget);
+      }
+    }
+  },
+
+  // レベル3にクロックアップした時の効果
+  async onClockupSelf(stack: StackWithCard<Unit>) {
+    // レベル3にクロックアップした時のみ発動
+    if (stack.processing.lv === 3) {
+      const owner = stack.processing.owner;
+
+      await System.show(stack, '八咫鏡', '味方全体に【加護】付与\nライフ+2');
+
+      // 全ての味方ユニットに【加護】を与える
+      for (const unit of owner.field) {
+        Effect.keyword(stack, stack.processing, unit, '加護', {
+          source: { unit: stack.processing.id, effectCode: 'level3_protection_all' },
+        });
+      }
+
+      // ライフを+2する
+      owner.life.current = Math.min(owner.life.current + 2, owner.life.max);
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-025.ts
+++ b/src/database/effects/cards/1-2-025.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
+import { Color } from '@/submodule/suit/constant/color';
 
 export const effects: CardEffects = {
   // 幸運の風：自分のターン終了時、黄属性のユニットのレベルを-2する
@@ -10,7 +11,7 @@ export const effects: CardEffects = {
 
     if (isTurnPlayer) {
       const yellowUnits = stack.processing.owner.field.filter(
-        unit => unit.catalog.color === 2 // 黄属性は2
+        unit => unit.catalog.color === Color.YELLOW
       );
 
       if (yellowUnits.length > 0) {

--- a/src/database/effects/cards/1-2-025.ts
+++ b/src/database/effects/cards/1-2-025.ts
@@ -1,0 +1,26 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 幸運の風：自分のターン終了時、黄属性のユニットのレベルを-2する
+  onTurnEnd: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン終了時のみ発動
+    const isTurnPlayer = stack.processing.owner.id === stack.core.getTurnPlayer().id;
+
+    if (isTurnPlayer) {
+      const yellowUnits = stack.processing.owner.field.filter(
+        unit => unit.catalog.color === 2 // 黄属性は2
+      );
+
+      if (yellowUnits.length > 0) {
+        await System.show(stack, '幸運の風', '黄属性ユニットのレベル-2');
+
+        // 黄属性ユニットのレベルを-2
+        yellowUnits.forEach(unit => {
+          Effect.clock(stack, stack.processing, unit, -2);
+        });
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-032.ts
+++ b/src/database/effects/cards/1-2-032.ts
@@ -1,0 +1,40 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【呪縛】の付与とフィールド出現時効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 【呪縛】キーワード能力の付与
+    // 封印されし魔人：行動権を消費
+    await System.show(stack, '封印されし魔人', '行動権を消費');
+    Effect.activate(stack, stack.processing, stack.processing, false);
+    Effect.keyword(stack, stack.processing, stack.processing, '呪縛');
+  },
+
+  // 永久の呪縛：ターン開始時に行動権を消費
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン開始時のみ発動
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      await System.show(stack, '永久の呪縛', '行動権を消費');
+      Effect.activate(stack, stack.processing, stack.processing, false);
+    }
+  },
+
+  // 劣化した魔術鉄鎖：効果によって対戦相手が手札を捨てた時に行動権を回復
+  onHandes: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // targetとsourceがCardオブジェクトであることを確認
+    if (!(stack.source instanceof Unit && stack.target instanceof Unit)) {
+      return;
+    }
+
+    // 対戦相手が手札を捨てた時に発動
+    const isOpponentCard = stack.target.owner.id === stack.processing.owner.opponent.id;
+    const isEffectHandes = stack.source.owner.id === stack.processing.owner.id;
+
+    if (isOpponentCard && isEffectHandes && !stack.processing.active) {
+      await System.show(stack, '劣化した魔術鉄鎖', '行動権を回復');
+      Effect.activate(stack, stack.processing, stack.processing, true);
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-035.ts
+++ b/src/database/effects/cards/1-2-035.ts
@@ -1,0 +1,46 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■クロック・アップ
+  // このユニット以外のあなたの【不死】ユニットが破壊されるたび、このユニットのレベルを+1する。
+  // ■絶望の略奪
+  // このユニットがクロックアップするたび、対戦相手は手札を1枚ランダムで捨てる。
+
+  // 不死ユニットが破壊された時の効果
+  onBreak: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 破壊されたのが自分の不死ユニットかつこのユニット以外かつトリガーでないかチェック
+    if (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id &&
+      stack.target.id !== stack.processing.id &&
+      stack.target.catalog.species?.includes('不死')
+    ) {
+      // レベルが3未満の場合のみ処理（レベルの上限は3）
+      if (stack.processing.lv < 3) {
+        await System.show(stack, 'クロック・アップ', 'レベル+1');
+        Effect.clock(stack, stack.processing, stack.processing, 1);
+      }
+    }
+  },
+
+  // クロックアップした時の効果
+  onClockupSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    // 相手の手札が0枚の場合は効果を発動しない
+    if (opponent.hand.length === 0) return;
+
+    await System.show(stack, '絶望の略奪', '手札を1枚破壊');
+
+    // 相手の手札からランダムで1枚選択
+    const [targetCards] = EffectHelper.random(opponent.hand, 1);
+    if (targetCards) {
+      // 選んだカードを捨てる
+      Effect.move(stack, stack.processing, targetCards, 'trash');
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-037.ts
+++ b/src/database/effects/cards/1-2-037.ts
@@ -1,0 +1,65 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 海底の宝物庫：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 捨札から2枚ランダムで手札に加える
+    const trashCards = stack.processing.owner.trash;
+
+    if (trashCards.length > 0) {
+      await System.show(stack, '海底の宝物庫', '捨札からカードを手札に加える');
+
+      const randomCards = EffectHelper.random(trashCards, Math.min(2, trashCards.length));
+      randomCards.forEach(card => {
+        Effect.move(stack, stack.processing, card, 'hand');
+      });
+    }
+  },
+
+  // 対戦相手のユニットがアタックした時の効果
+  onAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // アタックしているユニットが相手のユニットかチェック
+    const attacker = stack.target as Unit;
+    if (attacker.owner.id === stack.processing.owner.opponent.id) {
+      // 自分のトリガーゾーンにカードがあるか確認
+      const triggerCards = stack.processing.owner.trigger;
+
+      if (triggerCards.length > 0) {
+        await System.show(stack, '海底の宝物庫', 'トリガーカードを破壊\n相手ユニットを破壊');
+
+        // トリガーゾーンからランダムで1枚選択して破壊
+        const randomTriggers = EffectHelper.random(triggerCards, 1);
+        randomTriggers.forEach(trigger => {
+          Effect.move(stack, stack.processing, trigger, 'trash');
+        });
+
+        if (randomTriggers.length > 0) {
+          // アタックしたユニットを破壊
+          Effect.break(stack, stack.processing, attacker);
+        }
+      }
+    }
+  },
+
+  // ターン終了時の効果
+  onTurnEnd: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン終了時のみ発動
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      // トリガーゾーンが上限に達していないか確認
+      const triggerCount = stack.processing.owner.trigger.length;
+      const maxTrigger = stack.core.room.rule.player.max.trigger;
+
+      if (triggerCount < maxTrigger && stack.processing.owner.deck.length > 0) {
+        await System.show(stack, '海底の宝物庫', 'デッキからトリガーゾーンにセット');
+
+        // デッキからランダムで1枚選んでトリガーゾーンにセット
+        const randomCards = EffectHelper.random(stack.processing.owner.deck, 1);
+        randomCards.forEach(card => {
+          Effect.move(stack, stack.processing, card, 'trigger');
+        });
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-037.ts
+++ b/src/database/effects/cards/1-2-037.ts
@@ -35,10 +35,8 @@ export const effects: CardEffects = {
           Effect.move(stack, stack.processing, trigger, 'trash');
         });
 
-        if (randomTriggers.length > 0) {
-          // アタックしたユニットを破壊
-          Effect.break(stack, stack.processing, attacker);
-        }
+        // アタックしたユニットを破壊
+        Effect.break(stack, stack.processing, attacker);
       }
     }
   },

--- a/src/database/effects/cards/1-2-050.ts
+++ b/src/database/effects/cards/1-2-050.ts
@@ -1,0 +1,50 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【不屈】キーワード能力付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '不屈', 'ターン終了時に行動権を回復');
+    Effect.keyword(stack, stack.processing, stack.processing, '不屈', {
+      source: { unit: stack.processing.id },
+    });
+  },
+
+  // 平和の象徴：ターン開始時に行動権を消費
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン開始時
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      await System.show(stack, '平和の象徴', '行動権を消費');
+      Effect.activate(stack, stack.processing, stack.processing, false);
+    }
+  },
+
+  // 争いの追憶：相手ターン終了時、レベル2以上でユニットを消滅
+  onTurnEnd: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 相手のターン終了時
+    if (stack.processing.owner.id !== stack.core.getTurnPlayer().id) {
+      // 自身のレベルが2以上の場合
+      if (stack.processing.lv >= 2) {
+        const targets = EffectHelper.candidate(
+          stack.core,
+          unit => unit.owner.id === stack.processing.owner.id,
+          stack.processing.owner
+        );
+
+        if (targets.length > 0) {
+          await System.show(stack, '争いの追憶', 'ユニットを消滅');
+
+          const [target] = await EffectHelper.selectUnit(
+            stack,
+            stack.processing.owner,
+            targets,
+            '消滅させるユニットを選択'
+          );
+
+          Effect.delete(stack, stack.processing, target);
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-056.ts
+++ b/src/database/effects/cards/1-2-056.ts
@@ -1,0 +1,55 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【呪縛】【固着】キーワード能力付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // キーワード能力を付与
+
+    // 捕喰：フィールドに出た時に自分の他のユニットを全て破壊
+    await System.show(stack, '捕喰', '自身以外のユニットを破壊');
+
+    const ownUnits = stack.processing.owner.field.filter(unit => unit.id !== stack.processing.id);
+
+    ownUnits.forEach(unit => {
+      Effect.break(stack, stack.processing, unit);
+    });
+
+    Effect.keyword(stack, stack.processing, stack.processing, '呪縛', {
+      source: { unit: stack.processing.id },
+    });
+    Effect.keyword(stack, stack.processing, stack.processing, '固着', {
+      source: { unit: stack.processing.id },
+    });
+  },
+
+  // ユニットがフィールドに出た時の効果
+  onDrive: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のユニットがフィールドに出た時
+    const summonedUnit = stack.target as Unit;
+    if (
+      summonedUnit.owner.id === stack.processing.owner.id &&
+      summonedUnit.id !== stack.processing.id
+    ) {
+      await System.show(stack, '捕喰', 'ユニットを破壊\n行動権を回復');
+
+      // そのユニットを破壊
+      Effect.break(stack, stack.processing, summonedUnit);
+
+      // 自身の行動権を回復
+      Effect.activate(stack, stack.processing, stack.processing, true);
+    }
+  },
+
+  // 戦闘勝利時もしくはプレイヤーアタック成功時
+  onWinSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '滅亡', '基本BP-3000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, -3000, { isBaseBP: true });
+  },
+
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '滅亡', '基本BP-3000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, -3000, { isBaseBP: true });
+  },
+};

--- a/src/database/effects/cards/1-2-091.ts
+++ b/src/database/effects/cards/1-2-091.ts
@@ -1,0 +1,50 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■冥土の献上品
+  // 対戦相手のユニットがフィールドに出た時、あなたのユニットを1体選ぶ。
+  // それを破壊する。そうした場合、フィールドに出たユニットを破壊する。
+
+  // インターセプトカード用チェッカー実装
+  checkDrive(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+    const ownUnits = EffectHelper.candidate(stack.core, unit => unit.owner.id === owner.id, owner);
+
+    // 相手のユニットが召喚された時かつ自分のフィールドにユニットがいる場合に発動
+    return (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.opponent.id &&
+      ownUnits.length > 0
+    );
+  },
+
+  async onDrive(stack: StackWithCard) {
+    const owner = stack.processing.owner;
+
+    // 対戦相手の召喚したユニット
+    const summonedUnit = stack.target as Unit;
+
+    // 自分のユニットの選択肢を作成
+    const ownUnits = EffectHelper.candidate(stack.core, unit => unit.owner.id === owner.id, owner);
+
+    if (ownUnits.length > 0) {
+      await System.show(stack, '冥土の献上品', '自ユニットを破壊\n相手ユニットを破壊');
+
+      // 自分のユニットを1体選択
+      const [selectedUnit] = await EffectHelper.selectUnit(
+        stack,
+        owner,
+        ownUnits,
+        '破壊する自分のユニットを選択'
+      );
+
+      // 選択したユニットを破壊
+      Effect.break(stack, stack.processing, selectedUnit);
+
+      // フィールドに出たユニット(相手ユニット)を破壊
+      Effect.break(stack, stack.processing, summonedUnit);
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-103.ts
+++ b/src/database/effects/cards/1-2-103.ts
@@ -1,0 +1,99 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【固着】
+  // ■巨象の粉塵炎
+  // あなたの【獣】ユニットがフィールドに出るたび、対戦相手のユニットを1体選ぶ。それに2000ダメージを与える。
+  // ■巨象の業塵炎
+  // このユニットがオーバークロックした時、対戦相手の全てのユニットにあなたのフィールドにいる【獣】1体につき2000ダメージを与える。
+
+  // 召喚時の効果：固着を付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const targetCandidates = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.opponent.id,
+      stack.processing.owner
+    );
+
+    if (targetCandidates.length > 0) {
+      await System.show(
+        stack,
+        '巨象の粉塵炎＆固着',
+        '2000ダメージ\n対戦相手の効果によって手札に戻らない'
+      );
+      // ユニットを1体選択
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        targetCandidates,
+        '2000ダメージを与えるユニットを選択'
+      );
+
+      // 2000ダメージを与える
+      Effect.damage(stack, stack.processing, target, 2000);
+    } else {
+      await System.show(stack, '固着', '対戦相手の効果によって手札に戻らない');
+    }
+
+    // 固着を付与
+    Effect.keyword(stack, stack.processing, stack.processing, '固着');
+  },
+
+  // 味方獣ユニットがフィールドに出た時の効果
+  onDrive: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    const targetCandidates = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === opponent.id,
+      owner
+    );
+
+    // 自分の獣ユニットが出た時のみ処理
+    if (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id &&
+      stack.target.catalog.species?.includes('獣') &&
+      stack.target.id !== stack.processing.id
+    ) {
+      // 相手のユニットが存在する場合のみ処理
+      if (targetCandidates.length > 0) {
+        await System.show(stack, '巨象の粉塵炎', '2000ダメージ');
+
+        // ユニットを1体選択
+        const [target] = await EffectHelper.selectUnit(
+          stack,
+          owner,
+          targetCandidates,
+          '2000ダメージを与えるユニットを選択'
+        );
+
+        // 2000ダメージを与える
+        Effect.damage(stack, stack.processing, target, 2000);
+      }
+    }
+  },
+
+  // オーバークロック時の効果
+  onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // フィールドにいる獣ユニットの数を取得
+    const beastCount = owner.field.filter(unit => unit.catalog.species?.includes('獣')).length;
+
+    // ダメージ量を計算
+    const damage = 2000 * beastCount;
+
+    if (damage > 0 && opponent.field.length > 0) {
+      await System.show(stack, '巨象の業塵炎', `敵全体に[獣×2000]ダメージ`);
+
+      // 相手の全ユニットにダメージを与える
+      for (const target of opponent.field) {
+        Effect.damage(stack, stack.processing, target, damage);
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-104.ts
+++ b/src/database/effects/cards/1-2-104.ts
@@ -32,9 +32,9 @@ export const effects: CardEffects = {
     // 自分が破壊したカードである場合に発動
     if (
       stack.source instanceof Card &&
-      stack.source.owner.id === owner.id &&
+      stack.source.owner.id === owner.id && // 効果の発生源が自分である
       stack.target instanceof Card &&
-      stack.target.owner.id !== owner.id
+      stack.target.owner.id === owner.opponent.id // 破壊されたカードの所有者が対戦相手である
     ) {
       await System.show(stack, '龍機の覚醒め', '行動権を回復');
       Effect.activate(stack, stack.processing, stack.processing, true);

--- a/src/database/effects/cards/1-2-104.ts
+++ b/src/database/effects/cards/1-2-104.ts
@@ -26,13 +26,13 @@ export const effects: CardEffects = {
 
   // ■龍機の覚醒め
   // 対戦相手のトリガーゾーンにあるカードを破壊した時、このユニットの行動権を回復する。
-  // 実装メモ：カードの破壊を move で実装しているため、onBreak ではなく onTriggerDestroy という専用のイベントを用意する
   onLost: async (stack: StackWithCard<Unit>): Promise<void> => {
     const owner = stack.processing.owner;
 
     // 自分が破壊したカードである場合に発動
     if (
-      stack.source.id === owner.id &&
+      stack.source instanceof Card &&
+      stack.source.owner.id === owner.id &&
       stack.target instanceof Card &&
       stack.target.owner.id !== owner.id
     ) {

--- a/src/database/effects/cards/1-2-110.ts
+++ b/src/database/effects/cards/1-2-110.ts
@@ -1,0 +1,59 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■煌めく筋肉
+  // あなたのフィールドの【巨人】ユニットに【加護】を与える。
+  // ■ビルドガード
+  // あなたのユニットがブロックするたび、ターン終了時までこのユニットのBPを+1000する。
+
+  // 召喚時の効果表示
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '煌めく筋肉', '【巨人】に【加護】を付与');
+  },
+
+  // フィールド効果：巨人ユニットに加護を与える
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // 自分のフィールドの巨人ユニットを対象にする
+    owner.field.forEach(unit => {
+      // 巨人ユニットか確認
+      if (unit.catalog.species?.includes('巨人')) {
+        // 既にこのユニットが発行したDeltaが存在するか確認
+        const delta = unit.delta.find(
+          d => d.source?.unit === stack.processing.id && d.source?.effectCode === '煌めく筋肉'
+        );
+
+        // 既にDeltaが存在しない場合のみ加護を付与
+        if (!delta) {
+          Effect.keyword(stack, stack.processing, unit, '加護', {
+            source: { unit: stack.processing.id, effectCode: '煌めく筋肉' },
+          });
+        }
+      } else {
+        // 巨人でなくなった場合、このユニットが付与した加護を削除
+        unit.delta = unit.delta.filter(
+          d => !(d.source?.unit === stack.processing.id && d.source?.effectCode === '煌めく筋肉')
+        );
+      }
+    });
+  },
+
+  // ブロック時の効果
+  onBlock: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分のユニットがブロックした時のみ発動
+    if (stack.target instanceof Unit && stack.target.owner.id === owner.id) {
+      await System.show(stack, 'ビルドガード', 'BP+1000');
+
+      // BP+1000（ターン終了時まで）
+      Effect.modifyBP(stack, stack.processing, stack.processing, 1000, {
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-111.ts
+++ b/src/database/effects/cards/1-2-111.ts
@@ -1,0 +1,64 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // シャイニングオーラ：ユニットがアタックした時、レベルに応じた効果が発動
+  onAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const level = stack.processing.lv;
+
+    // レベル1～2の効果
+    if (level >= 1 && level <= 2) {
+      const targets = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === stack.processing.owner.opponent.id,
+        stack.processing.owner
+      );
+
+      if (targets.length > 0) {
+        await System.show(stack, 'シャイニングオーラ', '行動権を消費');
+
+        const [target] = await EffectHelper.selectUnit(
+          stack,
+          stack.processing.owner,
+          targets,
+          '行動権を消費するユニットを選択'
+        );
+
+        Effect.activate(stack, stack.processing, target, false);
+      }
+    }
+    // レベル3の効果
+    else if (level === 3) {
+      const targets = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === stack.processing.owner.opponent.id,
+        stack.processing.owner
+      );
+
+      if (targets.length > 0) {
+        await System.show(stack, 'シャイニングオーラ', '対戦相手のユニットを消滅\nレベル-2');
+
+        // 選択可能な数を決定（最大2体）
+        const selectCount = Math.min(2, targets.length);
+
+        // 対戦相手のユニットを選択
+        const selectedTargets = await EffectHelper.selectUnit(
+          stack,
+          stack.processing.owner,
+          targets,
+          '消滅させるユニットを選択',
+          selectCount
+        );
+
+        // 選択したユニットを消滅
+        selectedTargets.forEach(target => {
+          Effect.delete(stack, stack.processing, target);
+        });
+
+        // 自身のレベルを-2する
+        Effect.clock(stack, stack.processing, stack.processing, -2);
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-119.ts
+++ b/src/database/effects/cards/1-2-119.ts
@@ -31,10 +31,15 @@ export const effects: CardEffects = {
         } else {
           // 新しいDeltaを追加
           unit.delta.push(
-            new Delta({ type: 'bp', diff: 1000 }, undefined, undefined, undefined, {
-              unit: stack.processing.id,
-              effectCode: 'サポーター／昆虫',
-            })
+            new Delta(
+              { type: 'bp', diff: 1000 },
+              {
+                source: {
+                  unit: stack.processing.id,
+                  effectCode: 'サポーター／昆虫',
+                },
+              }
+            )
           );
         }
       }

--- a/src/database/effects/cards/1-2-130.ts
+++ b/src/database/effects/cards/1-2-130.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
     // 自分のターン開始時のみ発動
     if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
       // フィールドにユニットが0体以下かチェック
-      if (stack.processing.owner.field.length <= 0) {
+      if (stack.processing.owner.field.length === 0) {
         await System.show(stack, '聖女の祈り', 'カードを1枚引く\nCP+1');
 
         // カードを1枚引く

--- a/src/database/effects/cards/1-2-130.ts
+++ b/src/database/effects/cards/1-2-130.ts
@@ -1,0 +1,31 @@
+import { Card } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // トリガー効果の発動条件チェック
+  checkTurnStart: (stack: StackWithCard) => {
+    // 自分のターン開始時かつフィールドにユニットが0体以下の場合に発動
+    return (
+      stack.processing.owner.id === stack.core.getTurnPlayer().id &&
+      stack.processing.owner.field.length <= 0
+    );
+  },
+
+  // 聖女の祈り：ターン開始時、フィールドにユニットが0体以下の場合、カードを1枚引く、CPを+1する
+  onTurnStart: async (stack: StackWithCard<Card>): Promise<void> => {
+    // 自分のターン開始時のみ発動
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      // フィールドにユニットが0体以下かチェック
+      if (stack.processing.owner.field.length <= 0) {
+        await System.show(stack, '聖女の祈り', 'カードを1枚引く\nCP+1');
+
+        // カードを1枚引く
+        EffectTemplate.draw(stack.processing.owner, stack.core);
+
+        // CPを+1する
+        Effect.modifyCP(stack, stack.processing, stack.processing.owner, 1);
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-132.ts
+++ b/src/database/effects/cards/1-2-132.ts
@@ -4,7 +4,13 @@ import type { CardEffects, StackWithCard } from '../classes/types';
 
 export const effects: CardEffects = {
   // 伝説の奇術師：プレイヤーアタック関連の効果
-  onPlayerAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+  checkPlayerAttack: (stack: StackWithCard) => {
+    return stack.source instanceof Unit && stack.processing.owner.id === stack.source.owner.id
+      ? stack.processing.owner.hand.length > 0
+      : true;
+  },
+
+  onPlayerAttack: async (stack: StackWithCard): Promise<void> => {
     // attacker（プレイヤーアタックを行ったユニット）のチェック
     const attacker = stack.source as Unit;
 

--- a/src/database/effects/cards/1-2-132.ts
+++ b/src/database/effects/cards/1-2-132.ts
@@ -1,0 +1,53 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 伝説の奇術師：プレイヤーアタック関連の効果
+  onPlayerAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // attacker（プレイヤーアタックを行ったユニット）のチェック
+    const attacker = stack.source as Unit;
+
+    // 自分のユニットがプレイヤーアタックに成功した時
+    if (attacker.owner.id === stack.processing.owner.id) {
+      await System.show(stack, '伝説の奇術師', '手札を消滅\n捨札からトリガーカードを手札に加える');
+
+      // 自分の手札を表示して選択肢を提示
+      if (stack.processing.owner.hand.length > 0) {
+        const [selectedCard] = await EffectHelper.selectCard(
+          stack,
+          stack.processing.owner,
+          stack.processing.owner.hand,
+          '消滅させる手札を選択'
+        );
+
+        // 選択したカードを消滅させる
+        Effect.move(stack, stack.processing, selectedCard, 'delete');
+
+        // 捨札からトリガーカードを2枚までランダムで手札に加える
+        const triggerCards = stack.processing.owner.trash.filter(
+          card => card.catalog.type === 'trigger'
+        );
+
+        const randomCards = EffectHelper.random(triggerCards, Math.min(2, triggerCards.length));
+        randomCards.forEach(card => {
+          Effect.move(stack, stack.processing, card, 'hand');
+        });
+      }
+    }
+    // 自分がプレイヤーアタックを受けた時
+    else if (attacker.owner.id === stack.processing.owner.opponent.id) {
+      await System.show(stack, '伝説の奇術師', 'デッキからトリガーカードを手札に加える');
+
+      // デッキからトリガーカードを2枚までランダムで手札に加える
+      const triggerCards = stack.processing.owner.deck.filter(
+        card => card.catalog.type === 'trigger'
+      );
+
+      const randomCards = EffectHelper.random(triggerCards, Math.min(2, triggerCards.length));
+      randomCards.forEach(card => {
+        Effect.move(stack, stack.processing, card, 'hand');
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/1-3-009.ts
+++ b/src/database/effects/cards/1-3-009.ts
@@ -1,0 +1,60 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■地母神の降臨
+  // このユニット以外の全てのユニットに7000ダメージを与える。
+  async onDriveSelf(stack: StackWithCard<Unit>) {
+    // 全てのユニットを取得
+    const allUnits = stack.core.players
+      .map(p => p.field)
+      .flat()
+      .filter(unit => unit.id !== stack.processing.id);
+
+    if (allUnits.length > 0) {
+      await System.show(stack, '地母神の降臨', '全ユニットに7000ダメージ');
+
+      // 自身以外に7000ダメージを与える
+      for (const unit of allUnits) {
+        if (unit.id !== stack.processing.id) {
+          Effect.damage(stack, stack.processing, unit, 7000);
+        }
+      }
+    }
+  },
+
+  // ■母なる揺り籠
+  // あなたのターン開始時、全てのユニットに3000ダメージを与える。
+  async onTurnStartSelf(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+    const turnPlayer = stack.core.getTurnPlayer();
+
+    // 自分のターン開始時のみ発動
+    if (owner.id === turnPlayer.id) {
+      await System.show(stack, '母なる揺り籠', '全ユニットに3000ダメージ');
+
+      // 全てのユニットを取得
+      const allUnits = stack.core.players.map(p => p.field).flat();
+
+      // 全てのユニットに3000ダメージを与える
+      for (const unit of allUnits) {
+        Effect.damage(stack, stack.processing, unit, 3000);
+      }
+    }
+  },
+
+  // ■生命の淘汰
+  // このユニットが破壊された時、全てのユニットに5000ダメージを与える。
+  async onBreakSelf(stack: StackWithCard<Unit>) {
+    await System.show(stack, '生命の淘汰', '全ユニットに5000ダメージ');
+
+    // 全てのユニットを取得
+    const allUnits = stack.core.players.map(p => p.field).flat();
+
+    // 全てのユニットに5000ダメージを与える
+    for (const unit of allUnits) {
+      Effect.damage(stack, stack.processing, unit, 5000);
+    }
+  },
+};

--- a/src/database/effects/cards/1-3-009.ts
+++ b/src/database/effects/cards/1-3-009.ts
@@ -1,4 +1,4 @@
-import { Effect, System } from '..';
+import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
 import { Unit } from '@/package/core/class/card';
 
@@ -14,13 +14,9 @@ export const effects: CardEffects = {
 
     if (allUnits.length > 0) {
       await System.show(stack, '地母神の降臨', '全ユニットに7000ダメージ');
-
-      // 自身以外に7000ダメージを与える
-      for (const unit of allUnits) {
-        if (unit.id !== stack.processing.id) {
-          Effect.damage(stack, stack.processing, unit, 7000);
-        }
-      }
+      EffectHelper.exceptSelf(stack.core, stack.processing, unit =>
+        Effect.damage(stack, stack.processing, unit, 7000)
+      );
     }
   },
 

--- a/src/database/effects/cards/1-3-041.ts
+++ b/src/database/effects/cards/1-3-041.ts
@@ -14,7 +14,11 @@ export const effects: CardEffects = {
   },
 
   checkWin: (stack: StackWithCard) => {
-    return stack.source instanceof Unit && stack.source.catalog.species?.includes('戦士') === true;
+    return (
+      stack.source instanceof Unit &&
+      stack.source.catalog.species?.includes('戦士') === true &&
+      stack.source.owner.id === stack.processing.owner.id
+    );
   },
 
   onWin: async (stack: StackWithCard) => {

--- a/src/database/effects/cards/1-3-041.ts
+++ b/src/database/effects/cards/1-3-041.ts
@@ -9,16 +9,16 @@ export const effects: CardEffects = {
   },
 
   onDrive: async (stack: StackWithCard): Promise<void> => {
-    await System.show(stack, '生産工場', '【昆虫】を1枚引く');
-    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '昆虫' });
+    await System.show(stack, '戦場の誓い', '【戦士】を1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '戦士' });
   },
 
   checkWin: (stack: StackWithCard) => {
-    return stack.source instanceof Unit && stack.source.catalog.species?.includes('昆虫') === true;
+    return stack.source instanceof Unit && stack.source.catalog.species?.includes('戦士') === true;
   },
 
   onWin: async (stack: StackWithCard) => {
-    await System.show(stack, '生産工場', '属性の異なる【昆虫】を2枚引く');
+    await System.show(stack, '戦場の誓い', '属性の異なる【戦士】を2枚引く');
     const colors = EffectHelper.shuffle([
       Color.RED,
       Color.YELLOW,
@@ -29,7 +29,7 @@ export const effects: CardEffects = {
     let count = 0;
     for (const color of colors) {
       count += EffectTemplate.reinforcements(stack, stack.processing.owner, {
-        species: '昆虫',
+        species: '戦士',
         color,
       })
         ? 1

--- a/src/database/effects/cards/1-3-042.ts
+++ b/src/database/effects/cards/1-3-042.ts
@@ -9,16 +9,18 @@ export const effects: CardEffects = {
   },
 
   onDrive: async (stack: StackWithCard): Promise<void> => {
-    await System.show(stack, '生産工場', '【昆虫】を1枚引く');
-    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '昆虫' });
+    await System.show(stack, '魔道士の館', '【魔道士】を1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '魔道士' });
   },
 
-  checkWin: (stack: StackWithCard) => {
-    return stack.source instanceof Unit && stack.source.catalog.species?.includes('昆虫') === true;
+  checkBreak: (stack: StackWithCard) => {
+    return (
+      stack.target instanceof Unit && stack.target.catalog.species?.includes('魔道士') === true
+    );
   },
 
-  onWin: async (stack: StackWithCard) => {
-    await System.show(stack, '生産工場', '属性の異なる【昆虫】を2枚引く');
+  onBreak: async (stack: StackWithCard) => {
+    await System.show(stack, '魔道士の館', '属性の異なる【魔道士】を2枚引く');
     const colors = EffectHelper.shuffle([
       Color.RED,
       Color.YELLOW,
@@ -29,7 +31,7 @@ export const effects: CardEffects = {
     let count = 0;
     for (const color of colors) {
       count += EffectTemplate.reinforcements(stack, stack.processing.owner, {
-        species: '昆虫',
+        species: '魔道士',
         color,
       })
         ? 1

--- a/src/database/effects/cards/1-3-107.ts
+++ b/src/database/effects/cards/1-3-107.ts
@@ -1,0 +1,32 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【加護】
+  // ■恩寵の牙
+  // 対戦相手のユニットがフィールドに出た時、対戦相手の捨札にあるカードをランダムで3枚消滅させる。
+
+  // 召喚時の効果：加護を付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '加護', '効果に選ばれない');
+    Effect.keyword(stack, stack.processing, stack.processing, '加護');
+  },
+
+  // 相手ユニットが出た時の効果
+  onDrive: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 相手のユニットが出た時のみ処理
+    if (stack.target instanceof Unit && stack.target.owner.id === opponent.id) {
+      // 相手の捨て札が3枚以上あるか確認
+      if (opponent.trash.length > 0) {
+        await System.show(stack, '恩寵の牙', '捨札を3枚消滅');
+        EffectHelper.random(opponent.trash, Math.min(3, opponent.trash.length)).forEach(card =>
+          Effect.move(stack, stack.processing, card, 'delete')
+        );
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-3-121.ts
+++ b/src/database/effects/cards/1-3-121.ts
@@ -1,0 +1,33 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■アンフェア・タックス
+  // 対戦相手のターン開始時、対戦相手の手札が7枚の場合、対戦相手の手札を2枚ランダムで捨てる。
+  // NOTE: トリガーカードのチェッカーを実装
+  checkTurnStart(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+    const turnPlayer = stack.core.getTurnPlayer();
+    const opponent = owner.opponent;
+
+    // 相手のターン開始時かつ手札が7枚の場合に発動
+    return turnPlayer.id === opponent.id && opponent.hand.length === 7;
+  },
+
+  async onTurnStart(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 相手の手札が7枚であることを確認(念のため再チェック)
+    if (opponent.hand.length === 7) {
+      await System.show(stack, 'アンフェア・タックス', '手札を2枚捨てる');
+
+      // ランダムで2枚選んで捨てる
+      const cardsToDiscard = EffectHelper.random(opponent.hand, 2);
+      for (const card of cardsToDiscard) {
+        Effect.handes(stack, stack.processing, card);
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-3-126.ts
+++ b/src/database/effects/cards/1-3-126.ts
@@ -1,0 +1,36 @@
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■ライブオンステージ
+  // あなたのターン開始時、対戦相手のフィールドにいるユニット数が3体以上で、
+  // あなたのフィールドにいるユニット数が2体以下の場合、あなたはカードを1枚引く。あなたのCPを+2する。
+
+  // インターセプトカード用チェック関数
+  checkTurnStart(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+    const turnPlayer = stack.core.getTurnPlayer();
+
+    // 自分のターン開始時のみ発動
+    if (owner.id !== turnPlayer.id) return false;
+
+    // 対戦相手のフィールドにいるユニット数が3体以上
+    const opponentUnits = owner.opponent.field.length;
+
+    // 自分のフィールドにいるユニット数が2体以下
+    const ownUnits = owner.field.length;
+
+    return opponentUnits >= 3 && ownUnits <= 2;
+  },
+
+  // ライブオンステージの効果
+  async onTurnStart(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+
+    await System.show(stack, 'ライブオンステージ', 'カードを1枚引く\nCP+2');
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+    // CPを+2する
+    Effect.modifyCP(stack, stack.processing, owner, 2);
+  },
+};

--- a/src/database/effects/cards/1-3-202.ts
+++ b/src/database/effects/cards/1-3-202.ts
@@ -11,17 +11,17 @@ export const effects: CardEffects = {
 
   // 召喚時にスピードムーブを付与し、対戦相手のユニットに1000ダメージを与える
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    // スピードムーブを付与
-    await System.show(stack, '紅蓮の弾舞', '【スピードムーブ】を付与');
-    Effect.speedMove(stack, stack.processing);
-
     const opponent = stack.processing.owner.opponent;
 
     // 対戦相手のユニットを取得
     const opponentUnits = opponent.field;
 
     if (opponentUnits.length > 0) {
-      await System.show(stack, '紅蓮の弾舞', '敵ユニット1体に1000ダメージ');
+      await System.show(
+        stack,
+        '紅蓮の弾舞＆スピードムーブ',
+        '敵ユニット1体に1000ダメージ\n行動制限の影響を受けない'
+      );
 
       // ユニットを1体選択
       const [target] = await EffectHelper.selectUnit(
@@ -35,7 +35,11 @@ export const effects: CardEffects = {
         // 1000ダメージを与える
         Effect.damage(stack, stack.processing, target, 1000);
       }
+    } else {
+      await System.show(stack, 'スピードムーブ', '行動制限の影響を受けない');
     }
+
+    Effect.speedMove(stack, stack.processing);
   },
 
   // アタック時、対戦相手のコスト2以下のユニットに防御禁止を与える

--- a/src/database/effects/cards/1-3-203.ts
+++ b/src/database/effects/cards/1-3-203.ts
@@ -1,0 +1,41 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // アタッカー：アタック時にBP+2000
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'アタッカー', 'BP+2000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, 2000, {
+      event: 'turnEnd',
+      count: 1,
+    });
+  },
+
+  // 飽くなき向上心：プレイヤーアタック成功時にレベル+1
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '飽くなき向上心', 'レベル+1');
+    Effect.clock(stack, stack.processing, stack.processing, 1);
+  },
+
+  // 連撃の鎖：オーバークロック時に相手ユニットに【防御禁止】
+  onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+    const targets = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === opponent.id,
+      stack.processing.owner
+    );
+
+    if (targets.length > 0) {
+      await System.show(stack, '連撃の鎖', '【防御禁止】付与');
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        targets,
+        '【防御禁止】を与えるユニットを選択'
+      );
+      Effect.keyword(stack, stack.processing, target, '防御禁止');
+    }
+  },
+};

--- a/src/database/effects/cards/1-3-208.ts
+++ b/src/database/effects/cards/1-3-208.ts
@@ -1,0 +1,48 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■アタッカー
+  // このユニットがアタックした時、ターン終了時までこのユニットのBPを+2000する。
+  async onAttackSelf(stack: StackWithCard<Unit>) {
+    await System.show(stack, 'アタッカー', 'BP+2000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, 2000, {
+      event: 'turnEnd',
+      count: 1,
+    });
+  },
+
+  // ■飽くなき向上心
+  // このユニットがプレイヤーアタックに成功した時、このユニットのレベルを+1する。
+  async onPlayerAttackSelf(stack: StackWithCard<Unit>) {
+    await System.show(stack, '飽くなき向上心', 'レベル+1');
+    Effect.clock(stack, stack.processing, stack.processing, 1);
+  },
+
+  // ■連撃の鎖
+  // このユニットがオーバークロックした時、対戦相手のユニットを1体選ぶ。それに【防御禁止】を与える。
+  async onOverclockSelf(stack: StackWithCard<Unit>) {
+    const opponent = stack.processing.owner.opponent;
+    const candidates = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === opponent.id,
+      stack.processing.owner
+    );
+
+    if (candidates.length > 0) {
+      await System.show(stack, '連撃の鎖', '【防御禁止】を付与');
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        candidates,
+        '対戦相手のユニットを1体選んでください'
+      );
+
+      Effect.keyword(stack, stack.processing, target, '防御禁止', {
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/1-3-212.ts
+++ b/src/database/effects/cards/1-3-212.ts
@@ -1,0 +1,107 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Parry } from '@/package/core/class/parry';
+
+export const effects: CardEffects = {
+  // ■失われた翼の対価
+  // このユニットがフィールドに出た時、あなたの手札にあるトリガーカードを1枚ランダムで捨てる。そうした場合、このユニットに【スピードムーブ】を与える。
+  // このユニットが戦闘した時、戦闘終了時まで全ての効果を発動できない。
+  // このユニットがプレイヤーアタックに成功した時、このユニット以外のあなたのユニットを1体選ぶ。それを破壊する。そうした場合、対戦相手は自分の手札を1枚選んで捨て、あなたはカードを1枚引く。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 手札にトリガーカードがあるか確認
+    const triggerCards = owner.hand.filter(card => card.catalog.type === 'trigger');
+
+    if (triggerCards.length > 0) {
+      // ランダムで1枚選ぶ
+      const randomCards = EffectHelper.random(triggerCards, 1);
+      if (randomCards.length > 0 && randomCards[0]) {
+        const selectedCard = randomCards[0];
+        await System.show(
+          stack,
+          '失われた翼の対価',
+          'トリガーカードを捨て、【スピードムーブ】を付与'
+        );
+        Effect.move(stack, stack.processing, selectedCard, 'trash');
+        Effect.speedMove(stack, stack.processing);
+      }
+    }
+  },
+
+  // 戦闘時の効果
+  onBattleSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分自身の戦闘時のみ発動
+    if (
+      (stack.source instanceof Unit && stack.source.id === stack.processing.id) ||
+      (stack.target instanceof Unit && stack.target.id === stack.processing.id)
+    ) {
+      await System.show(stack, '失われた翼の対価', '全ての効果を発動できない');
+      throw new Parry(stack.processing);
+    }
+  },
+
+  // プレイヤーアタック成功時の効果
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 自分のユニットがプレイヤーアタックした時のみ発動
+    if (
+      stack.source instanceof Unit &&
+      stack.source.id === stack.processing.id &&
+      stack.target?.id === opponent.id
+    ) {
+      // 自分のユニットが他にいるか確認（このユニット以外のユニット）
+      const ownUnits = owner.field.filter(unit => unit.id !== stack.processing.id);
+
+      if (ownUnits.length > 0) {
+        await System.show(
+          stack,
+          '失われた翼の対価',
+          '味方ユニットを破壊\n手札を1枚破壊\nカードを1枚引く'
+        );
+
+        // 対象を選択可能なユニットを取得
+        const targetCandidates = EffectHelper.candidate(
+          stack.core,
+          unit => unit.owner.id === owner.id && unit.id !== stack.processing.id,
+          owner
+        );
+
+        if (targetCandidates.length > 0) {
+          // ユニットを1体選択
+          const [target] = await EffectHelper.selectUnit(
+            stack,
+            owner,
+            targetCandidates,
+            '破壊するユニットを選択'
+          );
+
+          // 相手の手札が1枚以上ある場合、1枚選んで捨てる
+          if (opponent.hand.length > 0) {
+            const [selectedCard] = await EffectHelper.selectCard(
+              stack,
+              opponent,
+              opponent.hand,
+              '捨てるカードを選択',
+              1
+            );
+
+            if (selectedCard) {
+              // 捨て札に移動
+              Effect.move(stack, stack.processing, selectedCard, 'trash');
+            }
+          }
+
+          // 選択したユニットを破壊
+          Effect.break(stack, stack.processing, target);
+          EffectTemplate.draw(stack.processing.owner, stack.core);
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-002.ts
+++ b/src/database/effects/cards/1-4-002.ts
@@ -1,0 +1,53 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+const mainEffect = async (stack: StackWithCard, attacker: Unit) => {
+  const [choice] = await System.prompt(stack, stack.processing.owner.id, {
+    title: '選略・鼓武激励',
+    type: 'option',
+    items: [
+      { id: '1', description: 'アタックしたユニットのBPを+2000する' },
+      { id: '2', description: 'アタックしたユニットのレベルを+1する' },
+    ],
+  });
+
+  if (choice === '1') {
+    await System.show(stack, '選略・鼓武激励', 'BP+2000');
+    Effect.modifyBP(stack, stack.processing, attacker, 2000, {
+      event: 'turnEnd',
+      count: 1,
+    });
+  } else {
+    await System.show(stack, '選略・鼓武激励', 'レベル+1');
+    Effect.clock(stack, stack.processing, attacker, 1);
+  }
+};
+
+export const effects: CardEffects = {
+  // バーングラウンド：フィールドに出た時、自身以外の全てのユニットに1000ダメージ
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'バーングラウンド', '全ユニットに1000ダメージ');
+
+    EffectHelper.exceptSelf(stack.core, stack.processing, unit => {
+      Effect.damage(stack, stack.processing, unit, 1000);
+    });
+  },
+
+  onAttackSelf: async (stack: StackWithCard<Unit>) => {
+    await mainEffect(stack, stack.processing);
+  },
+
+  // 選略・鼓武激励：あなたの【戦士】ユニットがアタックした時の効果
+  onAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // アタックしているユニットが自分の【戦士】ユニットか確認
+    const attacker = stack.target as Unit;
+    if (
+      attacker.owner.id === stack.processing.owner.id &&
+      attacker.id !== stack.processing.id &&
+      attacker.catalog.species?.includes('戦士')
+    ) {
+      await mainEffect(stack, attacker);
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-007.ts
+++ b/src/database/effects/cards/1-4-007.ts
@@ -1,0 +1,21 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // フォース＜ウィルス・灼＞：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (EffectTemplate.virusInjectable(stack.processing.owner.opponent)) {
+      await System.show(stack, 'フォース＜ウィルス・灼＞', '＜ウィルス・灼＞を【特殊召喚】');
+      await EffectTemplate.virusInject(stack, stack.processing.owner.opponent, '＜ウィルス・灼＞');
+    }
+  },
+
+  // 灼熱の暴風：アタック時の効果
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '灼熱の暴風', '対戦相手のユニットに2000ダメージ');
+    stack.processing.owner.opponent.field.forEach(unit => {
+      Effect.damage(stack, stack.processing, unit, 2000);
+    });
+  },
+};

--- a/src/database/effects/cards/1-4-008.ts
+++ b/src/database/effects/cards/1-4-008.ts
@@ -42,9 +42,7 @@ export const effects = {
   handEffect: (core: unknown, self: Unit) => {
     if (!self.delta.some(delta => delta.source?.unit === self.id)) {
       if (self.owner.field.some(unit => unit.catalog.color === Color.RED))
-        self.delta.push(
-          new Delta({ type: 'cost', value: -1 }, undefined, undefined, undefined, { unit: self.id })
-        );
+        self.delta.push(new Delta({ type: 'cost', value: -1 }, { source: { unit: self.id } }));
     } else {
       if (!self.owner.field.some(unit => unit.catalog.color === Color.RED))
         self.delta = self.delta.filter(delta => delta.source?.unit !== self.id);

--- a/src/database/effects/cards/1-4-015.ts
+++ b/src/database/effects/cards/1-4-015.ts
@@ -1,0 +1,34 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // フォース＜ウィルス・費＞：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (EffectTemplate.virusInjectable(stack.processing.owner.opponent)) {
+      await System.show(stack, 'フォース＜ウィルス・費＞', '＜ウィルス・費＞を【特殊召喚】');
+      await EffectTemplate.virusInject(stack, stack.processing.owner.opponent, '＜ウィルス・費＞');
+    }
+  },
+
+  // 金色の神術：ターン開始時の効果
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン開始時に発動
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      // 対戦相手のユニットを取得
+      const enemyUnits = stack.processing.owner.opponent.field;
+
+      if (enemyUnits.length > 0) {
+        await System.show(stack, '金色の神術', 'ランダムで【呪縛】を付与');
+
+        // ランダムで1体選択
+        const randomUnits = EffectHelper.random(enemyUnits, 1);
+
+        // 選択されたユニットがあれば【呪縛】を付与
+        randomUnits.forEach(unit => {
+          Effect.keyword(stack, stack.processing, unit, '呪縛');
+        });
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-029.ts
+++ b/src/database/effects/cards/1-4-029.ts
@@ -1,0 +1,13 @@
+import { Unit } from '@/package/core/class/card';
+import { EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // フォース＜ウィルス・力＞：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (EffectTemplate.virusInjectable(stack.processing.owner.opponent)) {
+      await System.show(stack, 'フォース＜ウィルス・力＞', '＜ウィルス・力＞を【特殊召喚】');
+      await EffectTemplate.virusInject(stack, stack.processing.owner.opponent, '＜ウィルス・力＞');
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-031.ts
+++ b/src/database/effects/cards/1-4-031.ts
@@ -1,0 +1,41 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // フォース＜ウィルス・攻＞：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (EffectTemplate.virusInjectable(stack.processing.owner.opponent)) {
+      await System.show(stack, 'フォース＜ウィルス・攻＞', '＜ウィルス・攻＞を【特殊召喚】');
+      await EffectTemplate.virusInject(stack, stack.processing.owner.opponent, '＜ウィルス・攻＞');
+    }
+  },
+
+  // 大いなる母の恵み：ターン開始時の効果
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン開始時に発動
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      // 自分のユニットを取得
+      const ownUnits = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === stack.processing.owner.id,
+        stack.processing.owner
+      );
+
+      if (ownUnits.length > 0) {
+        await System.show(stack, '大いなる母の恵み', '【貫通】を付与');
+
+        // ユニットを1体選択
+        const [target] = await EffectHelper.selectUnit(
+          stack,
+          stack.processing.owner,
+          ownUnits,
+          '【貫通】を与えるユニットを選択'
+        );
+
+        // 【貫通】を付与
+        Effect.keyword(stack, stack.processing, target, '貫通');
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-032.ts
+++ b/src/database/effects/cards/1-4-032.ts
@@ -1,0 +1,87 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【秩序の盾】【固着】
+  // ■森羅万象の理
+  // このユニットがフィールドに出た時、対戦相手の全てのユニットの基本BPを-2000する。
+  // ■安寧なる世のために
+  // 対戦相手のユニットがアタックした時、それの基本BPを-1000する。
+  // あなたのトリガーゾーンのカードが対戦相手の効果によって破壊された時、対戦相手のユニットを1体選ぶ。それの基本BPを-3000する。
+
+  // 召喚時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    await System.show(stack, '森羅万象の理', '【秩序の盾】【固着】\n敵全体の基本BPを-2000');
+
+    // キーワード能力を付与
+    Effect.keyword(stack, stack.processing, stack.processing, '秩序の盾');
+    Effect.keyword(stack, stack.processing, stack.processing, '固着');
+
+    // 相手全てのユニットの基本BPを-2000する
+    for (const unit of opponent.field) {
+      Effect.modifyBP(stack, stack.processing, unit, -2000, {
+        isBaseBP: true,
+      });
+    }
+  },
+
+  // 相手ユニットがアタックした時の効果
+  onAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 相手のユニットがアタックした時のみ発動
+    if (stack.source instanceof Unit && stack.source.owner.id !== owner.id) {
+      await System.show(stack, '安寧なる世のために', '敵の基本BPを-1000');
+
+      // アタックしたユニットの基本BPを-1000する
+      Effect.modifyBP(stack, stack.processing, stack.source, -1000, {
+        isBaseBP: true,
+      });
+    }
+  },
+
+  // トリガーが破壊された時の効果
+  onLost: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 自分のトリガーカードが相手の効果によって破壊された時のみ発動
+    if (
+      stack.source instanceof Unit &&
+      stack.source.owner.id !== owner.id &&
+      stack.target &&
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id
+    ) {
+      // 相手のユニットが存在する場合のみ処理
+      if (opponent.field.length > 0) {
+        // 対象を選択可能なユニットを取得
+        const targetCandidates = EffectHelper.candidate(
+          stack.core,
+          unit => unit.owner.id === opponent.id,
+          owner
+        );
+
+        if (targetCandidates.length > 0) {
+          await System.show(stack, '安寧なる世のために', '敵の基本BPを-3000');
+
+          // ユニットを1体選択
+          const [target] = await EffectHelper.selectUnit(
+            stack,
+            owner,
+            targetCandidates,
+            '基本BPを-3000するユニットを選択'
+          );
+
+          // 基本BPを-3000する
+          Effect.modifyBP(stack, stack.processing, target, -3000, {
+            isBaseBP: true,
+          });
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-070.ts
+++ b/src/database/effects/cards/1-4-070.ts
@@ -1,0 +1,89 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■森の女神 - インターセプトカード
+  // あなたのユニットが戦闘した時、ターン終了時までそれのBPを+2000する。
+  // あなたのユニットが戦闘で勝利した時、あなたはカードを1枚引く。あなたのCPを+1する。
+  // あなたがプレイヤーアタックを受けた時、プレイヤーアタックしたユニットの基本BPを-3000する。
+
+  // 味方ユニットが戦闘した時のインターセプト効果
+  onBattle: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分のユニットが戦闘した時のみ発動
+    if (stack.source instanceof Unit && stack.source.owner.id === owner.id) {
+      await System.show(stack, '森の女神', 'BP+2000');
+
+      // BP+2000（ターン終了時まで）
+      Effect.modifyBP(stack, stack.processing, stack.source, 2000, {
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+
+  // 戦闘で勝利した時のインターセプト効果
+  onWinSelf: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分のユニットが戦闘で勝利した時のみ発動
+    if (stack.source instanceof Unit && stack.source.owner.id === owner.id) {
+      await System.show(stack, '森の女神', 'カードを1枚引く\nCP+1');
+
+      // カードを1枚引く
+      EffectTemplate.draw(owner, stack.core);
+
+      // CPを+1する
+      Effect.modifyCP(stack, stack.processing, owner, 1);
+    }
+  },
+
+  // プレイヤーアタックを受けた時のインターセプト効果
+  onPlayerAttack: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分がプレイヤーアタックを受けた時のみ発動
+    if (
+      stack.source instanceof Unit &&
+      stack.source.owner.id !== owner.id && // 相手のユニット
+      stack.target?.id === owner.id // 自分がターゲット
+    ) {
+      await System.show(stack, '森の女神', '敵ユニットの基本BPを-3000');
+
+      // プレイヤーアタックしたユニットの基本BPを-3000する
+      Effect.modifyBP(stack, stack.processing, stack.source, -3000, {
+        isBaseBP: true,
+      });
+    }
+  },
+
+  // インターセプトカード効果の発動チェック：戦闘時
+  checkBattle: async (stack: StackWithCard): Promise<boolean> => {
+    const owner = stack.processing.owner;
+
+    // 自分のユニットが戦闘した時のみ発動可能
+    return stack.source instanceof Unit && stack.source.owner.id === owner.id;
+  },
+
+  // インターセプトカード効果の発動チェック：戦闘勝利時
+  checkWin: async (stack: StackWithCard): Promise<boolean> => {
+    const owner = stack.processing.owner;
+
+    // 自分のユニットが戦闘で勝利した時のみ発動可能
+    return stack.source instanceof Unit && stack.source.owner.id === owner.id;
+  },
+
+  // インターセプトカード効果の発動チェック：プレイヤーアタック時
+  checkPlayerAttack: async (stack: StackWithCard): Promise<boolean> => {
+    const owner = stack.processing.owner;
+
+    // 自分がプレイヤーアタックを受けた時のみ発動可能
+    return (
+      stack.source instanceof Unit &&
+      stack.source.owner.id !== owner.id && // 相手のユニット
+      stack.target?.id === owner.id // 自分がターゲット
+    );
+  },
+};

--- a/src/database/effects/cards/1-4-106.ts
+++ b/src/database/effects/cards/1-4-106.ts
@@ -1,0 +1,14 @@
+import { Unit } from '@/package/core/class/card';
+import { EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■トリガードロー
+  // このユニットがフィールドに出た時、あなたはトリガーカードを1枚引く。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'トリガードロー', 'トリガーカードを1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] });
+  },
+};

--- a/src/database/effects/cards/1-4-108.ts
+++ b/src/database/effects/cards/1-4-108.ts
@@ -1,0 +1,13 @@
+import { Unit } from '@/package/core/class/card';
+import { EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // フォース＜ウィルス・護＞：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (EffectTemplate.virusInjectable(stack.processing.owner.opponent)) {
+      await System.show(stack, 'フォース＜ウィルス・護＞', '＜ウィルス・護＞を【特殊召喚】');
+      await EffectTemplate.virusInject(stack, stack.processing.owner.opponent, '＜ウィルス・護＞');
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-115.ts
+++ b/src/database/effects/cards/1-4-115.ts
@@ -1,0 +1,47 @@
+import { Evolve, Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Color } from '@/submodule/suit/constant/color';
+
+export const effects: CardEffects = {
+  // ■清き水の導き
+  // このユニットがフィールドに出た時、あなたのフィールドのユニットが4体以下の場合、あなたの捨札にある進化ユニット以外のコスト3の青属性のユニットをランダムで1体【特殊召喚】する。
+  // ■インターセプトドロー
+  // このユニットが破壊された時、あなたはインターセプトカードを1枚引く。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // フィールドのユニットが4体以下かチェック
+    if (owner.field.length <= 4) {
+      // 捨札にある進化ユニット以外のコスト3の青属性のユニットを検索
+      const candidates = owner.trash.filter(
+        card =>
+          card instanceof Unit &&
+          !(card instanceof Evolve) && // 進化ユニット以外
+          card.catalog.cost === 3 &&
+          card.catalog.color === Color.BLUE
+      );
+
+      if (candidates.length > 0) {
+        await System.show(stack, '清き水の導き', '青属性コスト3のユニットを特殊召喚');
+
+        // ランダムで1体選ぶ
+        const randomUnits = EffectHelper.random(candidates, 1);
+        if (randomUnits.length > 0) {
+          const targetUnit = randomUnits[0] as Unit;
+
+          // 特殊召喚
+          await Effect.summon(stack, stack.processing, targetUnit, false);
+        }
+      }
+    }
+  },
+
+  // 破壊された時の効果
+  onBreakSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'インターセプトドロー', 'インターセプトカードを1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['intercept'] });
+  },
+};

--- a/src/database/effects/cards/1-4-120.ts
+++ b/src/database/effects/cards/1-4-120.ts
@@ -1,0 +1,62 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【不屈】
+  // ■ラッキー☆スター
+  // ユニットがアタックするたび、このユニットの基本BPを+1000する。
+  // ■フェイタル☆アロー
+  // あなたの【天使】ユニットに【貫通】を与える。
+
+  // 召喚時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'フェイタル☆アロー', '【不屈】\n【天使】に【貫通】を付与');
+
+    // 不屈を付与
+    Effect.keyword(stack, stack.processing, stack.processing, '不屈');
+  },
+
+  // アタック時の効果
+  onAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // どのユニットがアタックしてもこの効果は発動する
+    await System.show(stack, 'ラッキー☆スター', '基本BP+1000');
+
+    // 基本BPを+1000する
+    Effect.modifyBP(stack, stack.processing, stack.processing, 1000, {
+      isBaseBP: true,
+    });
+  },
+
+  // フィールド効果：天使ユニットに貫通を与える
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // 自分のフィールドの天使ユニットを対象にする
+    owner.field.forEach(unit => {
+      // 天使ユニットか確認
+      if (unit.catalog.species?.includes('天使')) {
+        // 既にこのユニットが発行したDeltaが存在するか確認
+        const delta = unit.delta.find(
+          d =>
+            d.source?.unit === stack.processing.id && d.source?.effectCode === 'フェイタル☆アロー'
+        );
+
+        // 既にDeltaが存在しない場合のみ貫通を付与
+        if (!delta) {
+          Effect.keyword(stack, stack.processing, unit, '貫通', {
+            source: { unit: stack.processing.id, effectCode: 'フェイタル☆アロー' },
+          });
+        }
+      } else {
+        // 天使でなくなった場合、このユニットが付与した貫通を削除
+        unit.delta = unit.delta.filter(
+          d =>
+            !(
+              d.source?.unit === stack.processing.id && d.source?.effectCode === 'フェイタル☆アロー'
+            )
+        );
+      }
+    });
+  },
+};

--- a/src/database/effects/cards/1-4-125.ts
+++ b/src/database/effects/cards/1-4-125.ts
@@ -1,0 +1,56 @@
+import { Card, Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 忘却の遺跡：プレイヤーアタックを受けた時、ライフが1以下の場合、相手は手札を全て捨てる
+  onPlayerAttack: async (stack: StackWithCard<Card>): Promise<void> => {
+    // プレイヤーアタックの発生元が対戦相手か確認
+    const attacker = stack.source;
+    if ('owner' in attacker && attacker.owner.id === stack.processing.owner.opponent.id) {
+      // 自分のライフが1以下かチェック
+      if (stack.processing.owner.life.current <= 1) {
+        await System.show(stack, '忘却の遺跡', '対戦相手の手札を全て捨てる');
+
+        // 対戦相手の手札を全て捨てる
+        const opponent = stack.processing.owner.opponent;
+        const opponentHand = [...opponent.hand]; // 配列のコピーを作成
+
+        // 手札がある場合、全て捨てる
+        opponentHand.forEach(card => {
+          Effect.handes(stack, stack.processing, card);
+        });
+      }
+    }
+  },
+
+  // ターン開始時の効果
+  onTurnStart: async (stack: StackWithCard<Card>): Promise<void> => {
+    // 自分のターン開始時かつライフが1以下の場合に発動
+    if (
+      stack.processing.owner.id === stack.core.getTurnPlayer().id &&
+      stack.processing.owner.life.current <= 1
+    ) {
+      await System.show(stack, '忘却の遺跡', 'トリガーゾーンのカードを全て破壊');
+
+      // 対戦相手のトリガーゾーンにあるカードを全て破壊
+      const opponent = stack.processing.owner.opponent;
+      const triggerCards = [...opponent.trigger]; // 配列のコピーを作成
+
+      // トリガーカードがある場合、全て破壊
+      triggerCards.forEach(card => {
+        Effect.move(stack, stack.processing, card, 'trash');
+      });
+    }
+  },
+
+  // インターセプトカードの発動条件チェック
+  checkPlayerAttack: (stack: StackWithCard<Card>): boolean => {
+    // カードの所有者のライフが1以下の場合に発動
+    return (
+      stack.processing.owner.life.current <= 1 &&
+      stack.source instanceof Unit &&
+      stack.source.owner.id !== stack.processing.owner.id
+    );
+  },
+};

--- a/src/database/effects/cards/1-4-125.ts
+++ b/src/database/effects/cards/1-4-125.ts
@@ -7,10 +7,10 @@ export const effects: CardEffects = {
   onPlayerAttack: async (stack: StackWithCard<Card>): Promise<void> => {
     // プレイヤーアタックの発生元が対戦相手か確認
     const attacker = stack.source;
-    if ('owner' in attacker && attacker.owner.id === stack.processing.owner.opponent.id) {
+    if (attacker instanceof Unit && attacker.owner.id === stack.processing.owner.opponent.id) {
       // 自分のライフが1以下かチェック
       if (stack.processing.owner.life.current <= 1) {
-        await System.show(stack, '忘却の遺跡', '対戦相手の手札を全て捨てる');
+        await System.show(stack, '忘却の遺跡', '手札を全て破壊');
 
         // 対戦相手の手札を全て捨てる
         const opponent = stack.processing.owner.opponent;
@@ -27,21 +27,16 @@ export const effects: CardEffects = {
   // ターン開始時の効果
   onTurnStart: async (stack: StackWithCard<Card>): Promise<void> => {
     // 自分のターン開始時かつライフが1以下の場合に発動
-    if (
-      stack.processing.owner.id === stack.core.getTurnPlayer().id &&
-      stack.processing.owner.life.current <= 1
-    ) {
-      await System.show(stack, '忘却の遺跡', 'トリガーゾーンのカードを全て破壊');
+    await System.show(stack, '忘却の遺跡', 'トリガーゾーンのカードを全て破壊');
 
-      // 対戦相手のトリガーゾーンにあるカードを全て破壊
-      const opponent = stack.processing.owner.opponent;
-      const triggerCards = [...opponent.trigger]; // 配列のコピーを作成
+    // 対戦相手のトリガーゾーンにあるカードを全て破壊
+    const opponent = stack.processing.owner.opponent;
+    const triggerCards = [...opponent.trigger]; // 配列のコピーを作成
 
-      // トリガーカードがある場合、全て破壊
-      triggerCards.forEach(card => {
-        Effect.move(stack, stack.processing, card, 'trash');
-      });
-    }
+    // トリガーカードがある場合、全て破壊
+    triggerCards.forEach(card => {
+      Effect.move(stack, stack.processing, card, 'trash');
+    });
   },
 
   // インターセプトカードの発動条件チェック
@@ -51,6 +46,13 @@ export const effects: CardEffects = {
       stack.processing.owner.life.current <= 1 &&
       stack.source instanceof Unit &&
       stack.source.owner.id !== stack.processing.owner.id
+    );
+  },
+
+  checkTurnStart: (stack: StackWithCard<Card>) => {
+    return (
+      stack.processing.owner.id === stack.core.getTurnPlayer().id &&
+      stack.processing.owner.life.current <= 1
     );
   },
 };

--- a/src/database/effects/cards/1-4-208.ts
+++ b/src/database/effects/cards/1-4-208.ts
@@ -1,5 +1,5 @@
 import { Unit } from '@/package/core/class/card';
-import { Effect, EffectHelper, System } from '..';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
 
 export const effects: CardEffects = {
@@ -35,6 +35,7 @@ export const effects: CardEffects = {
 
     // 消滅効果耐性を付与
     Effect.keyword(stack, stack.processing, stack.processing, '消滅効果耐性');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '悪魔' });
   },
 
   // 自分のユニット召喚時効果

--- a/src/database/effects/cards/1-4-208.ts
+++ b/src/database/effects/cards/1-4-208.ts
@@ -1,7 +1,6 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
-import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
   // 【消滅効果耐性】
@@ -12,36 +11,45 @@ export const effects: CardEffects = {
 
   // 召喚時効果
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    // 消滅効果耐性を付与
-    Effect.keyword(stack, stack.processing, stack.processing, '消滅効果耐性');
+    // 対象を1体選択
+    const fieldUnits = EffectHelper.candidate(stack.core, () => true, stack.processing.owner);
 
-    // デッキから悪魔ユニットを検索
-    const demonUnits = stack.processing.owner.deck.filter(
-      card => card instanceof Unit && card.catalog.species?.includes('悪魔')
+    await System.show(
+      stack,
+      '裂帛の威令',
+      `【消滅効果耐性】\n【悪魔】を1枚引く\nBP7000以上に【防御禁止】\nBP+3000`
+    );
+    const [target] = await EffectHelper.selectUnit(
+      stack,
+      stack.processing.owner,
+      fieldUnits,
+      'BPを+3000するユニットを選択'
     );
 
-    if (demonUnits.length > 0) {
-      await System.show(stack, '裂帛の威令', '【悪魔】ユニットを1枚手札に加える');
+    // BPを+3000（ターン終了時まで）
+    Effect.modifyBP(stack, stack.processing, target, 3000, {
+      source: { unit: stack.processing.id, effectCode: '裂帛の威令' },
+      event: 'turnEnd',
+      count: 1,
+    });
 
-      // ランダムで1枚選択
-      const selectedUnits = EffectHelper.random(demonUnits, 1);
-
-      // 手札に加える
-      for (const unit of selectedUnits) {
-        Effect.move(stack, stack.processing, unit, 'hand');
-      }
-    }
+    // 消滅効果耐性を付与
+    Effect.keyword(stack, stack.processing, stack.processing, '消滅効果耐性');
   },
 
   // 自分のユニット召喚時効果
   onDrive: async (stack: StackWithCard<Unit>): Promise<void> => {
     // 召喚されたユニットが自分のユニットか確認
-    if (stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id) {
+    if (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.id &&
+      stack.processing.id !== stack.target.id
+    ) {
       // プレイヤーのフィールド上のユニットを全て取得
       const fieldUnits = stack.core.players.map(player => player.field).flat();
 
       if (fieldUnits.length > 0) {
-        await System.show(stack, '裂帛の威令', 'BP+3000（ターン終了時まで）');
+        await System.show(stack, '裂帛の威令', 'BP+3000');
 
         // 対象を1体選択
         const [target] = await EffectHelper.selectUnit(
@@ -69,32 +77,19 @@ export const effects: CardEffects = {
       if (unit.currentBP >= 7000) {
         // 既にこのユニットが発行したDeltaが存在するか確認
         const delta = unit.delta.find(
-          d =>
-            d.source?.unit === stack.processing.id &&
-            d.source?.effectCode === '裂帛の威令' &&
-            d.effect.type === 'keyword' &&
-            d.effect.name === '防御禁止'
+          d => d.source?.unit === stack.processing.id && d.source?.effectCode === '裂帛の威令'
         );
 
         // 既にDeltaが存在しない場合のみ防御禁止を付与
         if (!delta) {
-          unit.delta.push(
-            new Delta({ type: 'keyword', name: '防御禁止' }, undefined, undefined, undefined, {
-              unit: stack.processing.id,
-              effectCode: '裂帛の威令',
-            })
-          );
+          Effect.keyword(stack, stack.processing, unit, '防御禁止', {
+            source: { unit: stack.processing.id, effectCode: '裂帛の威令' },
+          });
         }
       } else {
         // BP7000未満になった場合、このユニットが付与した防御禁止を削除
         unit.delta = unit.delta.filter(
-          d =>
-            !(
-              d.source?.unit === stack.processing.id &&
-              d.source?.effectCode === '裂帛の威令' &&
-              d.effect.type === 'keyword' &&
-              d.effect.name === '防御禁止'
-            )
+          d => !(d.source?.unit === stack.processing.id && d.source?.effectCode === '裂帛の威令')
         );
       }
     });

--- a/src/database/effects/cards/1-4-217.ts
+++ b/src/database/effects/cards/1-4-217.ts
@@ -1,0 +1,14 @@
+import type { Unit } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 自身が召喚された時に発動する効果を記述
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const hasCP = stack.processing.owner.opponent.cp.current > 0;
+    await System.show(stack, 'ブラックレイダー', `【盗賊】を1枚引く${hasCP ? '\nCP-12' : ''}`);
+
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '盗賊' });
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner.opponent, -12);
+  },
+};

--- a/src/database/effects/cards/1-4-220.ts
+++ b/src/database/effects/cards/1-4-220.ts
@@ -1,0 +1,30 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■天使のわっか
+  // このユニットがフィールドに出た時、対戦相手は自分の手札を1枚選んで捨てる。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    // 相手の手札が0枚の場合は何もしない
+    if (opponent.hand.length === 0) return;
+
+    await System.show(stack, '天使のわっか', '相手は手札を1枚捨てる');
+
+    // 相手に手札を1枚選ばせる
+    const [selectedCard] = await EffectHelper.selectCard(
+      stack,
+      opponent,
+      opponent.hand,
+      '捨てるカードを選択',
+      1
+    );
+
+    // 選んだカードを捨てる
+    Effect.move(stack, stack.processing, selectedCard, 'trash');
+  },
+};

--- a/src/database/effects/cards/1-4-221.ts
+++ b/src/database/effects/cards/1-4-221.ts
@@ -10,45 +10,39 @@ export const effects: CardEffects = {
       card => card instanceof Unit && card.catalog.species?.includes('侍')
     );
 
-    if (samuraiUnitsInHand.length > 0) {
-      // Randomly select one Samurai unit to discard
-      const [discardTarget] = EffectHelper.random(samuraiUnitsInHand);
+    // Randomly select one Samurai unit to discard
+    const [discardTarget] = EffectHelper.random(samuraiUnitsInHand);
+    // Find Samurai units in deck for search
+    const samuraiUnitsInDeck = owner.deck.filter(
+      card => card instanceof Unit && card.catalog.species?.includes('侍')
+    );
 
-      if (discardTarget) {
-        await System.show(
+    if (discardTarget && samuraiUnitsInDeck.length > 0) {
+      await System.show(
+        stack,
+        '白拍子の舞子＆永久の待ち人',
+        '【侍】に【不屈】と【秩序の盾】を与える\n手札から【侍】を捨てる\nデッキから【侍】を選んで引く'
+      );
+
+      // Let player choose a Samurai unit from deck
+      try {
+        const [selectedCard] = await EffectHelper.selectCard(
           stack,
-          '永久の待ち人',
-          'ランダムな【侍】を捨てる\nデッキから【侍】を選んで引く'
+          owner,
+          samuraiUnitsInDeck,
+          '手札に加えるカードを選択して下さい'
         );
 
-        // Find Samurai units in deck for search
-        const samuraiUnitsInDeck = owner.deck.filter(
-          card => card instanceof Unit && card.catalog.species?.includes('侍')
-        );
-
-        if (
-          samuraiUnitsInDeck.length > 0 &&
-          owner.hand.length < stack.core.room.rule.player.max.hand
-        ) {
-          // Let player choose a Samurai unit from deck
-          try {
-            const [selectedCard] = await EffectHelper.selectCard(
-              stack,
-              owner,
-              samuraiUnitsInDeck,
-              '手札に加えるカードを選択して下さい'
-            );
-
-            // Add selected card to hand
-            Effect.move(stack, stack.processing, selectedCard, 'hand');
-            // Discard the selected card
-            Effect.handes(stack, stack.processing, discardTarget);
-          } catch (error) {
-            // Failed to select a card, do nothing
-            console.error('Failed to select a card:', error);
-          }
-        }
+        // Add selected card to hand
+        Effect.move(stack, stack.processing, selectedCard, 'hand');
+        // Discard the selected card
+        Effect.handes(stack, stack.processing, discardTarget);
+      } catch (error) {
+        // Failed to select a card, do nothing
+        console.error('Failed to select a card:', error);
       }
+    } else {
+      await System.show(stack, '白拍子の舞子', '【侍】に【不屈】と【秩序の盾】を与える');
     }
   },
 

--- a/src/database/effects/cards/1-4-225.ts
+++ b/src/database/effects/cards/1-4-225.ts
@@ -1,0 +1,62 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // らいおんぱわー！：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 対戦相手のユニットを選び、強制防御を付与
+    const targets = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.opponent.id,
+      stack.processing.owner
+    );
+
+    if (targets.length > 0) {
+      await System.show(stack, 'らいおんぱわー！', '【強制防御】を付与');
+
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        targets,
+        '【強制防御】を与えるユニットを選択'
+      );
+
+      Effect.keyword(stack, stack.processing, target, '強制防御', {
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+
+  // ターン開始時の効果
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分のターン開始時に発動
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+      // ラウンド数が奇数かチェック
+      const roundNumber = stack.core.room.rule.system.round;
+
+      if (roundNumber % 2 === 1) {
+        // 奇数ラウンド
+        const targets = EffectHelper.candidate(
+          stack.core,
+          unit => unit.owner.id === stack.processing.owner.opponent.id,
+          stack.processing.owner
+        );
+
+        if (targets.length > 0) {
+          await System.show(stack, 'らいおんぱわー！', '【強制防御】を付与');
+
+          const [target] = await EffectHelper.selectUnit(
+            stack,
+            stack.processing.owner,
+            targets,
+            '【強制防御】を与えるユニットを選択'
+          );
+
+          Effect.keyword(stack, stack.processing, target, '強制防御');
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-226.ts
+++ b/src/database/effects/cards/1-4-226.ts
@@ -1,0 +1,38 @@
+import { Evolve, Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■エンジェル・コール
+  // このユニットがフィールドに出た時、あなたのフィールドにユニットが4体以下の場合、あなたのデッキから進化ユニット以外のコスト2以下の【天使】ユニットをランダムで1体【特殊召喚】する。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // フィールドのユニットが4体以下か確認
+    if (owner.field.length <= 4) {
+      // デッキから進化ユニット以外のコスト2以下の天使ユニットを検索
+      const candidates = owner.deck.filter(
+        card =>
+          card instanceof Unit &&
+          !(card instanceof Evolve) && // 進化ユニット以外
+          card.catalog.cost <= 2 &&
+          card.catalog.species?.includes('天使') // 天使ユニット
+      );
+
+      if (candidates.length > 0) {
+        await System.show(stack, 'エンジェル・コール', '【天使】ユニットを特殊召喚');
+
+        // ランダムで1体選ぶ
+        const randomUnits = EffectHelper.random(candidates, 1);
+        if (randomUnits.length > 0) {
+          const targetUnit = randomUnits[0] as Unit;
+
+          // 特殊召喚
+          await Effect.summon(stack, stack.processing, targetUnit, false);
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-302.ts
+++ b/src/database/effects/cards/1-4-302.ts
@@ -1,0 +1,82 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // バグ・サンシャイン：フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分の【昆虫】ユニットと対戦相手のユニットを選択
+    const ownInsectUnits = EffectHelper.candidate(
+      stack.core,
+      unit =>
+        unit.owner.id === stack.processing.owner.id &&
+        (unit.catalog.species?.includes('昆虫') || false) &&
+        unit.id !== stack.processing.id,
+      stack.processing.owner
+    );
+
+    const enemyUnits = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.opponent.id,
+      stack.processing.owner
+    );
+
+    // どちらも選択可能なユニットがある場合のみ発動
+    if (ownInsectUnits.length > 0 && enemyUnits.length > 0) {
+      await System.show(stack, 'バグ・サンシャイン', '【昆虫】ユニットを破壊\n5000ダメージ');
+
+      // 自分の【昆虫】ユニットを選択
+      const [insectUnit] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        ownInsectUnits,
+        '破壊する【昆虫】ユニットを選択'
+      );
+
+      // 対戦相手のユニットを選択
+      const [enemyUnit] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        enemyUnits,
+        'ダメージを与えるユニットを選択'
+      );
+
+      // 自分の【昆虫】ユニットを破壊
+      Effect.break(stack, stack.processing, insectUnit);
+
+      // 対戦相手のユニットに5000ダメージ
+      Effect.damage(stack, stack.processing, enemyUnit, 5000);
+    }
+  },
+
+  // バグ・ジャミング：【昆虫】ユニットが破壊されるたびに発動
+  onBreak: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 破壊されたユニットが自分の【昆虫】ユニットかチェック
+    const brokenUnit = stack.target as Unit;
+
+    if (
+      brokenUnit.owner.id === stack.processing.owner.id &&
+      brokenUnit.id !== stack.processing.id &&
+      (brokenUnit.catalog.species?.includes('昆虫') || false)
+    ) {
+      const targets = EffectHelper.candidate(
+        stack.core,
+        unit => unit.owner.id === stack.processing.owner.opponent.id,
+        stack.processing.owner
+      );
+
+      if (targets.length > 0) {
+        await System.show(stack, 'バグ・ジャミング', '【防御禁止】を付与');
+
+        const [target] = await EffectHelper.selectUnit(
+          stack,
+          stack.processing.owner,
+          targets,
+          '【防御禁止】を与えるユニットを選択'
+        );
+
+        Effect.keyword(stack, stack.processing, target, '防御禁止');
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-303.ts
+++ b/src/database/effects/cards/1-4-303.ts
@@ -1,0 +1,48 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+// 三叉の炎舞の共通処理
+const triggerDestroy = async (stack: StackWithCard<Unit>): Promise<void> => {
+  const opponent = stack.processing.owner.opponent;
+
+  if (opponent.trigger.length === 0) return;
+
+  await System.show(stack, '三叉の炎舞', '相手のトリガーを破壊');
+
+  // トリガーゾーンからランダムで1枚選ぶ
+  const [targetCard] = EffectHelper.random(opponent.trigger, 1);
+  if (targetCard) Effect.move(stack, stack.processing, targetCard, 'trash');
+};
+
+export const effects: CardEffects = {
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await triggerDestroy(stack);
+  },
+
+  // ターン開始時の効果
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const turnPlayer = stack.core.getTurnPlayer();
+
+    // 自分のターン開始時は常に発動
+    if (owner.id === turnPlayer.id) {
+      await triggerDestroy(stack);
+      return;
+    }
+
+    // 相手のターン開始時は自分の武身が4体以上いる場合のみ発動
+    const bushintaiCount = owner.field.filter(unit =>
+      unit.catalog.species?.includes('武身')
+    ).length;
+    if (bushintaiCount >= 4) {
+      await triggerDestroy(stack);
+    }
+  },
+
+  // 相手ターン終了時の効果
+  onTurnEnd: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await EffectTemplate.reincarnate(stack, stack.processing);
+  },
+};

--- a/src/database/effects/cards/1-4-304.ts
+++ b/src/database/effects/cards/1-4-304.ts
@@ -1,0 +1,113 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■選略・密偵勅命
+  // あなたの【忍者】ユニットがアタックした時、以下の効果から1つを選び発動する。
+  // ①：あなたは手札を1枚選んで捨てる。ターン終了時までアタックしたユニットに「ブロックされない」効果を与える。
+  // ②：ターン終了時までアタックしたユニットのBPを+2000する。
+  // ■曲者討伐
+  // あなたのトリガーカードの効果が発動するたび、対戦相手のユニットを1体選ぶ。それに2000ダメージを与える。
+
+  // 忍者ユニットがアタックした時の効果
+  onAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分の忍者ユニットがアタックした時のみ発動
+    if (
+      stack.source instanceof Unit &&
+      stack.source.owner.id === owner.id &&
+      stack.source.catalog.species?.includes('忍者')
+    ) {
+      // 選択肢を提示
+      const [choice] =
+        stack.processing.owner.hand.length > 0
+          ? await System.prompt(stack, owner.id, {
+              type: 'option',
+              title: '選略・密偵勅命',
+              items: [
+                { id: '1', description: '手札を1枚捨て、ブロックされない効果を得る' },
+                { id: '2', description: 'BP+2000' },
+              ],
+            })
+          : ['2'];
+
+      // 選択した効果を発動
+      switch (choice) {
+        case '1':
+          // ①：手札を1枚選んで捨て、ブロックされない効果を与える
+          if (owner.hand.length > 0) {
+            await System.show(stack, '選略・密偵勅命', '手札を1枚捨て、ブロックされない効果を付与');
+
+            // 手札を1枚選ぶ
+            const [selectedCard] = await EffectHelper.selectCard(
+              stack,
+              owner,
+              owner.hand,
+              '捨てるカードを選択',
+              1
+            );
+
+            // 選んだカードを捨てる
+            Effect.move(stack, stack.processing, selectedCard, 'trash');
+
+            // ブロックされない効果を与える（次元干渉/コスト0として実装）
+            Effect.keyword(stack, stack.processing, stack.source, '次元干渉', {
+              event: 'turnEnd',
+              count: 1,
+              cost: 0,
+            });
+          }
+          break;
+
+        case '2':
+          // ②：BP+2000
+          await System.show(stack, '選略・密偵勅命', 'BP+2000');
+
+          // BP+2000（ターン終了時まで）
+          Effect.modifyBP(stack, stack.processing, stack.source, 2000, {
+            event: 'turnEnd',
+            count: 1,
+          });
+          break;
+      }
+    }
+  },
+
+  // トリガーカード効果発動時
+  onTrigger: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分のトリガーカードの効果が発動したときのみ処理
+    // sourceがCardの場合のみ処理
+    if ('owner' in stack.source && stack.source.owner.id === owner.id) {
+      const opponent = owner.opponent;
+
+      // 相手のユニットが存在する場合のみ処理
+      if (opponent.field.length > 0) {
+        // 対象を選択可能なユニットを取得
+        const targetCandidates = EffectHelper.candidate(
+          stack.core,
+          unit => unit.owner.id === opponent.id,
+          owner
+        );
+
+        if (targetCandidates.length > 0) {
+          await System.show(stack, '曲者討伐', '敵に2000ダメージ');
+
+          // ユニットを1体選択
+          const [target] = await EffectHelper.selectUnit(
+            stack,
+            owner,
+            targetCandidates,
+            'ダメージを与えるユニットを選択'
+          );
+
+          // 2000ダメージを与える
+          Effect.damage(stack, stack.processing, target, 2000);
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-310.ts
+++ b/src/database/effects/cards/1-4-310.ts
@@ -1,0 +1,64 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■純真な心のままに
+  // このユニットがフィールドに出た時、対戦相手のトリガーゾーンにあるカードを全て手札に戻す。
+  // ■銀翼転身
+  // このユニットが破壊された時、あなたのフィールドにユニットが4体以下の場合、対戦相手のコスト2以下のユニットを1体選ぶ。それをあなたのフィールドに【複製】する。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    // 相手のトリガーゾーンにカードがあるか確認
+    if (opponent.trigger.length > 0) {
+      await System.show(stack, '純真な心のままに', 'トリガーゾーンのカードを手札に戻す');
+
+      // トリガーゾーンのカードを全て手札に戻す
+      // 配列のコピーを作成して処理（元の配列が変更されるため）
+      const triggerCards = [...opponent.trigger];
+
+      for (const card of triggerCards) {
+        Effect.move(stack, stack.processing, card, 'hand');
+      }
+    }
+  },
+
+  // 破壊された時の効果
+  onBreakSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // フィールドのユニットが4体以下か確認
+    if (owner.field.length <= 4) {
+      // 相手のコスト2以下のユニットを取得
+      const lowCostUnits = opponent.field.filter(unit => unit.catalog.cost <= 2);
+
+      if (lowCostUnits.length > 0) {
+        // 対象を選択可能なユニットを取得
+        const targetCandidates = EffectHelper.candidate(
+          stack.core,
+          unit => unit.owner.id === opponent.id && unit.catalog.cost <= 2,
+          owner
+        );
+
+        if (targetCandidates.length > 0) {
+          await System.show(stack, '銀翼転身', 'ユニットを【複製】する');
+
+          // ユニットを1体選択
+          const [target] = await EffectHelper.selectUnit(
+            stack,
+            owner,
+            targetCandidates,
+            '【複製】するユニットを選択'
+          );
+
+          // 選択したユニットを複製
+          await Effect.clone(stack, stack.processing, target, owner);
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/1-4-315.ts
+++ b/src/database/effects/cards/1-4-315.ts
@@ -30,12 +30,10 @@ export const effects: CardEffects = {
     if (opponent.trigger.length === 0) return;
 
     // トリガーゾーンからランダムで1枚選ぶ
-    const targetCards = EffectHelper.random(opponent.trigger, 1);
-    if (targetCards.length === 0) return;
-
-    const targetCard = targetCards[0];
+    const [target] = EffectHelper.random(opponent.trigger, 1);
+    if (!target) return;
 
     await System.show(stack, 'えんじぇりっく・ろすと', 'トリガーゾーンを1枚破壊');
-    Effect.break(stack, stack.processing, targetCard as Unit);
+    Effect.move(stack, stack.processing, target, 'trash');
   },
 };

--- a/src/database/effects/cards/1-4-315.ts
+++ b/src/database/effects/cards/1-4-315.ts
@@ -1,0 +1,41 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    if (opponent.hand.length === 0) return;
+
+    await System.show(stack, 'だてんしのいたずら', '相手は手札を2枚まで捨てる');
+
+    // 相手に手札を2枚まで選択させて捨てる
+    const selectedCards = await EffectHelper.selectCard(
+      stack,
+      opponent,
+      opponent.hand,
+      '捨てるカードを選択してください（最大2枚）',
+      Math.max(2, stack.processing.owner.opponent.hand.length)
+    );
+
+    for (const card of selectedCards) {
+      Effect.move(stack, stack.processing, card, 'trash');
+    }
+  },
+
+  onOverclock: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    if (opponent.trigger.length === 0) return;
+
+    // トリガーゾーンからランダムで1枚選ぶ
+    const targetCards = EffectHelper.random(opponent.trigger, 1);
+    if (targetCards.length === 0) return;
+
+    const targetCard = targetCards[0];
+
+    await System.show(stack, 'えんじぇりっく・ろすと', '相手のトリガーを破壊');
+    Effect.break(stack, stack.processing, targetCard as Unit);
+  },
+};

--- a/src/database/effects/cards/1-4-315.ts
+++ b/src/database/effects/cards/1-4-315.ts
@@ -8,15 +8,15 @@ export const effects: CardEffects = {
 
     if (opponent.hand.length === 0) return;
 
-    await System.show(stack, 'だてんしのいたずら', '相手は手札を2枚まで捨てる');
+    await System.show(stack, 'だてんしのいたずら', '手札を2枚まで捨てる');
 
     // 相手に手札を2枚まで選択させて捨てる
     const selectedCards = await EffectHelper.selectCard(
       stack,
       opponent,
       opponent.hand,
-      '捨てるカードを選択してください（最大2枚）',
-      Math.max(2, stack.processing.owner.opponent.hand.length)
+      '捨てるカードを選択してください',
+      Math.min(2, stack.processing.owner.opponent.hand.length)
     );
 
     for (const card of selectedCards) {
@@ -24,7 +24,7 @@ export const effects: CardEffects = {
     }
   },
 
-  onOverclock: async (stack: StackWithCard<Unit>): Promise<void> => {
+  onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     const opponent = stack.processing.owner.opponent;
 
     if (opponent.trigger.length === 0) return;
@@ -35,7 +35,7 @@ export const effects: CardEffects = {
 
     const targetCard = targetCards[0];
 
-    await System.show(stack, 'えんじぇりっく・ろすと', '相手のトリガーを破壊');
+    await System.show(stack, 'えんじぇりっく・ろすと', 'トリガーゾーンを1枚破壊');
     Effect.break(stack, stack.processing, targetCard as Unit);
   },
 };

--- a/src/database/effects/cards/1-4-318.ts
+++ b/src/database/effects/cards/1-4-318.ts
@@ -19,11 +19,9 @@ export const effects: CardEffects = {
       await System.show(stack, '途切れぬ血統', 'デッキから【ドラゴン】を特殊召喚');
 
       // 条件に合うカードがある場合、ランダムで1枚選んで特殊召喚
-      if (dragonUnits.length > 0) {
-        const [randomDragon] = EffectHelper.random(dragonUnits, 1);
-        if (randomDragon instanceof Unit) {
-          await Effect.summon(stack, stack.processing, randomDragon);
-        }
+      const [randomDragon] = EffectHelper.random(dragonUnits, 1);
+      if (randomDragon instanceof Unit) {
+        await Effect.summon(stack, stack.processing, randomDragon);
       }
     }
   },

--- a/src/database/effects/cards/1-4-318.ts
+++ b/src/database/effects/cards/1-4-318.ts
@@ -1,0 +1,30 @@
+import { Evolve, Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 途切れぬ血統：ユニットが破壊された時の効果
+  onBreakSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // フィールドにユニットが4体以下かチェック
+    // デッキから進化ユニット以外のコスト3以下の【ドラゴン】を検索
+    const dragonUnits = stack.processing.owner.deck.filter(
+      card =>
+        card instanceof Unit &&
+        !(card instanceof Evolve) &&
+        card.catalog.cost <= 3 &&
+        (card.catalog.species?.includes('ドラゴン') || false)
+    );
+
+    if (stack.processing.owner.field.length <= 4 && dragonUnits.length > 0) {
+      await System.show(stack, '途切れぬ血統', 'デッキから【ドラゴン】を特殊召喚');
+
+      // 条件に合うカードがある場合、ランダムで1枚選んで特殊召喚
+      if (dragonUnits.length > 0) {
+        const [randomDragon] = EffectHelper.random(dragonUnits, 1);
+        if (randomDragon instanceof Unit) {
+          await Effect.summon(stack, stack.processing, randomDragon);
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/2-0-004.ts
+++ b/src/database/effects/cards/2-0-004.ts
@@ -1,0 +1,53 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【狂戦士】【スピードムーブ】
+  // ■アタッカー
+  // このユニットがアタックした時、ターン終了時までこのユニットのBPを+2000する。
+  // ■狂獣乱破
+  // このユニットが戦闘した時、それがアタック中だった場合、対戦相手のユニットからランダムで1体に5000ダメージを与える。
+
+  // 召喚時の効果：キーワード能力を付与
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(
+      stack,
+      '狂戦士＆スピードムーブ',
+      'ターン開始時に強制的にアタックする\n行動制限の影響を受けない'
+    );
+    Effect.keyword(stack, stack.processing, stack.processing, '狂戦士');
+    Effect.speedMove(stack, stack.processing);
+  },
+
+  // アタック時の効果
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分自身のアタック時のみ発動
+    if (stack.source instanceof Unit && stack.source.id === stack.processing.id) {
+      await System.show(stack, 'アタッカー', 'BP+2000');
+
+      // BP+2000（ターン終了時まで）
+      Effect.modifyBP(stack, stack.processing, stack.processing, 2000, {
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+
+  // 戦闘時の効果
+  onBattleSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分自身の戦闘時かつアタック中かどうかを確認
+    // アタック中の場合、stack.sourceが自分自身になる
+    if (stack.processing.id === stack.source.id) {
+      const opponent = stack.processing.owner.opponent;
+
+      // 相手ユニットがいない場合は効果発動しない
+      if (opponent.field.length === 0) return;
+
+      await System.show(stack, '狂獣乱破', '敵に5000ダメージ');
+      EffectHelper.random(opponent.field, 1).forEach(unit =>
+        Effect.damage(stack, stack.processing, unit, 5000)
+      );
+    }
+  },
+};

--- a/src/database/effects/cards/2-0-102.ts
+++ b/src/database/effects/cards/2-0-102.ts
@@ -1,0 +1,41 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■前線突破
+  // このユニットのBPは+［お互いのトリガーゾーンにあるカードの数×1000］される。
+
+  // フィールド効果
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const self = stack.processing;
+    const owner = self.owner;
+    const opponent = owner.opponent;
+
+    // お互いのトリガーゾーンにあるカードの数
+    const triggerCount = owner.trigger.length + opponent.trigger.length;
+
+    // BPの増加量
+    const bpIncrease = triggerCount * 1000;
+
+    // 既にこのユニットが発行したDeltaが存在するか確認
+    const delta = self.delta.find(
+      delta => delta.source?.unit === self.id && delta.source?.effectCode === '前線突破'
+    );
+
+    if (delta && delta.effect.type === 'bp') {
+      // 既存のDeltaを更新
+      delta.effect.diff = bpIncrease;
+    } else {
+      // 新しいDeltaを発行
+      Effect.modifyBP(stack, self, self, bpIncrease, {
+        source: { unit: self.id, effectCode: '前線突破' },
+      });
+    }
+  },
+
+  // 召喚時のテキスト表示
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '前線突破', 'BP+[お互いのトリガーゾーンのカード数×1000]');
+  },
+};

--- a/src/database/effects/cards/2-0-136.ts
+++ b/src/database/effects/cards/2-0-136.ts
@@ -1,0 +1,32 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  checkBreak: (stack: StackWithCard) => {
+    return stack.target instanceof Unit && stack.processing.owner.id === stack.target.owner.id;
+  },
+
+  onBreak: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '玲瓏の鉱脈', 'CP+1');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, +1);
+  },
+
+  checkPlayerAttack: (stack: StackWithCard) => {
+    return stack.source instanceof Unit && stack.processing.owner.id === stack.source.owner.id;
+  },
+
+  onPlayerAttack: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '玲瓏の鉱脈', 'CP+2');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, +2);
+  },
+
+  checkTurnEnd: (stack: StackWithCard) => {
+    return stack.processing.owner.id === stack.core.getTurnPlayer().id;
+  },
+
+  onTurnEnd: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '玲瓏の鉱脈', 'CP+4');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, +4);
+  },
+};

--- a/src/database/effects/cards/2-0-204.ts
+++ b/src/database/effects/cards/2-0-204.ts
@@ -1,0 +1,57 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // スピードムーブ効果
+  async onDriveSelf(stack: StackWithCard<Unit>) {
+    // スピードムーブの説明表示
+    await System.show(stack, 'スピードムーブ', '行動制限の影響を受けない');
+
+    // スピードムーブの適用（行動制限を除去）
+    Effect.speedMove(stack, stack.processing);
+  },
+
+  // ■闇夜の切り裂き魔
+  // このユニットがアタックした時、自身以外の全てのユニットに1000ダメージを与える。
+  async onAttackSelf(stack: StackWithCard<Unit>) {
+    // 全ユニットを取得
+    const allUnits = stack.core.players
+      .map(p => p.field)
+      .flat()
+      .filter(unit => unit.id !== stack.processing.id);
+
+    if (allUnits.length > 0) {
+      await System.show(stack, '闇夜の切り裂き魔', '自身以外に1000ダメージ');
+
+      // 自身以外に1000ダメージを与える
+      for (const unit of allUnits) {
+        if (unit.id !== stack.processing.id) {
+          Effect.damage(stack, stack.processing, unit, 1000);
+        }
+      }
+    }
+  },
+
+  // ■パーフェクトクライム
+  // このユニットがプレイヤーアタックに成功した時、あなたのトリガーゾーンにあるカードを2枚ランダムで破壊する。
+  // そうした場合、このユニットをあなたの手札に戻す
+  async onPlayerAttackSelf(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+    const triggers = owner.trigger;
+
+    // トリガーが2枚以上ある場合のみ処理
+    if (triggers.length >= 2) {
+      await System.show(stack, 'パーフェクトクライム', 'トリガーゾーンを2枚破壊\n手札に戻る');
+
+      // ランダムで2枚選んで破壊
+      const destroyTargets = EffectHelper.random(triggers, 2);
+      for (const card of destroyTargets) {
+        Effect.move(stack, stack.processing, card, 'trash');
+      }
+
+      // このユニットを手札に戻す
+      Effect.bounce(stack, stack.processing, stack.processing);
+    }
+  },
+};

--- a/src/database/effects/cards/2-0-204.ts
+++ b/src/database/effects/cards/2-0-204.ts
@@ -23,13 +23,7 @@ export const effects: CardEffects = {
 
     if (allUnits.length > 0) {
       await System.show(stack, '闇夜の切り裂き魔', '自身以外に1000ダメージ');
-
-      // 自身以外に1000ダメージを与える
-      for (const unit of allUnits) {
-        if (unit.id !== stack.processing.id) {
-          Effect.damage(stack, stack.processing, unit, 1000);
-        }
-      }
+      allUnits.forEach(unit => Effect.damage(stack, stack.processing, unit, 1000));
     }
   },
 

--- a/src/database/effects/cards/2-0-222.ts
+++ b/src/database/effects/cards/2-0-222.ts
@@ -23,7 +23,12 @@ export const effects: CardEffects = {
 
       // 各対象カードにコスト-1のDeltaを適用
       targets.forEach(card => {
-        card.delta.push(new Delta({ type: 'cost', value: -1 }, 'turnEnd', 1, true));
+        card.delta.push(
+          new Delta(
+            { type: 'cost', value: -1 },
+            { event: 'turnEnd', count: 1, onlyForOwnersTurn: true }
+          )
+        );
       });
     }
   },

--- a/src/database/effects/cards/2-0-301.ts
+++ b/src/database/effects/cards/2-0-301.ts
@@ -1,0 +1,34 @@
+import { Unit } from '@/package/core/class/card';
+import { EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■募獣
+  // このユニット以外のあなたの【獣】ユニットがフィールドに出た時、【獣】ユニットのカードを1枚ランダムで手札に加える。
+
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    if (
+      stack.target instanceof Unit &&
+      stack.target.catalog.species?.includes('獣') // 獣ユニット
+    ) {
+      await System.show(stack, '募獣', '【獣】ユニットを1枚引く');
+      EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '獣' });
+    }
+  },
+
+  // ユニット召喚時の効果
+  onDrive: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分の獣ユニットが召喚された時のみ発動
+    if (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id &&
+      stack.target.id !== stack.processing.id && // 自分自身以外
+      stack.target.catalog.species?.includes('獣') // 獣ユニット
+    ) {
+      await System.show(stack, '募獣', '【獣】ユニットを1枚引く');
+      EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '獣' });
+    }
+  },
+};

--- a/src/database/effects/cards/2-0-317.ts
+++ b/src/database/effects/cards/2-0-317.ts
@@ -8,7 +8,6 @@ export const effects: CardEffects = {
     const opponentUnits = stack.processing.owner.opponent.field;
     if (opponentUnits.length === 0) return;
 
-    // プロンプトを表示して効果を選択
     const [choice] =
       opponentUnits.filter(unit => unit.lv >= 3).length > 0
         ? await System.prompt(stack, stack.processing.owner.id, {
@@ -25,17 +24,21 @@ export const effects: CardEffects = {
       // ①：対戦相手の全てのレベル3以上のユニットを破壊する
       const level3OrHigherUnits = opponentUnits.filter(unit => unit.lv >= 3);
 
-      await System.show(stack, '選略・空間を統べる覇者', '敵全体のLv3以上のユニットを破壊');
+      if (level3OrHigherUnits.length > 0) {
+        await System.show(stack, '選略・空間を統べる覇者', '敵全体のLv3以上のユニットを破壊');
 
-      for (const unit of level3OrHigherUnits) {
-        Effect.break(stack, stack.processing, unit);
+        for (const unit of level3OrHigherUnits) {
+          Effect.break(stack, stack.processing, unit);
+        }
       }
     } else if (choice === '2') {
       // ②：対戦相手の全てのユニットに【沈黙】を与える
-      await System.show(stack, '選略・空間を統べる覇者', '敵全体に【沈黙】を与える');
+      if (opponentUnits.length > 0) {
+        await System.show(stack, '選略・空間を統べる覇者', '敵全体に【沈黙】を与える');
 
-      for (const unit of opponentUnits) {
-        Effect.keyword(stack, stack.processing, unit, '沈黙');
+        for (const unit of opponentUnits) {
+          Effect.keyword(stack, stack.processing, unit, '沈黙');
+        }
       }
     }
   },

--- a/src/database/effects/cards/2-0-318.ts
+++ b/src/database/effects/cards/2-0-318.ts
@@ -47,7 +47,7 @@ export const effects: CardEffects = {
       const allUnits = [...owner.field, ...owner.opponent.field];
       allUnits.forEach(unit => {
         // Deltaで一時的BP増加（event: 'turnEnd', count: 1 でターン終了時まで）
-        unit.delta.push(new Delta({ type: 'bp', diff: 5000 }, 'turnEnd', 1));
+        unit.delta.push(new Delta({ type: 'bp', diff: 5000 }, { event: 'turnEnd', count: 1 }));
       });
       await System.show(stack, '選略・ジャッジガベル', 'BP+5000');
     } else if (choice === '2') {

--- a/src/database/effects/cards/2-1-008.ts
+++ b/src/database/effects/cards/2-1-008.ts
@@ -1,0 +1,33 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 支援狙撃：フィールドに出た時、自分の【戦士】ユニットを1体選び、行動権を回復する
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const targets = EffectHelper.candidate(
+      stack.core,
+      unit => {
+        return (
+          unit.owner.id === stack.processing.owner.id &&
+          (unit.catalog.species?.includes('戦士') || false) &&
+          unit.id !== stack.processing.id
+        );
+      },
+      stack.processing.owner
+    );
+
+    if (targets.length > 0) {
+      await System.show(stack, '支援狙撃', '行動権回復');
+
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        targets,
+        '行動権を回復するユニットを選択'
+      );
+
+      Effect.activate(stack, stack.processing, target, true);
+    }
+  },
+};

--- a/src/database/effects/cards/2-1-008.ts
+++ b/src/database/effects/cards/2-1-008.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
       unit => {
         return (
           unit.owner.id === stack.processing.owner.id &&
-          (unit.catalog.species?.includes('戦士') || false) &&
+          (unit.catalog.species?.includes('戦士') ?? false) &&
           unit.id !== stack.processing.id
         );
       },

--- a/src/database/effects/cards/2-1-010.ts
+++ b/src/database/effects/cards/2-1-010.ts
@@ -1,0 +1,88 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■天上剣技・心眼の太刀
+  // このユニットがフィールドに出た時、対戦相手は自分のトリガーゾーンを公開する。あなたはその中からカードを1枚選び、それをデッキに戻す。
+  // あなたの【天使】ユニットに【破壊効果耐性】と【次元干渉／コスト3】を与える。
+  // ■天命の一閃
+  // このユニットがプレイヤーアタックに成功した時、あなたのライフを+1する。
+
+  // 召喚時効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    await System.show(
+      stack,
+      '天上剣技・心眼の太刀',
+      'トリガーゾーンを公開\n1枚選んでデッキに戻す\n【天使】に【破壊効果耐性】と【次元干渉／コスト3】を付与'
+    );
+
+    // 相手のトリガーゾーンにカードがある場合、1枚選んでデッキに戻す
+    if (opponent.trigger.length > 0) {
+      const [selectedCard] = await EffectHelper.selectCard(
+        stack,
+        stack.processing.owner,
+        opponent.trigger,
+        'デッキに戻すカードを選択',
+        1
+      );
+
+      // 選んだカードをデッキに戻す
+      Effect.move(stack, stack.processing, selectedCard, 'deck');
+    }
+  },
+
+  // フィールド効果: 天使ユニットに破壊効果耐性と次元干渉/コスト3を与える
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // 天使ユニットに効果を付与
+    owner.field.forEach(unit => {
+      if (unit.catalog.species?.includes('天使')) {
+        // 既にこのユニットが発行したDeltaが存在するか確認（破壊効果耐性）
+        const breakResistDelta = unit.delta.find(
+          d => d.source?.unit === stack.processing.id && d.source?.effectCode === '破壊効果耐性'
+        );
+
+        // 破壊効果耐性が付与されていなければ付与
+        if (!breakResistDelta) {
+          Effect.keyword(stack, stack.processing, unit, '破壊効果耐性', {
+            source: { unit: stack.processing.id, effectCode: '破壊効果耐性' },
+          });
+        }
+
+        // 既にこのユニットが発行したDeltaが存在するか確認（次元干渉/コスト3）
+        const dimensionDelta = unit.delta.find(
+          d => d.source?.unit === stack.processing.id && d.source?.effectCode === '次元干渉'
+        );
+
+        // 次元干渉が付与されていなければ付与
+        if (!dimensionDelta) {
+          Effect.keyword(stack, stack.processing, unit, '次元干渉', {
+            source: { unit: stack.processing.id, effectCode: '次元干渉' },
+            cost: 3, // コスト3を指定
+          });
+        }
+      }
+    });
+  },
+
+  // プレイヤーアタック成功時の効果
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 自分がプレイヤーアタックした時のみ処理
+    if (
+      stack.source instanceof Unit &&
+      stack.source.id === stack.processing.id &&
+      stack.target?.id === owner.opponent.id
+    ) {
+      await System.show(stack, '天命の一閃', 'ライフ+1');
+
+      // ライフを+1する（最大値を超えないように）
+      owner.life.current = Math.min(owner.life.current + 1, owner.life.max);
+    }
+  },
+};

--- a/src/database/effects/cards/2-1-014.ts
+++ b/src/database/effects/cards/2-1-014.ts
@@ -59,7 +59,11 @@ export const effects: CardEffects = {
     );
 
     if (targets.length > 0) {
-      await System.show(stack, 'ブルベリフリーズ♪', `レベル${targetLevel}以上のユニットを破壊`);
+      await System.show(
+        stack,
+        '視界良好＆ブルベリフリーズ♪',
+        `手札の青属性のコスト-1\nレベル${targetLevel}以上のユニットを破壊`
+      );
 
       // Select target unit
       const [target] = await EffectHelper.selectUnit(
@@ -71,6 +75,8 @@ export const effects: CardEffects = {
 
       // Destroy it
       Effect.break(stack, stack.processing, target);
+    } else {
+      await System.show(stack, '視界良好', '手札の青属性のコスト-1');
     }
   },
 };

--- a/src/database/effects/cards/2-1-014.ts
+++ b/src/database/effects/cards/2-1-014.ts
@@ -36,10 +36,15 @@ export const effects: CardEffects = {
         } else if (hasNotSummonedUnits) {
           // Add delta if condition is met
           card.delta.push(
-            new Delta({ type: 'cost', value: -1 }, undefined, undefined, undefined, {
-              unit: stack.processing.id,
-              effectCode: '視界良好',
-            })
+            new Delta(
+              { type: 'cost', value: -1 },
+              {
+                source: {
+                  unit: stack.processing.id,
+                  effectCode: '視界良好',
+                },
+              }
+            )
           );
         }
       }

--- a/src/database/effects/cards/2-1-015.ts
+++ b/src/database/effects/cards/2-1-015.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
     const destroyCount = unitsToDestroy.length;
 
     // 条件確認：捨札にカードがあり、フィールドにユニットが2体以上
-    if (owner.trash.length > 0 && owner.field.length >= 2) {
+    if (owner.trash.length > 0 && owner.field.length >= 2 && owner.deck.length > 10) {
       await System.show(
         stack,
         '魂沌遊戯',
@@ -18,13 +18,11 @@ export const effects: CardEffects = {
       );
 
       // デッキが10枚になるようにカードを捨てる
-      if (owner.deck.length > 10) {
-        const discardCount = owner.deck.length - 10;
-        const cardsToDiscard = owner.deck.slice(0, discardCount);
+      const discardCount = owner.deck.length - 10;
+      const cardsToDiscard = owner.deck.slice(0, discardCount);
 
-        for (const card of cardsToDiscard) {
-          Effect.move(stack, stack.processing, card, 'trash');
-        }
+      for (const card of cardsToDiscard) {
+        Effect.move(stack, stack.processing, card, 'trash');
       }
 
       for (const unit of unitsToDestroy) {

--- a/src/database/effects/cards/2-1-107.ts
+++ b/src/database/effects/cards/2-1-107.ts
@@ -1,0 +1,91 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■選告・ラピッドラビット
+  // このユニットがフィールドに出た時、対戦相手は以下の効果から1つを選び発動する。
+  // ①：あなたのユニットからランダムで1体に【加護】と【破壊効果耐性】を与える。
+  // ②：あなたはトリガーカードを2枚引く。
+  // ■サポーター／天使
+  // あなたの【天使】ユニットのBPを+1000する。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    await System.show(
+      stack,
+      '選告・ラピッドラビット',
+      '相手が選択：\n①ユニットに【加護】【破壊効果耐性】\n②トリガーカードを2枚引く\n【天使】のBPを+1000'
+    );
+
+    const [selectedChoice] = await System.prompt(stack, opponent.id, {
+      type: 'option',
+      title: '選告・ラピッドラビット',
+      items: [
+        { id: '1', description: 'ユニットに【加護】と【破壊効果耐性】を与える' },
+        { id: '2', description: 'トリガーカードを2枚引く' },
+      ],
+    });
+
+    // 選択した効果を発動
+    switch (selectedChoice) {
+      case '1':
+        // ①：ユニットからランダムで1体に【加護】と【破壊効果耐性】を与える
+        if (owner.field.length > 0) {
+          const [target] = EffectHelper.random(owner.field, 1);
+          if (target) {
+            // 効果表示
+            await System.show(stack, '選告・ラピッドラビット', '【加護】と【破壊効果耐性】を付与');
+            // 加護と破壊効果耐性を付与
+            Effect.keyword(stack, stack.processing, target, '加護');
+            Effect.keyword(stack, stack.processing, target, '破壊効果耐性');
+          }
+        }
+        break;
+
+      case '2':
+        await System.show(stack, '選告・ラピッドラビット', 'トリガーカードを2枚引く');
+        [...Array(2)].forEach(() =>
+          EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] })
+        );
+        break;
+    }
+
+    await System.show(stack, 'サポーター／天使', '【天使】のBP+1000');
+  },
+
+  // フィールド効果：天使ユニットのBPを+1000する
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // 自分の天使ユニットを対象にする
+    owner.field.forEach(unit => {
+      // 天使ユニットか確認
+      if (unit.catalog.species?.includes('天使')) {
+        // 既にこのユニットが発行したDeltaが存在するか確認
+        const delta = unit.delta.find(
+          d => d.source?.unit === stack.processing.id && d.source?.effectCode === 'サポーター／天使'
+        );
+
+        if (delta && delta.effect.type === 'bp') {
+          // 既存のDeltaを更新
+          delta.effect.diff = 1000;
+        } else {
+          // 新しいDeltaを発行
+          Effect.modifyBP(stack, stack.processing, unit, 1000, {
+            source: { unit: stack.processing.id, effectCode: 'サポーター／天使' },
+          });
+        }
+      } else {
+        // 天使でなくなった場合、このユニットが付与したBP上昇を削除
+        unit.delta = unit.delta.filter(
+          d =>
+            !(d.source?.unit === stack.processing.id && d.source?.effectCode === 'サポーター／天使')
+        );
+      }
+    });
+  },
+};

--- a/src/database/effects/cards/2-1-120.ts
+++ b/src/database/effects/cards/2-1-120.ts
@@ -36,10 +36,15 @@ export const effects: CardEffects = {
 
         if (!existingDelta) {
           card.delta.push(
-            new Delta({ type: 'cost', value: -1 }, undefined, undefined, undefined, {
-              unit: stack.processing.id,
-              effectCode: 'warrior_cost_reduction',
-            })
+            new Delta(
+              { type: 'cost', value: -1 },
+              {
+                source: {
+                  unit: stack.processing.id,
+                  effectCode: 'warrior_cost_reduction',
+                },
+              }
+            )
           );
         }
       }

--- a/src/database/effects/cards/2-1-120.ts
+++ b/src/database/effects/cards/2-1-120.ts
@@ -1,0 +1,95 @@
+import { Effect, System } from '..';
+import { Delta } from '@/package/core/class/delta';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // このカードがフィールドに出た時、フィールド効果の内容を表示
+  async onDriveSelf(stack: StackWithCard<Unit>) {
+    await System.show(
+      stack,
+      '転戦の天ノ河',
+      '手札の【戦士】コスト-1\n【戦士】のBPを+[【戦士】数×500]'
+    );
+  },
+
+  // ■転戦の天ノ河
+  // あなたの手札の【戦士】ユニットのコストを-1する。
+  // あなたの【戦士】ユニットのBPを+[あなたのフィールドにいる【戦士】×500]する。
+  fieldEffect(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+
+    // フィールド上の戦士ユニット数をカウント
+    const warriorCount = owner.field.filter(unit => unit.catalog.species?.includes('戦士')).length;
+
+    // BP増加量
+    const bpBonus = warriorCount * 500;
+
+    // 手札の戦士ユニットのコスト減少処理
+    for (const card of owner.hand) {
+      if (card instanceof Unit && card.catalog.species?.includes('戦士')) {
+        const existingDelta = card.delta.find(
+          delta =>
+            delta.source?.unit === stack.processing.id &&
+            delta.source?.effectCode === 'warrior_cost_reduction'
+        );
+
+        if (!existingDelta) {
+          card.delta.push(
+            new Delta({ type: 'cost', value: -1 }, undefined, undefined, undefined, {
+              unit: stack.processing.id,
+              effectCode: 'warrior_cost_reduction',
+            })
+          );
+        }
+      }
+    }
+
+    // フィールド上の戦士ユニットのBP増加処理
+    for (const unit of owner.field) {
+      if (unit.catalog.species?.includes('戦士')) {
+        const existingDelta = unit.delta.find(
+          delta =>
+            delta.source?.unit === stack.processing.id &&
+            delta.source?.effectCode === 'warrior_bp_boost'
+        );
+
+        if (existingDelta) {
+          // 既存のDeltaを更新 (BP deltaの場合はdiffプロパティを使用)
+          if (existingDelta.effect.type === 'bp') {
+            existingDelta.effect.diff = bpBonus;
+          }
+        } else {
+          // 新しいDeltaを追加
+          Effect.modifyBP(stack, stack.processing, unit, bpBonus, {
+            source: { unit: stack.processing.id, effectCode: 'warrior_bp_boost' },
+          });
+        }
+      }
+    }
+  },
+
+  // ■星華の導き
+  // あなたの【戦士】ユニットがフィールドに出た時、それに【スピードムーブ】を与える。
+  async onDrive(stack: StackWithCard) {
+    // 召喚されたユニットが戦士タイプかつ自分の所有ユニットかチェック
+    if (
+      stack.target instanceof Unit &&
+      stack.target.catalog.species?.includes('戦士') &&
+      stack.target.owner.id === stack.processing.owner.id
+    ) {
+      await System.show(stack, '星華の導き', '【スピードムーブ】を与える');
+      Effect.speedMove(stack, stack.target);
+    }
+  },
+
+  // ■星輝の恩寵
+  // あなたのユニットがプレイヤーアタックに成功した時、それのレベルを+1する。
+  async onPlayerAttack(stack: StackWithCard) {
+    // 自分のユニットがプレイヤーアタックに成功した時のみ発動
+    if (stack.source instanceof Unit && stack.source.owner.id === stack.processing.owner.id) {
+      await System.show(stack, '星輝の恩寵', 'レベル+1');
+      Effect.clock(stack, stack.processing, stack.source, 1);
+    }
+  },
+};

--- a/src/database/effects/cards/2-1-134.ts
+++ b/src/database/effects/cards/2-1-134.ts
@@ -1,0 +1,64 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Evolve, Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■エクストリーム・サモン
+  // あなたの進化ユニット以外のユニットがフィールドに出た時、そのユニットをあなたの捨札、デッキから4体まで【特殊召喚】する。
+  // NOTE: インターセプトカードのチェッカーを実装
+  checkDrive(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+
+    // 自分の進化ユニット以外のユニットが召喚された時に発動
+    return (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id &&
+      !(stack.target instanceof Evolve)
+    );
+  },
+
+  async onDrive(stack: StackWithCard) {
+    const owner = stack.processing.owner;
+
+    // 召喚されたユニット
+    if (!(stack.target instanceof Unit) || stack.target instanceof Evolve) return;
+    const summonedUnit = stack.target;
+
+    // このユニットと同じカードIDを持つカードを捨て札とデッキから探す
+    const sameIdInTrash = owner.trash.filter(
+      card => card instanceof Unit && card.catalog.id === summonedUnit.catalog.id
+    );
+
+    const sameIdInDeck = owner.deck.filter(
+      card => card instanceof Unit && card.catalog.id === summonedUnit.catalog.id
+    );
+
+    // 候補となるカードを合わせる
+    const candidates = [...sameIdInTrash, ...sameIdInDeck];
+
+    if (candidates.length > 0) {
+      // 最大4体まで特殊召喚できる
+      const maxSummons = Math.min(candidates.length, 4);
+      const availableSpace = stack.core.room.rule.player.max.field - owner.field.length;
+      const actualSummons = Math.min(maxSummons, availableSpace);
+
+      if (actualSummons > 0) {
+        await System.show(
+          stack,
+          'エクストリーム・サモン',
+          `同名ユニットを${actualSummons}体【特殊召喚】`
+        );
+
+        // 特殊召喚するユニットを選択
+        const unitsToSummon = EffectHelper.random(candidates, actualSummons);
+
+        // 一体ずつ特殊召喚する
+        for (const unit of unitsToSummon) {
+          if (unit instanceof Unit) {
+            await Effect.summon(stack, stack.processing, unit);
+          }
+        }
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/2-2-004.ts
+++ b/src/database/effects/cards/2-2-004.ts
@@ -33,7 +33,13 @@ export const effects: CardEffects = {
       owner.trigger.length < stack.core.room.rule.player.max.trigger
     ) {
       await System.show(stack, '炎式機工甲冑二式', 'デッキから1枚トリガーゾーンにセット');
-      const [card] = EffectHelper.random(owner.deck, 1);
+      const [card] = await EffectHelper.selectCard(
+        stack,
+        stack.processing.owner,
+        stack.processing.owner.deck,
+        'トリガーゾーンにセットするカードを選んで下さい',
+        1
+      );
       if (card) {
         Effect.move(stack, stack.processing, card, 'trigger');
       }

--- a/src/database/effects/cards/2-2-021.ts
+++ b/src/database/effects/cards/2-2-021.ts
@@ -11,7 +11,7 @@ export const effects: CardEffects = {
 
   // 召喚時に秩序の盾を付与
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, '秩序の盾', '【秩序の盾】を付与');
+    await System.show(stack, '秩序の盾', '対戦相手の効果によるダメージを受けない');
     Effect.keyword(stack, stack.processing, stack.processing, '秩序の盾');
   },
 

--- a/src/database/effects/cards/2-2-105.ts
+++ b/src/database/effects/cards/2-2-105.ts
@@ -1,0 +1,83 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+import { Delta } from '@/package/core/class/delta';
+
+export const effects: CardEffects = {
+  // ■推理とは爆発だァ！
+  // このユニットがフィールドに出た時、あなたの手札のカードとフィールドのユニットのレベルを+1する。
+  async onDriveSelf(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+    const handCards = owner.hand;
+    const fieldUnits = owner.field;
+
+    await System.show(stack, '推理とは爆発だァ！', '手札とフィールドのユニットのレベル+1');
+
+    // 手札のカードのレベルを+1する
+    for (const card of handCards) {
+      if (card instanceof Unit) {
+        card.lv = Math.min(card.lv + 1, 3);
+      }
+    }
+
+    // フィールドのユニットのレベルを+1する
+    for (const unit of fieldUnits) {
+      if (unit.id !== stack.processing.id) {
+        // 自身以外
+        Effect.clock(stack, stack.processing, unit, 1);
+      }
+    }
+  },
+
+  // ■ロジックなど燃え尽きろォ！
+  // あなたのユニットがオーバークロックした時、対戦相手のユニットを1体選ぶ。それに3000ダメージを与える。
+  async onOverclock(stack: StackWithCard) {
+    // 自分のユニットがオーバークロックした時のみ発動
+    if (
+      !stack.target ||
+      !(stack.target instanceof Unit) ||
+      stack.target.owner.id !== stack.processing.owner.id
+    )
+      return;
+
+    const opponent = stack.processing.owner.opponent;
+    const candidates = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === opponent.id,
+      stack.processing.owner
+    );
+
+    if (candidates.length > 0) {
+      await System.show(stack, 'ロジックなど燃え尽きろォ！', '3000ダメージ');
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        candidates,
+        'ダメージを与えるユニットを選んでください'
+      );
+
+      Effect.damage(stack, stack.processing, target, 3000);
+    }
+  },
+
+  // ■真相はお見通しだァ！
+  // このユニットが破壊された時、あなたの手札の赤属性ユニットのコストを-1する。
+  async onBreakSelf(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+
+    await System.show(stack, '真相はお見通しだァ！', '手札の赤属性ユニットのコスト-1');
+
+    // 手札の赤属性ユニットを検索
+    const redUnits = owner.hand.filter(
+      card => card instanceof Unit && card.catalog.color === 1 // 1 = RED color enum value
+    );
+
+    if (redUnits.length > 0) {
+      // 注意: ユニットのIDを指定しないDeltaを生成
+      // これにより、ユニットがフィールドを離れても効果が持続する
+      for (const unit of redUnits) {
+        unit.delta.push(new Delta({ type: 'cost', value: -1 }));
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/2-2-107.ts
+++ b/src/database/effects/cards/2-2-107.ts
@@ -8,8 +8,7 @@ export const effects: CardEffects = {
   isBootable: (core, self: Unit): boolean => {
     const opponentInactiveUnits = self.owner.opponent.field.filter(unit => !unit.active);
 
-    if (opponentInactiveUnits.length > 0) return true;
-    return false;
+    return opponentInactiveUnits.length > 0;
   },
 
   onBootSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
@@ -55,10 +54,7 @@ export const effects: CardEffects = {
           '【複製】する【機械】ユニットを選択'
         );
 
-        // 選択されたカードを複製する (特殊召喚で複製を実現)
-        if (choice instanceof Unit) {
-          await Effect.clone(stack, stack.processing, choice, stack.processing.owner);
-        }
+        await Effect.clone(stack, stack.processing, choice, stack.processing.owner);
       }
     }
   },

--- a/src/database/effects/cards/2-2-109.ts
+++ b/src/database/effects/cards/2-2-109.ts
@@ -1,0 +1,45 @@
+import type { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Delta } from '@/package/core/class/delta';
+import type { Core } from '@/package/core/core';
+
+export const effects: CardEffects = {
+  // 自身が召喚された時に発動する効果を記述
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const targets = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.id && stack.processing.id !== unit.id,
+      stack.processing.owner
+    );
+    if (targets.length > 0) {
+      await System.show(stack, 'マジカル☆スウィート', '手札に戻す\nコスト-1');
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        targets,
+        '手札に戻すユニットを選択してください',
+        1
+      );
+      Effect.bounce(stack, stack.processing, target, 'hand');
+      target.delta.push(new Delta({ type: 'cost', value: -1 }));
+    }
+  },
+
+  isBootable: (core: Core, self: Unit) => {
+    return EffectHelper.candidate(core, () => true, self.owner).length > 0;
+  },
+
+  onBootSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const targets = EffectHelper.candidate(stack.core, () => true, stack.processing.owner);
+    await System.show(stack, '起動・あま～いイチゴケーキ♪', 'ユニットのレベルを-1');
+    const [target] = await EffectHelper.selectUnit(
+      stack,
+      stack.processing.owner,
+      targets,
+      'レベルを下げるユニットを選択して下さい',
+      1
+    );
+    Effect.clock(stack, stack.processing, target, -1);
+  },
+};

--- a/src/database/effects/cards/2-2-109.ts
+++ b/src/database/effects/cards/2-2-109.ts
@@ -22,7 +22,7 @@ export const effects: CardEffects = {
         1
       );
       Effect.bounce(stack, stack.processing, target, 'hand');
-      target.delta.push(new Delta({ type: 'cost', value: -1 }));
+      target.delta.push(new Delta({ type: 'cost', value: -1 }, { permanent: true }));
     }
   },
 

--- a/src/database/effects/cards/2-2-120.ts
+++ b/src/database/effects/cards/2-2-120.ts
@@ -10,9 +10,7 @@ export const effects: CardEffects = {
     const owner = self.owner;
     const opponent = owner.opponent;
     if (owner.hand.includes(self) && opponent.field.length >= 2 && owner.field.length === 0) {
-      self.delta.push(
-        new Delta({ type: 'cost', value: -3 }, undefined, undefined, undefined, { unit: self.id })
-      );
+      self.delta.push(new Delta({ type: 'cost', value: -3 }, { source: { unit: self.id } }));
     } else {
       self.delta = self.delta.filter(delta => delta.source?.unit !== self.id);
     }

--- a/src/database/effects/cards/2-3-004.ts
+++ b/src/database/effects/cards/2-3-004.ts
@@ -57,10 +57,15 @@ export const effects: CardEffects = {
       } else if (costReduction < 0) {
         // 新しいDeltaを追加（コスト減少がある場合のみ）
         self.delta.push(
-          new Delta({ type: 'cost', value: costReduction }, undefined, undefined, undefined, {
-            unit: self.id,
-            effectCode: '忍び寄る羽音',
-          })
+          new Delta(
+            { type: 'cost', value: costReduction },
+            {
+              source: {
+                unit: self.id,
+                effectCode: '忍び寄る羽音',
+              },
+            }
+          )
         );
       }
     }

--- a/src/database/effects/cards/2-3-010.ts
+++ b/src/database/effects/cards/2-3-010.ts
@@ -16,10 +16,9 @@ export const effects: CardEffects = {
             type: 'cost',
             value: Math.max(-self.owner.delete.length, -14),
           },
-          undefined,
-          undefined,
-          undefined,
-          { unit: self.id }
+          {
+            source: { unit: self.id },
+          }
         )
       );
     }

--- a/src/database/effects/cards/2-3-014.ts
+++ b/src/database/effects/cards/2-3-014.ts
@@ -62,11 +62,15 @@ export const effects: CardEffects = {
   onBreakSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     // Find cost 4 or lower samurai units in trash
     const targets = stack.processing.owner.trash.filter(
-      card => card instanceof Unit && card.catalog.species?.includes('侍') && card.catalog.cost <= 4
+      card =>
+        card instanceof Unit &&
+        card.catalog.type === 'unit' &&
+        card.catalog.species?.includes('侍') &&
+        card.catalog.cost <= 4
     );
-    const [target] = EffectHelper.random(targets) as Unit[];
+    const [target] = EffectHelper.random(targets);
 
-    if (target) {
+    if (target instanceof Unit) {
       await System.show(stack, '極中法度', 'コスト4以下の【侍】を【特殊召喚】\n自身を消滅');
       // Special summon it
       await Effect.summon(stack, stack.processing, target);

--- a/src/database/effects/cards/2-3-014.ts
+++ b/src/database/effects/cards/2-3-014.ts
@@ -64,25 +64,13 @@ export const effects: CardEffects = {
     const targets = stack.processing.owner.trash.filter(
       card => card instanceof Unit && card.catalog.species?.includes('侍') && card.catalog.cost <= 4
     );
+    const [target] = EffectHelper.random(targets) as Unit[];
 
-    if (targets.length > 0) {
+    if (target) {
       await System.show(stack, '極中法度', 'コスト4以下の【侍】を【特殊召喚】\n自身を消滅');
-
-      // Select a unit to summon
-      const [target] = await EffectHelper.selectUnit(
-        stack,
-        stack.processing.owner,
-        targets as Unit[],
-        '特殊召喚する【侍】ユニットを選択'
-      );
-
       // Special summon it
-      const summoned = await Effect.summon(stack, stack.processing, target);
-
-      if (summoned) {
-        // Delete this unit
-        Effect.delete(stack, stack.processing, stack.processing);
-      }
+      await Effect.summon(stack, stack.processing, target);
+      Effect.delete(stack, stack.processing, stack.processing);
     }
   },
 };

--- a/src/database/effects/cards/2-3-015.ts
+++ b/src/database/effects/cards/2-3-015.ts
@@ -26,10 +26,7 @@ export const effects: CardEffects = {
               -16
             ),
           },
-          undefined,
-          undefined,
-          undefined,
-          { unit: self.id }
+          { source: { unit: self.id } }
         )
       );
     }

--- a/src/database/effects/cards/2-3-039.ts
+++ b/src/database/effects/cards/2-3-039.ts
@@ -1,0 +1,32 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // カードが発動可能であるかを調べ、発動条件を満たしていれば true を、そうでなければ false を返す。
+  checkTurnStart: (stack: StackWithCard) => {
+    return (
+      stack.processing.owner.id !== stack.core.getTurnPlayer().id &&
+      stack.processing.owner.field.some(unit => unit.catalog.species?.includes('天使'))
+    );
+  },
+
+  onTurnStart: async (stack: StackWithCard): Promise<void> => {
+    await System.show(
+      stack,
+      'エンジェルシンフォニー',
+      `【天使】のBP+${stack.processing.lv > 1 ? '10000' : '5000'}\n【破壊効果耐性】を与える`
+    );
+    stack.processing.owner.field.forEach(unit => {
+      if (unit.catalog.species?.includes('天使')) {
+        Effect.modifyBP(stack, stack.processing, unit, stack.processing.lv > 1 ? 10000 : 5000, {
+          event: 'turnEnd',
+          count: 1,
+        });
+        Effect.keyword(stack, stack.processing, unit, '破壊効果耐性', {
+          event: 'turnEnd',
+          count: 1,
+        });
+      }
+    });
+  },
+};

--- a/src/database/effects/cards/2-3-109.ts
+++ b/src/database/effects/cards/2-3-109.ts
@@ -1,4 +1,4 @@
-import { Effect, EffectHelper, System } from '..';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
 import type { Unit } from '@/package/core/class/card';
 import type { Core } from '@/package/core/core';
@@ -30,14 +30,7 @@ export const effects: CardEffects = {
         '消滅させるカードを選択'
       );
       Effect.move(stack, self, card, 'delete');
-      // トリガーカードを1枚引く
-      const triggers = owner.deck.filter(card => card.catalog.type === 'trigger');
-      if (triggers.length > 0 && owner.trigger.length < stack.core.room.rule.player.max.trigger) {
-        const [triggerCard] = EffectHelper.random(triggers, 1);
-        if (triggerCard) {
-          Effect.move(stack, self, triggerCard, 'trigger');
-        }
-      }
+      EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] });
     }
   },
 };

--- a/src/database/effects/cards/2-3-109.ts
+++ b/src/database/effects/cards/2-3-109.ts
@@ -21,7 +21,7 @@ export const effects: CardEffects = {
     const self = stack.processing;
     const owner = self.owner;
     if (owner.hand.length > 0) {
-      await System.show(stack, '竜の一矢', '手札1枚消滅\nトリガーカード1枚引く');
+      await System.show(stack, '竜の一矢', '手札を1枚消滅\nトリガーカード1枚引く');
       // 手札選択
       const [card] = await EffectHelper.selectCard(
         stack,

--- a/src/database/effects/cards/2-3-112.ts
+++ b/src/database/effects/cards/2-3-112.ts
@@ -1,0 +1,51 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // ■ラブリーシュート
+  // このユニットがフィールドに出た時、あなたは進化ユニットカードを1枚引く。
+  // ■アステルの守護
+  // あなたのフィールドに【天使】ユニットが2体以上いる場合、このユニットに【加護】を与える。
+
+  // フィールドに出た時の効果
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(
+      stack,
+      'ラブリーシュート&アステルの守護',
+      '進化ユニットカードを1枚引く\n【加護】を得る'
+    );
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['advanced_unit'] });
+  },
+
+  // フィールド効果：天使ユニットが2体以上いる場合、加護を付与
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const owner = stack.processing.owner;
+
+    // 天使ユニットの数を取得
+    const angelCount = owner.field.filter(unit => unit.catalog.species?.includes('天使')).length;
+
+    // 加護の付与・削除処理
+    // 既にこのユニットが発行したDeltaが存在するか確認
+    const delta = stack.processing.delta.find(
+      d => d.source?.unit === stack.processing.id && d.source?.effectCode === 'アステルの守護'
+    );
+
+    if (angelCount >= 2) {
+      // 天使が2体以上いて、まだ加護を持っていなければ付与
+      if (!delta) {
+        Effect.keyword(stack, stack.processing, stack.processing, '加護', {
+          source: { unit: stack.processing.id, effectCode: 'アステルの守護' },
+        });
+      }
+    } else {
+      // 天使が2体未満の場合、このユニットが付与した加護を削除
+      if (delta) {
+        stack.processing.delta = stack.processing.delta.filter(
+          d =>
+            !(d.source?.unit === stack.processing.id && d.source?.effectCode === 'アステルの守護')
+        );
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/2-3-113.ts
+++ b/src/database/effects/cards/2-3-113.ts
@@ -18,7 +18,7 @@ export const effects: CardEffects = {
       await System.show(
         stack,
         'びっくりさせちゃえ！',
-        "ユニットを1体消滅'同名カードを手札・捨札・デッキから消滅"
+        'ユニットを1体消滅\n同名カードを手札・捨札・デッキから消滅'
       );
 
       try {

--- a/src/database/effects/cards/2-3-118.ts
+++ b/src/database/effects/cards/2-3-118.ts
@@ -21,10 +21,7 @@ export const effects: CardEffects = {
             type: 'cost',
             value: Math.max(-silencedUnits, -4),
           },
-          undefined,
-          undefined,
-          undefined,
-          { unit: self.id }
+          { source: { unit: self.id } }
         )
       );
     }

--- a/src/database/effects/cards/2-3-121.ts
+++ b/src/database/effects/cards/2-3-121.ts
@@ -73,8 +73,6 @@ export const effects: CardEffects = {
     Effect.bounce(stack, stack.processing, stack.processing, 'hand');
 
     // Reduce cost by 2
-    stack.processing.delta.push(
-      new Delta({ type: 'cost', value: -2 }, undefined, undefined, undefined, undefined, true)
-    );
+    stack.processing.delta.push(new Delta({ type: 'cost', value: -2 }, { permanent: true }));
   },
 };

--- a/src/database/effects/cards/2-3-121.ts
+++ b/src/database/effects/cards/2-3-121.ts
@@ -74,7 +74,7 @@ export const effects: CardEffects = {
 
     // Reduce cost by 2
     stack.processing.delta.push(
-      new Delta({ type: 'cost', value: -2 }, undefined, undefined, undefined)
+      new Delta({ type: 'cost', value: -2 }, undefined, undefined, undefined, undefined, true)
     );
   },
 };

--- a/src/database/effects/cards/2-3-204.ts
+++ b/src/database/effects/cards/2-3-204.ts
@@ -29,10 +29,15 @@ export const effects: CardEffects = {
     } else if (reduction > 0) {
       // 新しいdeltaを追加
       self.delta.push(
-        new Delta({ type: 'cost', value: -reduction }, undefined, undefined, undefined, {
-          unit: self.id,
-          effectCode: '血濡れの妃王',
-        })
+        new Delta(
+          { type: 'cost', value: -reduction },
+          {
+            source: {
+              unit: self.id,
+              effectCode: '血濡れの妃王',
+            },
+          }
+        )
       );
     }
   },

--- a/src/database/effects/cards/2-3-218.ts
+++ b/src/database/effects/cards/2-3-218.ts
@@ -12,9 +12,14 @@ export const effects: CardEffects = {
       targetDelta.effect.value = core.round;
     } else {
       self.delta.push(
-        new Delta({ type: 'cost', value: core.round }, undefined, undefined, undefined, {
-          unit: self.id,
-        })
+        new Delta(
+          { type: 'cost', value: core.round },
+          {
+            source: {
+              unit: self.id,
+            },
+          }
+        )
       );
     }
   },

--- a/src/database/effects/cards/PR-017.ts
+++ b/src/database/effects/cards/PR-017.ts
@@ -1,0 +1,33 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // カードが発動可能であるかを調べ、発動条件を満たしていれば true を、そうでなければ false を返す。
+  checkDrive: (stack: StackWithCard) => {
+    return stack.target instanceof Unit && stack.processing.owner.id === stack.target.owner.id;
+  },
+
+  // 実際の効果本体
+  // 関数名に self は付かない
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '滅亡の未来都市', '【機械】ユニットを1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '機械' });
+  },
+
+  checkTurnStart: (stack: StackWithCard) => {
+    return (
+      stack.core.getTurnPlayer().id === stack.processing.owner.id &&
+      stack.processing.owner.field.filter(unit => unit.catalog.species?.includes('機械')).length >=
+        3
+    );
+  },
+
+  onTurnStart: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '滅亡の未来都市', '【機械】以外の基本BP-4000');
+    stack.core.players
+      .flatMap(player => player.field)
+      .filter(unit => !unit.catalog.species?.includes('機械'))
+      .forEach(unit => Effect.modifyBP(stack, stack.processing, unit, -4000, { isBaseBP: true }));
+  },
+};

--- a/src/database/effects/cards/PR-040.ts
+++ b/src/database/effects/cards/PR-040.ts
@@ -1,0 +1,51 @@
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■盗賊のアジト
+  // あなたのユニットがフィールドに出た時、【盗賊】ユニットのカードを1枚ランダムで手札に加える。
+  // NOTE: トリガーカードのチェッカーを実装
+  checkDrive(stack: StackWithCard): boolean {
+    // 自分のユニットが召喚された時に発動
+    return stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id;
+  },
+
+  async onDrive(stack: StackWithCard) {
+    await System.show(stack, '盗賊のアジト', '【盗賊】のカードを手札に加える');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '盗賊' });
+  },
+
+  // あなたの【盗賊】ユニットがプレイヤーアタックに成功した時、対戦相手は手札を1枚ランダムで捨て、あなたはカードを1枚引く。
+  checkPlayerAttack(stack: StackWithCard): boolean {
+    // プレイヤーアタックに成功したユニットが自分の【盗賊】ユニットか確認
+    return (
+      stack.source instanceof Unit &&
+      stack.source.owner.id === stack.processing.owner.id &&
+      stack.source.catalog.species?.includes('盗賊') === true
+    );
+  },
+
+  async onPlayerAttack(stack: StackWithCard) {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    await System.show(stack, '盗賊のアジト', '手札を1枚捨てる\nカードを1枚引く');
+
+    // 相手の手札が存在する場合、1枚ランダムで捨てる
+    if (opponent.hand.length > 0) {
+      const randomCard = EffectHelper.random(opponent.hand, 1)[0];
+      if (randomCard) {
+        Effect.handes(stack, stack.processing, randomCard);
+      }
+    }
+
+    // 自分はカードを1枚引く
+    if (owner.deck.length > 0 && owner.hand.length < stack.core.room.rule.player.max.hand) {
+      const cardToDraw = owner.deck[0];
+      if (cardToDraw) {
+        Effect.move(stack, stack.processing, cardToDraw, 'hand');
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/PR-042.ts
+++ b/src/database/effects/cards/PR-042.ts
@@ -1,0 +1,23 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■ウェイト・イリュージョン
+  // このユニットがフィールドに出た時、対戦相手のコスト3以上の全てのユニットの行動権を消費する。
+  async onDriveSelf(stack: StackWithCard<Unit>) {
+    const opponent = stack.processing.owner.opponent;
+
+    // 対戦相手のコスト3以上のユニットを取得
+    const highCostUnits = opponent.field.filter(unit => unit.catalog.cost >= 3);
+
+    if (highCostUnits.length > 0) {
+      await System.show(stack, 'ウェイト・イリュージョン', 'コスト3以上のユニットの行動権を消費');
+
+      // 行動権を消費
+      for (const unit of highCostUnits) {
+        Effect.activate(stack, stack.processing, unit, false);
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/PR-076.ts
+++ b/src/database/effects/cards/PR-076.ts
@@ -1,0 +1,14 @@
+import type { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 自身が召喚された時に発動する効果を記述
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '熟練の手さばき', '手札を1枚破壊\nカードを1枚引く');
+    EffectHelper.random(stack.processing.owner.opponent.hand, 1).forEach(card =>
+      Effect.handes(stack, stack.processing, card)
+    );
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/database/effects/cards/PR-078.ts
+++ b/src/database/effects/cards/PR-078.ts
@@ -1,0 +1,42 @@
+import { Color } from '@/submodule/suit/constant/color';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■おおきくなるよ！
+  // あなたの赤属性ユニットがフィールドに出た時、ターン終了時までそれに【スピードムーブ】を与える。
+  // NOTE: インターセプトカードのチェッカー実装
+  checkDrive(stack: StackWithCard): boolean {
+    // 自分の赤属性ユニットが召喚された時に発動
+    return (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.id &&
+      stack.target.catalog.color === Color.RED
+    );
+  },
+
+  async onDrive(stack: StackWithCard) {
+    if (stack.target instanceof Unit) {
+      await System.show(stack, 'おおきくなるよ！', '【スピードムーブ】を付与');
+      Effect.speedMove(stack, stack.target);
+    }
+  },
+
+  // あなたのユニットが戦闘した時、それがアタック中だった場合、ターン終了時までそれのBPを+2000する。
+  // NOTE: アタック中であるかは、stack.target(アタッカー)が自ユニットであるかを検証
+  checkBattle(stack: StackWithCard): boolean {
+    // 自分のユニットがアタック中の戦闘である場合に発動
+    return stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id;
+  },
+
+  async onBattle(stack: StackWithCard) {
+    if (stack.target instanceof Unit) {
+      await System.show(stack, 'おおきくなるよ！', 'BP+2000');
+      Effect.modifyBP(stack, stack.processing, stack.target, 2000, {
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/PR-084.ts
+++ b/src/database/effects/cards/PR-084.ts
@@ -1,0 +1,21 @@
+import type { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  onTurnEnd: async (stack: StackWithCard<Unit>) => {
+    if (stack.core.getTurnPlayer().id !== stack.processing.owner.id) {
+      await System.show(stack, '天使のおかんむり', '自身のレベル+1');
+      Effect.clock(stack, stack.processing, stack.processing, 1);
+    }
+  },
+
+  onClockupSelf: async (stack: StackWithCard<Unit>) => {
+    if (stack.processing.owner.opponent.field.length > 0) {
+      await System.show(stack, '天使のいたずら', 'デッキに戻す');
+      EffectHelper.random(stack.processing.owner.opponent.field).forEach(unit =>
+        Effect.bounce(stack, stack.processing, unit, 'deck')
+      );
+    }
+  },
+};

--- a/src/database/effects/cards/PR-085.ts
+++ b/src/database/effects/cards/PR-085.ts
@@ -69,8 +69,7 @@ export const effects: CardEffects = {
       await System.show(stack, '隻眼の光刃', '捨札から【機械】を【特殊召喚】');
 
       // ランダムで1体選択
-      const selectedUnit = EffectHelper.random(eligibleUnits, 1)[0];
-
+      const [selectedUnit] = EffectHelper.random(eligibleUnits, 1);
       if (selectedUnit instanceof Unit) {
         // 特殊召喚
         await Effect.summon(stack, stack.processing, selectedUnit);

--- a/src/database/effects/cards/PR-092.ts
+++ b/src/database/effects/cards/PR-092.ts
@@ -1,0 +1,43 @@
+import type { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 自身が召喚された時に発動する効果を記述
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'スピードムーブ', '行動制限の影響を受けない');
+    Effect.speedMove(stack, stack.processing);
+  },
+
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const targets = [
+      ...stack.processing.owner.field,
+      ...stack.processing.owner.opponent.field,
+    ].filter(unit => unit.id !== stack.processing.id);
+
+    if (targets.length > 0) {
+      await System.show(stack, '盗賊の極意', '自身以外の行動権を消費');
+      targets.forEach(unit => Effect.activate(stack, stack.processing, unit, false));
+    }
+  },
+
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (stack.processing.lv <= 2) {
+      await System.show(stack, '盗賊の極意', 'レベル+1\nデッキからトリガーカードをセット');
+      Effect.clock(stack, stack.processing, stack.processing, 1);
+      EffectHelper.random(
+        stack.processing.owner.deck.filter(card => card.catalog.type === 'trigger'),
+        1
+      ).forEach(card => Effect.move(stack, stack.processing, card, 'trigger'));
+    }
+  },
+
+  onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (stack.processing.owner.opponent.trigger.length > 0) {
+      await System.show(stack, '盗賊の極意', 'トリガーゾーンをデッキに戻す');
+      stack.processing.owner.opponent.trigger.forEach(card =>
+        Effect.move(stack, stack.processing, card, 'deck')
+      );
+    }
+  },
+};

--- a/src/database/effects/cards/PR-109.ts
+++ b/src/database/effects/cards/PR-109.ts
@@ -51,7 +51,7 @@ export const effects: CardEffects = {
         stack,
         stack.processing.owner,
         targets,
-        '手札に加えるカカードを選択して下さい',
+        '手札に加えるカードを選択して下さい',
         1
       );
 

--- a/src/database/effects/cards/PR-109.ts
+++ b/src/database/effects/cards/PR-109.ts
@@ -1,0 +1,64 @@
+import type { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 自身が召喚された時に発動する効果を記述
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const targets = [
+      ...stack.processing.owner.field,
+      ...stack.processing.owner.opponent.field,
+    ].filter(unit => unit.id !== stack.processing.id);
+    if (targets.length > 0) {
+      await System.show(
+        stack,
+        '天意の執行',
+        '【加護】\n【沈黙効果耐性】\n自身以外の行動権を消費\n【呪縛】を与える'
+      );
+      targets.forEach(unit => {
+        Effect.keyword(stack, stack.processing, unit, '呪縛');
+        Effect.activate(stack, stack.processing, unit, false);
+      });
+    } else {
+      await System.show(
+        stack,
+        '加護＆沈黙効果耐性',
+        '効果に選ばれない\n対戦相手の効果によって【沈黙】を付与されない'
+      );
+    }
+
+    Effect.keyword(stack, stack.processing, stack.processing, '加護');
+    Effect.keyword(stack, stack.processing, stack.processing, '沈黙効果耐性');
+  },
+
+  onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const targets = stack.processing.owner.opponent.field.filter(unit => !unit.active);
+    if (targets.length > 0) {
+      await System.show(stack, '天意の執行', '行動済みの敵全体を消滅');
+      targets.forEach(unit => Effect.delete(stack, stack.processing, unit));
+    }
+  },
+
+  onTurnEnd: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (
+      stack.processing.owner.id === stack.core.getTurnPlayer().id &&
+      stack.processing.owner.hand.length <= 6 &&
+      stack.processing.owner.deck.length >= 5
+    ) {
+      await System.show(stack, '天意の選定', 'デッキから5枚見る\n1枚選び手札に加える\n残りは消滅');
+      const targets = EffectHelper.random(stack.processing.owner.deck, 5);
+      const [draw] = await EffectHelper.selectCard(
+        stack,
+        stack.processing.owner,
+        targets,
+        '手札に加えるカカードを選択して下さい',
+        1
+      );
+
+      Effect.move(stack, stack.processing, draw, 'hand');
+      targets.forEach(card => {
+        if (card.id !== draw.id) Effect.move(stack, stack.processing, card, 'delete');
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/PR-116.ts
+++ b/src/database/effects/cards/PR-116.ts
@@ -33,9 +33,14 @@ export const effects: CardEffects = {
       delta.effect.value = reduce;
     } else {
       self.delta.push(
-        new Delta({ type: 'cost', value: reduce }, undefined, undefined, undefined, {
-          unit: self.id,
-        })
+        new Delta(
+          { type: 'cost', value: reduce },
+          {
+            source: {
+              unit: self.id,
+            },
+          }
+        )
       );
     }
   },

--- a/src/database/effects/cards/PR-135.ts
+++ b/src/database/effects/cards/PR-135.ts
@@ -1,0 +1,36 @@
+import { Unit } from '@/package/core/class/card';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { System } from '../classes/system';
+import { Effect } from '../classes/effect';
+
+export const effects: CardEffects = {
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    // プレイヤーのフィールド上の昆虫ユニット数を数える
+    const insectCount = stack.processing.owner.field.filter(unit =>
+      unit.catalog.species?.includes('機械')
+    ).length;
+
+    const bpBoost = insectCount * 1000;
+
+    stack.processing.owner.field
+      .filter(unit => unit.catalog.species?.includes('機械'))
+      .forEach(unit => {
+        // 既にこのユニットが発行したDeltaが存在するか確認
+        const delta = unit.delta.find(d => d.source?.unit === stack.processing.id);
+
+        if (delta && delta.effect.type === 'bp') {
+          // Deltaを編集する
+          delta.effect.diff = bpBoost;
+        } else {
+          // 新しいDeltaを追加
+          Effect.modifyBP(stack, stack.processing, unit, bpBoost, {
+            source: { unit: stack.processing.id },
+          });
+        }
+      });
+  },
+
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(stack, 'サポーター／機械', 'BP+[【機械】×1000]');
+  },
+};

--- a/src/database/effects/cards/PR-135.ts
+++ b/src/database/effects/cards/PR-135.ts
@@ -5,7 +5,7 @@ import { Effect } from '../classes/effect';
 
 export const effects: CardEffects = {
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    // プレイヤーのフィールド上の昆虫ユニット数を数える
+    // プレイヤーのフィールド上の機械ユニット数を数える
     const insectCount = stack.processing.owner.field.filter(unit =>
       unit.catalog.species?.includes('機械')
     ).length;

--- a/src/database/effects/cards/PR-187.ts
+++ b/src/database/effects/cards/PR-187.ts
@@ -1,0 +1,3 @@
+import { effects } from './1-1-011';
+
+export { effects };

--- a/src/database/effects/cards/PR-191.ts
+++ b/src/database/effects/cards/PR-191.ts
@@ -1,0 +1,5 @@
+import { effects } from './2-0-204';
+
+// Re-export the effects module from 2-0-204.ts
+// NOTE: PR-191.tsは2-0-204.tsの実装を再利用
+export { effects };

--- a/src/database/effects/cards/PR-193.ts
+++ b/src/database/effects/cards/PR-193.ts
@@ -1,0 +1,3 @@
+import { effects } from './1-4-315';
+
+export { effects };

--- a/src/database/effects/cards/PR-202.ts
+++ b/src/database/effects/cards/PR-202.ts
@@ -1,0 +1,54 @@
+import type { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 自身が召喚された時に発動する効果を記述
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (
+      stack.processing.owner.opponent.hand.length > 0 &&
+      stack.processing.owner.hand.length < stack.core.room.rule.player.max.hand
+    ) {
+      await System.show(stack, 'イリシットレジャー', '対戦相手の手札を1枚作成');
+      EffectHelper.random(stack.processing.owner.opponent.hand, 1).forEach(card => {
+        const target = card.clone(stack.processing.owner);
+        stack.processing.owner.hand.push(target);
+      });
+    }
+  },
+
+  onPlayerAttackSelf: async (stack: StackWithCard): Promise<void> => {
+    const targets = stack.processing.owner.opponent.hand.filter(
+      card => card.catalog.type === 'unit'
+    ) as Unit[];
+    if (targets.length > 0) {
+      await System.show(stack, 'ギルティー・ロスト', '手札から【特殊召喚】\n【沈黙】を与える');
+      await Promise.all(
+        EffectHelper.random(targets, 1).map(async unit => {
+          await Effect.summon(stack, stack.processing, unit);
+          Effect.keyword(stack, stack.processing, unit, '沈黙');
+        })
+      );
+    }
+  },
+
+  onTurnEnd: async (stack: StackWithCard): Promise<void> => {
+    const targets = stack.processing.owner.opponent.field.filter(unit => unit.hasKeyword('沈黙'));
+    if (
+      stack.processing.owner.id === stack.core.getTurnPlayer().id &&
+      targets.length > 0 &&
+      stack.processing.owner.field.length <= 4
+    ) {
+      await System.show(stack, 'ギルティー・ロスト', '【沈黙】を持つユニットを【複製】し破壊');
+      const [target] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        targets,
+        '【複製】して破壊するユニットを選択',
+        1
+      );
+      await Effect.clone(stack, stack.processing, target, stack.processing.owner);
+      Effect.break(stack, stack.processing, target, 'effect');
+    }
+  },
+};

--- a/src/database/effects/cards/PR-205.ts
+++ b/src/database/effects/cards/PR-205.ts
@@ -1,0 +1,86 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // カードが発動可能であるかを調べ、発動条件を満たしていれば true を、そうでなければ false を返す。
+  checkDrive: (stack: StackWithCard) => {
+    const oppCandidate = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id !== stack.processing.owner.id,
+      stack.processing.owner
+    );
+    const ownCandidate = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.id,
+      stack.processing.owner
+    );
+
+    const isChoice1Avail = stack.processing.owner.cp.current >= 1 && oppCandidate.length > 0;
+    const isChoice2Avail = ownCandidate.length > 0;
+
+    return (
+      stack.target instanceof Unit &&
+      stack.processing.owner.id === stack.target.owner.id &&
+      (isChoice1Avail || isChoice2Avail)
+    );
+  },
+
+  // 実際の効果本体
+  // 関数名に self は付かない
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    const oppCandidate = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id !== stack.processing.owner.id,
+      stack.processing.owner
+    );
+    const ownCandidate = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.id,
+      stack.processing.owner
+    );
+
+    const isChoice1Avail = stack.processing.owner.cp.current >= 1 && oppCandidate.length > 0;
+    const isChoice2Avail = ownCandidate.length > 0;
+
+    let choice: string | undefined = undefined;
+    if (isChoice1Avail && isChoice2Avail) {
+      [choice] = await System.prompt(stack, stack.processing.owner.id, {
+        title: '選略・モノクローム',
+        type: 'option',
+        items: [
+          { id: '1', description: 'CP-1\n手札に戻す' },
+          { id: '2', description: '【沈黙効果耐性】を与える' },
+        ],
+      });
+    } else {
+      if (isChoice1Avail) choice = '1';
+      if (isChoice2Avail) choice = '2';
+    }
+
+    switch (choice) {
+      case '1': {
+        const [target] = await EffectHelper.selectUnit(
+          stack,
+          stack.processing.owner,
+          oppCandidate,
+          '手札に戻すユニットを選択して下さい'
+        );
+        Effect.modifyCP(stack, stack.processing, stack.processing.owner, -1);
+        Effect.bounce(stack, stack.processing, target, 'hand');
+        break;
+      }
+
+      case '2': {
+        const [target] = await EffectHelper.selectUnit(
+          stack,
+          stack.processing.owner,
+          ownCandidate,
+          '【沈黙効果耐性】を与えるユニットを選択して下さい'
+        );
+        Effect.keyword(stack, stack.processing, target, '沈黙効果耐性');
+        break;
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/PR-209.ts
+++ b/src/database/effects/cards/PR-209.ts
@@ -7,7 +7,7 @@ export const effects: CardEffects = {
   // このユニットがフィールドに出た時、このユニットのレベルを+1する。
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     await System.show(stack, '豪傑王の野心', 'レベル+1');
-    Effect.clock(stack, stack.processing, stack.processing, 1, true);
+    Effect.clock(stack, stack.processing, stack.processing, 1, false);
   },
 
   // ■ウルクの暴君

--- a/src/database/effects/cards/PR-211.ts
+++ b/src/database/effects/cards/PR-211.ts
@@ -1,0 +1,36 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■ネオ・サンダーボルト
+  // あなたのユニットがフィールドに出た時、対戦相手の全ての行動済ユニットを消滅させる。
+  // NOTE: インターセプトカードのチェッカーを実装
+  checkDrive(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+
+    // 自分のユニットが召喚された時 かつ 相手の行動済みユニットがいる場合に発動
+    return (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id &&
+      owner.opponent.field.some(unit => !unit.active)
+    );
+  },
+
+  async onDrive(stack: StackWithCard) {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 対戦相手の行動済みユニットをすべて取得
+    const inactiveUnits = opponent.field.filter(unit => !unit.active);
+
+    if (inactiveUnits.length > 0) {
+      await System.show(stack, 'ネオ・サンダーボルト', '行動済ユニットを消滅');
+
+      // すべての行動済ユニットを消滅
+      for (const unit of inactiveUnits) {
+        Effect.delete(stack, stack.processing, unit);
+      }
+    }
+  },
+};

--- a/src/database/effects/cards/PR-215.ts
+++ b/src/database/effects/cards/PR-215.ts
@@ -1,0 +1,49 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // ■神への反逆
+  // あなたのターン開始時、対戦相手のトリガーゾーンのカードをランダムで1枚破壊する。
+  // NOTE: インターセプトカードのチェッカーを実装
+  checkTurnStart(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+    const turnPlayer = stack.core.getTurnPlayer();
+
+    // 自分のターン開始時かつ相手のトリガーゾーンにカードがある場合に発動
+    return owner.id === turnPlayer.id && owner.opponent.trigger.length > 0;
+  },
+
+  async onTurnStart(stack: StackWithCard<Unit>) {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 相手のトリガーゾーンにカードがあるか確認
+    if (opponent.trigger.length > 0) {
+      await System.show(stack, '神への反逆', 'トリガーカードを破壊');
+
+      // ランダムで1枚選んで破壊
+      const targetCard = EffectHelper.random(opponent.trigger, 1)[0];
+      if (targetCard) {
+        Effect.move(stack, stack.processing, targetCard, 'trash');
+      }
+    }
+  },
+
+  // 対戦相手の【神】ユニットがフィールドに出た時、それを破壊する。
+  checkDrive(stack: StackWithCard): boolean {
+    // 相手の【神】ユニットが召喚された時に発動
+    return (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.opponent.id &&
+      stack.target.catalog.species?.includes('神') === true
+    );
+  },
+
+  async onDrive(stack: StackWithCard) {
+    if (stack.target instanceof Unit) {
+      await System.show(stack, '神への反逆', '【神】ユニットを破壊');
+      Effect.break(stack, stack.processing, stack.target);
+    }
+  },
+};

--- a/src/database/effects/cards/PR-216.ts
+++ b/src/database/effects/cards/PR-216.ts
@@ -1,0 +1,46 @@
+import master from '@/database/catalog';
+import { EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+import { Evolve, Unit } from '@/package/core/class/card';
+import { Trigger } from '@/package/core/class/card/Trigger';
+import { Intercept } from '@/package/core/class/card/Intercept';
+
+export const effects: CardEffects = {
+  // カードが発動可能であるかを調べ、発動条件を満たしていれば true を、そうでなければ false を返す。
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  checkDrive: (stack: StackWithCard) => {
+    return true;
+  },
+
+  // 実際の効果本体
+  // 関数名に self は付かない
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, 'ぶくなぎ綾花', `ランダムなカードを${stack.processing.lv}枚作成`);
+    [
+      ...Array(
+        Math.min(
+          stack.processing.lv,
+          stack.core.room.rule.player.max.hand - stack.processing.owner.hand.length
+        )
+      ),
+    ].forEach(() => {
+      const [catalog] = EffectHelper.random(Array.from(master.values()));
+      if (catalog) {
+        switch (catalog.type) {
+          case 'unit':
+            stack.processing.owner.hand.push(new Unit(stack.processing.owner, catalog.id));
+            break;
+          case 'advanced_unit':
+            stack.processing.owner.hand.push(new Evolve(stack.processing.owner, catalog.id));
+            break;
+          case 'intercept':
+            stack.processing.owner.hand.push(new Intercept(stack.processing.owner, catalog.id));
+            break;
+          case 'trigger':
+            stack.processing.owner.hand.push(new Trigger(stack.processing.owner, catalog.id));
+            break;
+        }
+      }
+    });
+  },
+};

--- a/src/database/effects/cards/PR-216.ts
+++ b/src/database/effects/cards/PR-216.ts
@@ -1,9 +1,8 @@
+/*
 import master from '@/database/catalog';
 import { EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
-import { Evolve, Unit } from '@/package/core/class/card';
-import { Trigger } from '@/package/core/class/card/Trigger';
-import { Intercept } from '@/package/core/class/card/Intercept';
+import { Evolve, Unit, Trigger, Intercept } from '@/package/core/class/card';
 
 export const effects: CardEffects = {
   // カードが発動可能であるかを調べ、発動条件を満たしていれば true を、そうでなければ false を返す。
@@ -44,3 +43,4 @@ export const effects: CardEffects = {
     });
   },
 };
+*/

--- a/src/database/effects/cards/SP-007.ts
+++ b/src/database/effects/cards/SP-007.ts
@@ -1,0 +1,3 @@
+import { effects } from './1-1-011';
+
+export { effects };

--- a/src/database/effects/cards/SP-026.ts
+++ b/src/database/effects/cards/SP-026.ts
@@ -1,0 +1,1 @@
+export { effects } from './1-1-028.ts';

--- a/src/database/effects/cards/SP-056.ts
+++ b/src/database/effects/cards/SP-056.ts
@@ -1,0 +1,3 @@
+import { effects } from './1-0-108';
+
+export { effects };

--- a/src/database/effects/cards/SP-061.ts
+++ b/src/database/effects/cards/SP-061.ts
@@ -1,0 +1,5 @@
+import { effects } from './1-1-058';
+
+// Re-export the effects module from 1-1-058.ts
+// NOTE: SP-061.tsは1-1-058.tsの実装を再利用
+export { effects };

--- a/src/database/effects/cards/_guide.md
+++ b/src/database/effects/cards/_guide.md
@@ -12,14 +12,15 @@
 
 イベント名の代表的なものを挙げる。
 
-| 識別子    | 内容                           | 例          |
-| --------- | ------------------------------ | ----------- |
-| drive     | 召喚された                     | onDrive     |
-| break     | 破壊された                     | onBreak     |
-| bounce    | 手札に戻す効果が発動した       | onBounce    |
-| damage    | ダメージを与える効果が発動した | onDamage    |
-| turnStart | ターン開始                     | onTurnStart |
-| overclock | オーバークロックした           | onOverclock |
+| 識別子       | 内容                           | 例             |
+| ------------ | ------------------------------ | -------------- |
+| drive        | 召喚された                     | onDrive        |
+| break        | 破壊された                     | onBreak        |
+| bounce       | 手札に戻す効果が発動した       | onBounce       |
+| damage       | ダメージを与える効果が発動した | onDamage       |
+| turnStart    | ターン開始                     | onTurnStart    |
+| overclock    | オーバークロックした           | onOverclock    |
+| playerAttack | プレイヤーアタックに成功した   | onPlayerAttack |
 
 関数名には、以下の Suffix が有効。
 
@@ -41,6 +42,15 @@
 ### カードの型
 
 `src/submodule/suit/types/game/card/index.ts`を参照。実装は`src/package/core/class/card/*.ts`を参照。
+
+### 共通ガイドライン
+
+- 発動タイミングについて言及されていないキーワード効果(【】で括られた能力)がテキストにある時、それは召喚時に付与されることを示している。onDriveSelfの処理に追加すること。
+- カードの移動は Effect.move を、BPの操作は Effect.modifyBP を使い、各オブジェクトの値を直接操作してはならない。
+- 「ブロックされない」効果は、 Effect.keyword() で '次元干渉' を付与し、そのコストに0を指定する。
+- ユニットを選ぶ効果は `EffectHelper.selectUnit()` を利用するが、この引数に渡す選択肢は予め `EffectHelper.candidate()` で選択可能であるかを検証しておかなければならない。
+- カードを選ぶ効果は `EffectHelper.selectCard()`を利用する。 selectUnit() と selectCard() の違いは、その選択対象がフィールドいるかいないかである。フィールド上のユニットを選ぶ場合は前者を、そうでない場合は後者を利用せよ。
+- エラーハンドリングはフレームワーク側が実施するので、例外を投げる可能性のある関数を呼び出す場合でも try-catch は必ずしも必要ではない。
 
 ### 通常関数
 

--- a/src/database/effects/cards/_intercept-template.ts
+++ b/src/database/effects/cards/_intercept-template.ts
@@ -1,17 +1,27 @@
-import { System } from '..';
+import { EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
 
 export const effects: CardEffects = {
   // カードが発動可能であるかを調べ、発動条件を満たしていれば true を、そうでなければ false を返す。
-  checkDrive: (stack: StackWithCard) => {
-    // Example usage of stack to prevent unused variable warning
-    console.log(`Checking drive effect for card: ${stack.processing.catalogId}`);
-    return true;
+  // (たとえどのような条件でも発動するカードであったとしても) onXXX に対応する check関数が必ず必要。
+
+  // 対戦相手のCPが効果によって増加した時、あなたは[増加したCP×1]枚カードを引く
+  checkModifyCP: (stack: StackWithCard) => {
+    return (
+      stack.target?.id === stack.processing.owner.opponent.id &&
+      stack.option?.type === 'cp' &&
+      stack.option.value > 0
+    );
   },
 
   // 実際の効果本体
   // 関数名に self は付かない
-  onDrive: async (stack: StackWithCard): Promise<void> => {
-    await System.show(stack, '効果名', '');
+  onModifyCP: async (stack: StackWithCard): Promise<void> => {
+    const count = stack.option?.type === 'cp' ? stack.option.value : 0;
+
+    if (count > 0) {
+      await System.show(stack, '効果I', '[増加したCP×1]枚カードを引く');
+      [...Array(count)].forEach(() => EffectTemplate.draw(stack.processing.owner, stack.core));
+    }
   },
 };

--- a/src/database/effects/cards/_unit-template.ts
+++ b/src/database/effects/cards/_unit-template.ts
@@ -1,18 +1,120 @@
 import type { Unit } from '@/package/core/class/card';
-import { System } from '..';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../classes/types';
+import type { Core } from '@/package/core/core';
+
+// 共通処理は別関数に切り出すとよい。
+const subEffect = async (stack: StackWithCard<Unit>) => {
+  await System.show(stack, '効果II', 'インターセプトカードとトリガーカードを1枚ずつ引く');
+  EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['intercept'] });
+  EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] });
+};
 
 export const effects: CardEffects = {
-  // 自身が召喚された時に発動する効果を記述
+  // 【秩序の盾】(発動タイミングが明記されていないキーワード効果は、召喚時に付与される)
+  // フィールド効果を持つ場合は、それが発動するとどういう効果を発揮するかも表示する
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, '効果名', '');
+    await System.show(
+      stack,
+      '効果III＆秩序の盾',
+      'BP+3000\n【不滅】を得る\n対戦相手の効果によってダメージを受けない'
+    );
+    Effect.keyword(stack, stack.processing, stack.processing, '秩序の盾');
   },
 
-  // 自身以外が召喚された時に発動する効果を記述
-  // 味方ユニットであるかの判定などを忘れない
-  onDrive: async (stack: StackWithCard): Promise<void> => {
-    // Now we can safely access stack.processing without a check
-    // because StackWithCard guarantees it exists
-    await System.show(stack, '効果名', '');
+  // このユニットが破壊または消滅した時、あなたはトリガーカードとインターセプトカードを1枚ずつ引く
+  onBreakSelf: subEffect,
+  onDeleteSelf: subEffect,
+
+  // あなたのターン終了時、それが偶数ラウンドの場合、お互いのユニットを1体ずつ選ぶ。それらを破壊する。
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const oppTargets = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.opponent.id,
+      stack.processing.owner
+    );
+    const ownTargets = EffectHelper.candidate(
+      stack.core,
+      unit => unit.owner.id === stack.processing.owner.id,
+      stack.processing.owner
+    );
+
+    if (
+      stack.processing.owner.id === stack.core.getTurnPlayer().id && // 自分のターン
+      stack.core.round % 2 === 0 && // 偶数ラウンド
+      oppTargets.length > 0 && // 相手のユニットを1体以上選択可能
+      ownTargets.length > 0 // 自分のユニットを1体以上選択可能
+    ) {
+      await System.show(stack, '効果I', 'お互いのユニットを破壊');
+      const [ownTarget] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        ownTargets,
+        '破壊するユニットを選択して下さい',
+        1
+      );
+      const [oppTarget] = await EffectHelper.selectUnit(
+        stack,
+        stack.processing.owner,
+        oppTargets,
+        '破壊するユニットを選択して下さい',
+        1
+      );
+
+      Effect.break(stack, stack.processing, ownTarget, 'effect');
+      Effect.break(stack, stack.processing, oppTarget, 'effect');
+    }
+  },
+
+  // あなたのライフが1以下の場合、このユニットに【不滅】を与え、BPを+3000する。
+  fieldEffect: (stack: StackWithCard<Unit>) => {
+    // NOTE: 必要な処理は以下
+    // - ライフが1以下で効果を発動していない場合、発動する。
+    // - ライフが1より大で効果を発動している場合、削除する。
+    const immDelta = stack.processing.delta.find(
+      delta => delta.source?.unit === stack.processing.id && delta.source.effectCode === '不滅'
+    );
+    const bpDelta = stack.processing.delta.find(
+      delta => delta.source?.unit === stack.processing.id && delta.source.effectCode === 'BP'
+    );
+
+    if (stack.processing.owner.life.current <= 1) {
+      // keyword/modifyBPの `{source: {unit: ...}}` は、どのユニットから受けた効果であるかを示し、フィールド効果の場合に用いる。
+      // 他のユニットに対して指定しておくと、指定元のユニットがフィールドを離れた際に自動的に削除処理が実行される。
+      if (!immDelta)
+        Effect.keyword(stack, stack.processing, stack.processing, '不滅', {
+          source: { unit: stack.processing.id, effectCode: '不滅' },
+        });
+      if (!bpDelta)
+        Effect.modifyBP(stack, stack.processing, stack.processing, +3000, {
+          source: { unit: stack.processing.id, effectCode: 'BP' },
+        });
+    } else {
+      // 自分の効果で付与されたDeltaをフィルタする
+      if (immDelta || bpDelta)
+        stack.processing.delta = stack.processing.delta.filter(
+          delta => delta.source?.unit !== stack.processing.id
+        );
+    }
+  },
+
+  // あなたのトリガーゾーンにあるカードを1枚ランダムで破壊する。そうした場合、デッキから1枚選び、トリガーゾーンにセットする。
+  isBootable: (core: Core, self: Unit) => {
+    return self.owner.trigger.length > 0 && self.owner.deck.length > 0;
+  },
+
+  onBootSelf: async (stack: StackWithCard) => {
+    await System.show(stack, '起動・効果IV', 'トリガーゾーンを1枚破壊\nデッキから1枚選びセット');
+    const [target] = await EffectHelper.selectCard(
+      stack,
+      stack.processing.owner,
+      stack.processing.owner.deck,
+      'トリガーゾーンにセットするカードを選択して下さい',
+      1
+    );
+    EffectHelper.random(stack.processing.owner.trigger).forEach(card =>
+      Effect.move(stack, stack.processing, card, 'trash')
+    );
+    Effect.move(stack, stack.processing, target, 'trigger');
   },
 };

--- a/src/database/effects/classes/effect.ts
+++ b/src/database/effects/classes/effect.ts
@@ -589,11 +589,7 @@ export class Effect {
       );
 
       // 行動制限を付与
-      Effect.keyword(stack, target, target, '行動制限', {
-        event: 'turnStart',
-        count: 1,
-        onlyForOwnersTurn: true,
-      });
+      Effect.keyword(stack, target, target, '行動制限');
 
       // 起動アイコン
       if (typeof target.catalog.onBootSelf === 'function')

--- a/src/database/effects/classes/effect.ts
+++ b/src/database/effects/classes/effect.ts
@@ -82,7 +82,7 @@ export class Effect {
       return false;
     }
 
-    target.delta.push(new Delta({ type: 'damage', value: damage }, 'turnEnd', 1));
+    target.delta.push(new Delta({ type: 'damage', value: damage }, { event: 'turnEnd', count: 1 }));
     stack.addChildStack('damage', source, target, {
       type: 'damage',
       cause: type,
@@ -122,11 +122,11 @@ export class Effect {
     if ('isBaseBP' in option) {
       target.bp += value;
     } else if ('source' in option) {
-      target.delta.push(
-        new Delta({ type: 'bp', diff: value }, undefined, undefined, undefined, option.source)
-      );
+      target.delta.push(new Delta({ type: 'bp', diff: value }, { source: option.source }));
     } else {
-      target.delta.push(new Delta({ type: 'bp', diff: value }, option.event, option.count));
+      target.delta.push(
+        new Delta({ type: 'bp', diff: value }, { event: option.event, count: option.count })
+      );
     }
 
     stack.core.room.soundEffect(value >= 0 ? 'grow' : 'damage');
@@ -486,20 +486,8 @@ export class Effect {
 
     const delta =
       keyword === '次元干渉'
-        ? new Delta(
-            { type: 'keyword', name: keyword, cost: option?.cost ?? 0 },
-            option?.event,
-            option?.count,
-            option?.onlyForOwnersTurn,
-            option?.source
-          )
-        : new Delta(
-            { type: 'keyword', name: keyword },
-            option?.event,
-            option?.count,
-            option?.onlyForOwnersTurn,
-            option?.source
-          );
+        ? new Delta({ type: 'keyword', name: keyword, cost: option?.cost ?? 0 }, { ...option })
+        : new Delta({ type: 'keyword', name: keyword }, { ...option });
     target.delta.push(delta);
 
     switch (keyword) {
@@ -670,7 +658,9 @@ export class Effect {
     if (deathCounter && count < deathCounter.count) {
       deathCounter.count = count;
     } else {
-      target.delta.push(new Delta({ type: 'death' }, 'turnEnd', count, true));
+      target.delta.push(
+        new Delta({ type: 'death' }, { event: 'turnEnd', count, onlyForOwnersTurn: true })
+      );
     }
   }
 }

--- a/src/database/effects/classes/effect.ts
+++ b/src/database/effects/classes/effect.ts
@@ -140,7 +140,8 @@ export class Effect {
   }
 
   /**
-   * 対象を破壊する
+   * ユニットを破壊する
+   * ! フィールド上のユニット以外を破壊する場合はこのメソッドではなく Effect.handes() や Effect.move() で捨札に送る操作を実行します。
    * @param source 効果の発動元
    * @param target 破壊の対象
    * @param cause その破壊の原因 (カードテキストの実装にあたっては基本的にeffect以外使用してはいけない)
@@ -178,6 +179,7 @@ export class Effect {
 
   /**
    * 対象を消滅させる
+   * ! フィールド上のユニット以外を消滅させる場合はこのメソッドではなく Effect.move() で消滅札に送る操作を実行します。
    * @param source 効果の発動元
    * @param target 消滅の対象
    */

--- a/src/database/effects/classes/helper.ts
+++ b/src/database/effects/classes/helper.ts
@@ -19,6 +19,12 @@ export class EffectHelper {
     units.forEach(effect);
   }
 
+  /**
+   * 【セレクトハック】や【加護】を持つユニットを考慮して、プレイヤー向けにユニットの選択肢を生成する
+   * @param filter 独自のフィルタ関数
+   * @param selector 選択肢を提供するプレイヤー
+   * @returns 選択可能なユニット
+   */
   static candidate(core: Core, filter: (unit: Unit) => boolean, selector: Player): Unit[] {
     const exceptBlessing = (unit: Unit) => !unit.hasKeyword('加護');
     const units = core.players

--- a/src/database/effects/classes/templates.ts
+++ b/src/database/effects/classes/templates.ts
@@ -65,10 +65,10 @@ export class EffectTemplate {
    * @param match サーチする条件
    * @returns void
    */
-  static reinforcements(stack: Stack, player: Player, match: ReinforcementMatcher): void {
+  static reinforcements(stack: Stack, player: Player, match: ReinforcementMatcher): boolean {
     // 召喚者の手札が上限に達している場合は何もしない
     if (player.hand === undefined || player.hand.length >= stack.core.room.rule.player.max.hand)
-      return;
+      return false;
 
     // 召喚者のデッキから条件に合致するカードを探す
     const target = player.deck.find(c => {
@@ -85,9 +85,10 @@ export class EffectTemplate {
     // targetを引き抜き、手札に加える
     if (target && stack.processing) {
       Effect.move(stack, stack.processing, target, 'hand');
+      return true;
     }
 
-    return;
+    return false;
   }
 
   static async reincarnate(stack: Stack, unit: Unit) {

--- a/src/database/effects/classes/templates.ts
+++ b/src/database/effects/classes/templates.ts
@@ -131,7 +131,9 @@ export class EffectTemplate {
       // ウィルスを生成して特殊召喚
       const virusUnit = new Unit(player, virus);
       await Effect.summon(stack, stack.processing, virusUnit);
-      virusUnit.delta.push(new Delta({ type: 'life' }, 'turnEnd', 2, true));
+      virusUnit.delta.push(
+        new Delta({ type: 'life' }, { event: 'turnEnd', count: 2, onlyForOwnersTurn: true })
+      );
       Effect.keyword(stack, virusUnit, virusUnit, '攻撃禁止');
       Effect.keyword(stack, virusUnit, virusUnit, '防御禁止');
     }

--- a/src/package/core/class/card/Card.ts
+++ b/src/package/core/class/card/Card.ts
@@ -8,6 +8,7 @@ export abstract class Card extends Atom implements ICard {
   catalogId: string;
   lv: number = 1;
   delta: Delta[];
+  generation: number = 1;
 
   constructor(owner: Player, catalogId: string) {
     super(owner);
@@ -25,6 +26,7 @@ export abstract class Card extends Atom implements ICard {
   reset() {
     this.delta = this.delta.filter(delta => delta.permanent);
     this.lv = 1;
+    this.generation++;
   }
 
   abstract clone(owner: Player): Card;

--- a/src/package/core/class/card/Card.ts
+++ b/src/package/core/class/card/Card.ts
@@ -23,7 +23,7 @@ export abstract class Card extends Atom implements ICard {
   }
 
   reset() {
-    this.delta = [];
+    this.delta = this.delta.filter(delta => delta.permanent);
     this.lv = 1;
   }
 

--- a/src/package/core/class/delta.ts
+++ b/src/package/core/class/delta.ts
@@ -5,6 +5,15 @@ export interface DeltaSource {
   unit: IUnit['id'];
   effectCode?: string; // 1つのユニットが異なる条件で複数のフィールド効果を持つ場合、それを識別するためのID
 }
+
+interface DeltaConstructorOptionParams {
+  event?: string;
+  count?: number;
+  onlyForOwnersTurn?: boolean;
+  source?: DeltaSource;
+  permanent?: boolean;
+}
+
 export class Delta implements IDelta {
   id: string;
   count: number;
@@ -14,21 +23,14 @@ export class Delta implements IDelta {
   onlyForOwnersTurn: boolean; // このパラメータが true のとき、eventに合致するイベントが発生しても自分のターン中でない場合はcountを減算しない
   permanent: boolean; // このパラメータが true のとき、unit.reset() しても残す (効果が永続するという意味ではない。その場合はeventにundefiendを設定する。)
 
-  constructor(
-    effect: DeltaEffect,
-    event: string | undefined = undefined,
-    count: number = 0,
-    onlyForOwnersTurn = false,
-    source: DeltaSource | undefined = undefined,
-    permanent: boolean = false
-  ) {
+  constructor(effect: DeltaEffect, options: DeltaConstructorOptionParams | undefined = {}) {
     this.id = crypto.randomUUID();
     this.effect = effect;
-    this.event = event;
-    this.count = count;
-    this.onlyForOwnersTurn = onlyForOwnersTurn;
-    this.source = source;
-    this.permanent = permanent;
+    this.event = options.event;
+    this.count = options.count ?? 0;
+    this.onlyForOwnersTurn = options.onlyForOwnersTurn ?? false;
+    this.source = options.source;
+    this.permanent = options.permanent ?? false;
   }
 
   /**

--- a/src/package/core/class/delta.ts
+++ b/src/package/core/class/delta.ts
@@ -12,13 +12,15 @@ export class Delta implements IDelta {
   effect: DeltaEffect;
   source?: DeltaSource;
   onlyForOwnersTurn: boolean; // このパラメータが true のとき、eventに合致するイベントが発生しても自分のターン中でない場合はcountを減算しない
+  permanent: boolean; // このパラメータが true のとき、unit.reset() しても残す (効果が永続するという意味ではない。その場合はeventにundefiendを設定する。)
 
   constructor(
     effect: DeltaEffect,
     event: string | undefined = undefined,
     count: number = 0,
     onlyForOwnersTurn = false,
-    source: DeltaSource | undefined = undefined
+    source: DeltaSource | undefined = undefined,
+    permanent: boolean = false
   ) {
     this.id = crypto.randomUUID();
     this.effect = effect;
@@ -26,6 +28,7 @@ export class Delta implements IDelta {
     this.count = count;
     this.onlyForOwnersTurn = onlyForOwnersTurn;
     this.source = source;
+    this.permanent = permanent;
   }
 
   /**

--- a/src/package/core/class/stack.ts
+++ b/src/package/core/class/stack.ts
@@ -98,15 +98,20 @@ export class Stack implements IStack {
       nonTurnPlayer: [...(nonTurnPlayer?.field ?? [])],
     };
 
-    if (this.type === 'overclock' && this.target instanceof Unit) {
-      this.target.overclocked = true;
-      this.target.active = true;
-      this.target.delta = this.target.delta.filter(
-        delta => !(delta.effect.type === 'keyword' && delta.effect.name === '行動制限')
-      );
-      core.room.soundEffect('clock-up-field');
-      core.room.soundEffect('reboot');
-      core.room.sync();
+    if (this.type === 'overclock') {
+      if (this.target instanceof Unit && this.target.lv === 3) {
+        this.target.overclocked = true;
+        this.target.active = true;
+        this.target.delta = this.target.delta.filter(
+          delta => !(delta.effect.type === 'keyword' && delta.effect.name === '行動制限')
+        );
+        core.room.soundEffect('clock-up-field');
+        core.room.soundEffect('reboot');
+        core.room.sync();
+      } else {
+        // NOTE: Effect.clock()で onClockup効果解決後に対象のユニットがフィールドを去った or レベルが下がる場合がある
+        return;
+      }
     }
 
     // まず イベントに起因するカードの効果を処理

--- a/src/package/core/core.ts
+++ b/src/package/core/core.ts
@@ -665,7 +665,12 @@ export class Core {
     } else {
       card.active = true;
       player.field.push(card);
-      card.delta = [new Delta({ type: 'keyword', name: '行動制限' }, 'turnStart', 1, true)];
+      card.delta = [
+        new Delta(
+          { type: 'keyword', name: '行動制限' },
+          { event: 'turnStart', count: 1, onlyForOwnersTurn: true }
+        ),
+      ];
     }
 
     card.initBP();

--- a/src/package/core/core.ts
+++ b/src/package/core/core.ts
@@ -245,6 +245,14 @@ export class Core {
       });
     }
 
+    // 行動制限を解除する
+    this.getTurnPlayer().field.forEach(
+      unit =>
+        (unit.delta = unit.delta.filter(
+          delta => !(delta.effect.type === 'keyword' && delta.effect.name === '行動制限')
+        ))
+    );
+
     // ターン開始スタックを積み、解決する
     this.histories = [];
     this.stack = [
@@ -666,12 +674,7 @@ export class Core {
     } else {
       card.active = true;
       player.field.push(card);
-      card.delta = [
-        new Delta(
-          { type: 'keyword', name: '行動制限' },
-          { event: 'turnStart', count: 1, onlyForOwnersTurn: true }
-        ),
-      ];
+      card.delta = [new Delta({ type: 'keyword', name: '行動制限' })];
     }
 
     card.initBP();

--- a/src/package/core/core.ts
+++ b/src/package/core/core.ts
@@ -30,6 +30,7 @@ type EffectResponseCallback = Function;
 
 interface History {
   card: Card;
+  generation: number;
   action: 'drive' | 'boot';
 }
 
@@ -688,7 +689,9 @@ export class Core {
     this.histories.push({
       card: card,
       action: 'drive',
+      generation: card.generation,
     });
+
     this.stack = [
       new Stack({
         type: 'drive',
@@ -951,12 +954,16 @@ export class Core {
         if (
           target.catalog.isBootable(this, target) &&
           !this.histories.some(
-            history => history.action === 'boot' && history.card.id === target.id
+            history =>
+              history.action === 'boot' &&
+              history.card.id === target.id &&
+              history.generation === target.generation
           )
         ) {
           this.histories.push({
             card: target,
             action: 'boot',
+            generation: target.generation,
           });
           this.room.soundEffect('recover');
           await new Promise(resolve => setTimeout(resolve, 900));

--- a/src/package/core/core.ts
+++ b/src/package/core/core.ts
@@ -656,6 +656,7 @@ export class Core {
       card.active = source.active;
       player.field[index] = card;
       this.fieldEffectUnmount(source);
+      card.delta = [];
 
       if (!source.isCopy) {
         player.trash.push(source);
@@ -969,6 +970,7 @@ export class Core {
         if (target && target.card && player && isOnHand) {
           player.hand = player.hand.filter(c => c.id !== target.card?.id);
           player.trash.push(target.card);
+          target.card.reset();
           this.room.sync();
           this.room.soundEffect('trash');
         }

--- a/src/package/server/apiRouter.ts
+++ b/src/package/server/apiRouter.ts
@@ -38,7 +38,7 @@ async function getCardsHandler(req: Request): Promise<Response> {
   const cardIds = files
     .filter(f => f.endsWith('.ts'))
     .map(f => f.replace(/\.ts$/, ''))
-    .filter(id => /^[0-9]+-[0-9]+-[0-9]+$/.test(id));
+    .filter(id => /^[0-9]+-[0-9]+-[0-9]+$/.test(id) || /(PR|SP)-[0-9]{3}/.test(id));
   return new Response(JSON.stringify(cardIds), {
     status: 200,
     headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 多数の新しいカード効果を追加しました。これには、特定条件下でのバトルポイント（BP）増加、キーワード付与（例：「加護」「不屈」「スピードムーブ」など）、ユニットの特殊召喚、手札・トリガーゾーン・デッキ・墓地間のカード移動、カードの破壊や消滅、CP（コマンドポイント）増加、ライフ回復などが含まれます。
  - プレイヤーや対戦相手の行動・ターン・攻撃・オーバークロックなどに応じて多彩な効果が発動します。
  - 条件付きでの効果適用や選択肢の提示、複数の効果が組み合わさったカードも追加されています。

- **改善**
  - 一部効果の説明文や表示メッセージを分かりやすく調整しました。
  - 効果の発動条件や適用範囲を明確化し、ユーザーインターフェースの一貫性を向上させました。

- **リファクタ**
  - 効果の内部処理やデータ管理方法を整理し、今後の拡張や保守性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->