### PR TITLE
fix: サンドボックスルームをServerに登録して接続可能にする

### DIFF
--- a/src/package/server/apiRouter.ts
+++ b/src/package/server/apiRouter.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { isSandboxEnabled, getSandboxConfig, SandboxRoom } from '@/sandbox';
 import type { SyncPayload } from '@/submodule/suit/types/message/payload/client';
+import { Server } from './index';
 
 type Handler = (req: Request, params: Record<string, string>) => Promise<Response> | Response;
 
@@ -119,8 +120,10 @@ function createSandboxRoomHandler(_req: Request): Response {
     );
   }
 
-  const config = getSandboxConfig();
   sandboxRoom = new SandboxRoom('Sandbox Room');
+
+  // Register the sandbox room in the server's rooms map
+  Server.registerRoom(sandboxRoom);
 
   console.log(`[Sandbox] Room created with ID: ${sandboxRoom.id}`);
 
@@ -138,10 +141,10 @@ function createSandboxRoomHandler(_req: Request): Response {
  */
 async function loadSandboxStateHandler(req: Request): Promise<Response> {
   if (!isSandboxEnabled()) {
-    return new Response(
-      JSON.stringify({ error: 'Sandbox mode is disabled' }),
-      { status: 403, headers: CORS_HEADERS }
-    );
+    return new Response(JSON.stringify({ error: 'Sandbox mode is disabled' }), {
+      status: 403,
+      headers: CORS_HEADERS,
+    });
   }
 
   if (sandboxRoom === null) {
@@ -190,17 +193,17 @@ async function loadSandboxStateHandler(req: Request): Promise<Response> {
  */
 function startSandboxGameHandler(_req: Request): Response {
   if (!isSandboxEnabled()) {
-    return new Response(
-      JSON.stringify({ error: 'Sandbox mode is disabled' }),
-      { status: 403, headers: CORS_HEADERS }
-    );
+    return new Response(JSON.stringify({ error: 'Sandbox mode is disabled' }), {
+      status: 403,
+      headers: CORS_HEADERS,
+    });
   }
 
   if (sandboxRoom === null) {
-    return new Response(
-      JSON.stringify({ error: 'Sandbox room does not exist' }),
-      { status: 404, headers: CORS_HEADERS }
-    );
+    return new Response(JSON.stringify({ error: 'Sandbox room does not exist' }), {
+      status: 404,
+      headers: CORS_HEADERS,
+    });
   }
 
   sandboxRoom.startSandbox();
@@ -220,20 +223,24 @@ function startSandboxGameHandler(_req: Request): Response {
  */
 function destroySandboxRoomHandler(_req: Request): Response {
   if (!isSandboxEnabled()) {
-    return new Response(
-      JSON.stringify({ error: 'Sandbox mode is disabled' }),
-      { status: 403, headers: CORS_HEADERS }
-    );
+    return new Response(JSON.stringify({ error: 'Sandbox mode is disabled' }), {
+      status: 403,
+      headers: CORS_HEADERS,
+    });
   }
 
   if (sandboxRoom === null) {
-    return new Response(
-      JSON.stringify({ error: 'Sandbox room does not exist' }),
-      { status: 404, headers: CORS_HEADERS }
-    );
+    return new Response(JSON.stringify({ error: 'Sandbox room does not exist' }), {
+      status: 404,
+      headers: CORS_HEADERS,
+    });
   }
 
   const roomId = sandboxRoom.id;
+
+  // Unregister the sandbox room from the server's rooms map
+  Server.unregisterRoom(roomId);
+
   sandboxRoom = null;
 
   console.log(`[Sandbox] Room ${roomId} destroyed`);

--- a/src/package/server/index.ts
+++ b/src/package/server/index.ts
@@ -23,11 +23,15 @@ class ServerError extends Error {
 }
 
 export class Server {
+  /** Static instance reference for sandbox API access */
+  private static instance: Server | null = null;
+
   private rooms: Map<string, Room> = new Map(); // roomId <-> Room
   private clientRooms: Map<ServerWebSocket, string> = new Map();
   private clients: Map<ServerWebSocket, User> = new Map();
 
   constructor(port?: number) {
+    Server.instance = this;
     const serverPort = port || process.env.PORT;
     console.log(`PORT: ${serverPort}`);
 
@@ -315,5 +319,33 @@ export class Server {
       }
       case 'list':
     }
+  }
+
+  /**
+   * Register a room in the server's rooms map (for sandbox)
+   */
+  static registerRoom(room: Room): boolean {
+    if (!Server.instance) {
+      console.error('[Server] No server instance available');
+      return false;
+    }
+    Server.instance.rooms.set(room.id, room);
+    console.log(`[Server] Room ${room.id} registered`);
+    return true;
+  }
+
+  /**
+   * Unregister a room from the server's rooms map (for sandbox)
+   */
+  static unregisterRoom(roomId: string): boolean {
+    if (!Server.instance) {
+      console.error('[Server] No server instance available');
+      return false;
+    }
+    const deleted = Server.instance.rooms.delete(roomId);
+    if (deleted) {
+      console.log(`[Server] Room ${roomId} unregistered`);
+    }
+    return deleted;
   }
 }


### PR DESCRIPTION
- SandboxRoomをServer.rooms mapに登録/解除する機能を追加
- SandboxRoom.joinをオーバーライドしてloadStateで設定済みのプレイヤーに対応
- StateLoaderでプレイヤーが存在しない場合に新規作成するよう修正
- 不要なclients.delete呼び出しを削除
- 新規プレイヤー参加時にclients/core/playersすべてに登録するよう修正