### PR TITLE
不具合修正 1-4-232.ts

### DIFF
--- a/src/database/effects/cards/1-4-232.ts
+++ b/src/database/effects/cards/1-4-232.ts
@@ -9,6 +9,28 @@ export const effects: CardEffects = {
     Effect.keyword(stack, stack.processing, stack.processing as Unit, '固着');
   },
 
+  fieldEffect: (stack: StackWithCard<Unit>) => {
+    // 封神太極陣
+    const owner = stack.processing.owner;
+
+    owner.field.forEach(unit => {
+      // 既にこのユニットが発行したDeltaが存在するか確認
+      const delta = unit.delta.find(
+        d => d.source?.unit === stack.processing.id && d.source?.effectCode === '封神太極陣'
+      );
+
+      if (!delta) {
+        // 新しいDeltaを発行
+        Effect.modifyBP(stack, stack.processing, unit, 1000, {
+          source: {
+            unit: stack.processing.id,
+            effectCode: '封神太極陣',
+          },
+        });
+      }
+    });
+  },
+
   onOverclockSelf: async (stack: StackWithCard): Promise<void> => {
     await System.show(stack, '討神義牙', '【貫通】を得る');
     Effect.keyword(stack, stack.processing, stack.processing as Unit, '貫通');


### PR DESCRIPTION
1-4-232 開闢王伏羲
・味方ユニットのBP+1000の効果が実装されていなかったのを修正。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カード「封神太極陣」のフィールドエフェクトを追加しました。フィールド上の味方ユニットに対して、条件を満たす場合に戦闘力を1000増加させるエフェクトが発動するようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->