### PR TITLE
不具合修正 1-3-027.ts

### DIFF
--- a/src/database/effects/cards/1-3-027.ts
+++ b/src/database/effects/cards/1-3-027.ts
@@ -57,14 +57,12 @@ export const effects: CardEffects = {
       '破壊するユニットを選択して下さい'
     );
 
-    const [opponentTarget] = hasOpponent
-      ? await EffectHelper.pickUnit(
-          stack,
-          stack.processing.owner,
-          opponentFilter,
-          '破壊するユニットを選択して下さい'
-        )
-      : [];
+    const [opponentTarget] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      opponentFilter,
+      '破壊するユニットを選択して下さい'
+    );
 
     if (opponentTarget) Effect.break(stack, stack.processing, opponentTarget, 'effect');
     if (undeadTarget) Effect.break(stack, stack.processing, undeadTarget, 'effect');


### PR DESCRIPTION
1-3-027 大魔導士リーナ
破壊対象が居ない場合でもアタック時の効果が発動する不具合を修正。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* カード「1-3-027」の攻撃効果の発動条件を修正しました。効果がより正確に判定されるようになります。
* ゲーム画面に表示されるメッセージを更新し、効果の状態をより適切に表示するようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->