### PR TITLE
20260111 カード追加

### DIFF
--- a/src/database/effects/cards/1-0-001.ts
+++ b/src/database/effects/cards/1-0-001.ts
@@ -1,0 +1,27 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  //■ダメージブレイク
+  //このユニットがオーバークロックした時、対戦相手のユニットを1体選ぶ。それに4000ダメージを与える。
+
+  onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    if (!EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)) {
+      return;
+    }
+
+    await System.show(stack, 'ダメージブレイク', '対戦相手のユニットに4000ダメージ');
+
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'opponents',
+      'ダメージを与えるユニットを選択'
+    );
+
+    Effect.damage(stack, stack.processing, target, 4000);
+  },
+};

--- a/src/database/effects/cards/1-0-006.ts
+++ b/src/database/effects/cards/1-0-006.ts
@@ -1,0 +1,13 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  //【スピードムーブ】
+  //（このユニットはフィールドに出たターンの行動制限の影響を受けない）
+
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'スピードムーブ', '行動制限の影響を受けない');
+    Effect.speedMove(stack, stack.processing);
+  },
+};

--- a/src/database/effects/cards/1-0-012.ts
+++ b/src/database/effects/cards/1-0-012.ts
@@ -1,0 +1,43 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  //■デーモンスピア
+  //このユニットがフィールドに出た時、対戦相手のユニットを1体選ぶ。それに4000ダメージを与える。
+  //■トリガーロスト
+  //このユニットがアタックした時、対戦相手のトリガーゾーンにあるカードを1枚ランダムで破壊する。
+
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    if (!EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)) {
+      return;
+    }
+
+    await System.show(stack, 'デーモンスピア', '対戦相手のユニットに4000ダメージ');
+
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'opponents',
+      'ダメージを与えるユニットを選択'
+    );
+
+    Effect.damage(stack, stack.processing, target, 4000);
+  },
+
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    //対戦相手のトリガーゾーンにカードがあるか確認
+    if (opponent.trigger.length === 0) return;
+
+    await System.show(stack, 'トリガーロスト', 'トリガーゾーンのカードを破壊');
+
+    // ランダムで1枚選択して破壊
+    EffectHelper.random(opponent.trigger, 1).forEach(card =>
+      Effect.move(stack, stack.processing, card, 'trash')
+    );
+  },
+};

--- a/src/database/effects/cards/1-0-013.ts
+++ b/src/database/effects/cards/1-0-013.ts
@@ -1,0 +1,40 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  //■憤怒の炎
+  //このユニットがフィールドに出た時、対戦相手のユニット全体に3000ダメージを与える。
+  //■ダメージブレイク
+  //このユニットがプレイヤーアタックに成功した時、対戦相手のユニットを1体選ぶ。それに7000ダメージを与える
+
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const opponent = stack.processing.owner.opponent;
+
+    await System.show(stack, '憤怒の炎', '対戦相手のユニット全体に3000ダメージ');
+
+    //対戦相手のユニット全体に3000ダメージを与える
+    for (const unit of opponent.field) {
+      Effect.damage(stack, stack.processing, unit, 3000);
+    }
+  },
+
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    if (!EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)) {
+      return;
+    }
+
+    await System.show(stack, 'ダメージブレイク', '対戦相手のユニットに7000ダメージ');
+
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'opponents',
+      'ダメージを与えるユニットを選択'
+    );
+
+    Effect.damage(stack, stack.processing, target, 7000);
+  },
+};

--- a/src/database/effects/cards/1-0-077.ts
+++ b/src/database/effects/cards/1-0-077.ts
@@ -1,0 +1,29 @@
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  //■アーマーブレイク
+  //あなたのユニットがフィールドに出た時、対戦相手のユニットを1体選ぶ。それに3000ダメージを与える。
+
+  checkDrive: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+    const selectCheck = EffectHelper.isUnitSelectable(stack.core, 'opponents', owner);
+
+    const ownerCheck = stack.source.id === owner.id;
+
+    return selectCheck && ownerCheck;
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, 'アーマーブレイク', '対戦相手のユニットに3000ダメージ');
+
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'opponents',
+      'ダメージを与えるユニットを選択'
+    );
+
+    Effect.damage(stack, stack.processing, target, 3000);
+  },
+};

--- a/src/database/effects/cards/SP-055.ts
+++ b/src/database/effects/cards/SP-055.ts
@@ -1,0 +1,1 @@
+export { effects } from './1-0-012';


### PR DESCRIPTION
以下のカードを追加します。

1-0-001 ブラッドハウンド
1-0-006 拷問官アーテー
1-0-012 魔槍のリリム
1-0-013 蛮王ベリアル
1-0-077 アーマーブレイク
SP-055  魔槍のリリム

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数の新しいカードエフェクトを追加しました。敵ユニットへのダメージ効果、移動制限の免除、トリガーゾーンのカード破壊など、戦闘をより戦略的にする新しい能力が利用可能になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->