### PR TITLE
新規カード追加

### DIFF
--- a/src/database/effects/cards/1-0-062.ts
+++ b/src/database/effects/cards/1-0-062.ts
@@ -1,0 +1,16 @@
+import type { Card } from '@/package/core/class/card';
+import { Unit } from '@/package/core/class/card';
+import { EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがフィールドに出た時、あなたはカードを1枚引く。
+  checkDrive: (stack: StackWithCard<Card>): boolean => {
+    return stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id;
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '何でも屋の陳列台', 'カードを1枚引く');
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/database/effects/cards/1-0-102.ts
+++ b/src/database/effects/cards/1-0-102.ts
@@ -1,0 +1,21 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 【スピードムーブ】
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'スピードムーブ', '行動制限の影響を受けない');
+    Effect.speedMove(stack, stack.processing);
+  },
+
+  // このユニットがアタックした時、ターン終了時までこのユニットのBPを+2000する。
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'アタッカー', 'BP+2000');
+
+    Effect.modifyBP(stack, stack.processing, stack.processing, 2000, {
+      event: 'turnEnd',
+      count: 1,
+    });
+  },
+};

--- a/src/database/effects/cards/1-1-031.ts
+++ b/src/database/effects/cards/1-1-031.ts
@@ -1,0 +1,50 @@
+import type { Card } from '@/package/core/class/card';
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがフィールドに出た時、あなたのユニットと対戦相手のユニットをそれぞれ1体ずつ選ぶ。
+  // それらに5000ダメージを与える。
+  checkDrive: (stack: StackWithCard<Card>): boolean => {
+    // あなたのユニットがフィールドに出た時
+    const isOwnUnit =
+      stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id;
+
+    // 自分と相手にユニットが存在するか確認
+    const hasOwnUnits = EffectHelper.isUnitSelectable(stack.core, 'owns', stack.processing.owner);
+    const hasOpponentUnits = EffectHelper.isUnitSelectable(
+      stack.core,
+      'opponents',
+      stack.processing.owner
+    );
+
+    return isOwnUnit && hasOwnUnits && hasOpponentUnits;
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    await System.show(stack, 'ブロウ・アップ', '味方に5000ダメージ\n敵に5000ダメージ');
+
+    // 自分のユニットを選択
+    const [ownTarget] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'owns',
+      '5000ダメージを与える自分のユニットを選択'
+    );
+
+    // 対戦相手のユニットを選択
+    const [opponentTarget] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'opponents',
+      '5000ダメージを与える相手のユニットを選択'
+    );
+
+    // 選んだユニットにダメージを与える
+    Effect.damage(stack, stack.processing, ownTarget, 5000);
+    Effect.damage(stack, stack.processing, opponentTarget, 5000);
+  },
+};

--- a/src/database/effects/cards/1-1-032.ts
+++ b/src/database/effects/cards/1-1-032.ts
@@ -1,0 +1,29 @@
+import type { Card } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットが戦闘した時、ターン終了時まであなたの全ての【悪魔】ユニットのBPを+3000する。
+  checkBattle: (stack: StackWithCard<Card>): boolean => {
+    const owner = stack.processing.owner;
+
+    // 自分のフィールドに【悪魔】ユニットが存在するか
+    return owner.field.some(unit => unit.catalog.species?.includes('悪魔'));
+  },
+
+  onBattle: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    await System.show(stack, '威圧', '【悪魔】のBP+3000');
+
+    // 自分のフィールドの全ての【悪魔】ユニットにBP+3000を付与
+    owner.field
+      .filter(unit => unit.catalog.species?.includes('悪魔'))
+      .forEach(unit =>
+        Effect.modifyBP(stack, stack.processing, unit, 3000, {
+          event: 'turnEnd',
+          count: 1,
+        })
+      );
+  },
+};

--- a/src/database/effects/cards/1-1-072.ts
+++ b/src/database/effects/cards/1-1-072.ts
@@ -1,0 +1,33 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // このユニットのBPは+［あなたのライフ×1000］される。
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, '正統なる血統', 'BP+[ライフ×1000]');
+  },
+
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    const self = stack.processing;
+    const owner = self.owner;
+
+    // 現在のライフに基づくBP増加量
+    const bpIncrease = owner.life.current * 1000;
+
+    // 既にこのユニットが発行したDeltaが存在するか確認
+    const delta = self.delta.find(
+      delta => delta.source?.unit === self.id && delta.source?.effectCode === '正統なる血統'
+    );
+
+    if (delta && delta.effect.type === 'bp') {
+      // 既存のDeltaを更新
+      delta.effect.diff = bpIncrease;
+    } else {
+      // 新しいDeltaを発行
+      Effect.modifyBP(stack, self, self, bpIncrease, {
+        source: { unit: self.id, effectCode: '正統なる血統' },
+      });
+    }
+  },
+};

--- a/src/database/effects/cards/1-1-091.ts
+++ b/src/database/effects/cards/1-1-091.ts
@@ -1,0 +1,43 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットが戦闘した時、ターン終了時までそれのBPを+1000し、戦闘終了時まで【貫通】を与える。
+  checkBattle: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+
+    // 戦闘中の自ユニットを特定
+    const ownUnit = [stack.source, stack.target].find(
+      (object): object is Unit => object instanceof Unit && object.owner.id === owner.id
+    );
+
+    // ユニットが存在し、フィールドにまだいる場合のみ発動
+    return !!ownUnit && owner.field.some(unit => unit.id === ownUnit.id);
+  },
+
+  onBattle: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 戦闘中の自ユニットを特定
+    const [battleUnit] = [stack.source, stack.target].filter(
+      (object): object is Unit => object instanceof Unit && object.owner.id === owner.id
+    );
+
+    if (!battleUnit) return;
+
+    await System.show(stack, '正拳突き', 'BP+1000\n【貫通】を得る');
+
+    // BP+1000（ターン終了時まで）
+    Effect.modifyBP(stack, stack.processing, battleUnit, 1000, {
+      event: 'turnEnd',
+      count: 1,
+    });
+
+    // 【貫通】を付与（戦闘終了時まで）
+    Effect.keyword(stack, stack.processing, battleUnit, '貫通', {
+      event: '_postBattle',
+      count: 1,
+    });
+  },
+};

--- a/src/database/effects/cards/1-2-014.ts
+++ b/src/database/effects/cards/1-2-014.ts
@@ -1,0 +1,78 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // このユニットがフィールドに出た時、対戦相手のトリガーゾーンにあるカードを2枚ランダムで破壊する。
+  // 対戦相手のトリガーゾーンにカードがない場合、あなたのデッキからランダムで1枚トリガーゾーンにインターセプトカードをセットする。
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    if (opponent.trigger.length > 0) {
+      // 対戦相手のトリガーゾーンにカードがある場合、2枚ランダムで破壊
+      await System.show(stack, '堕天使の鎮魂歌', 'トリガーゾーンのカードを2枚破壊');
+
+      const cardsToDestroy = EffectHelper.random(
+        opponent.trigger,
+        Math.min(2, opponent.trigger.length)
+      );
+      cardsToDestroy.forEach(card => Effect.move(stack, stack.processing, card, 'trash'));
+    } else {
+      // 対戦相手のトリガーゾーンにカードがない場合、デッキからインターセプトカードをセット
+      const interceptCards = owner.deck.filter(card => card.catalog.type === 'intercept');
+
+      if (
+        interceptCards.length > 0 &&
+        owner.trigger.length < stack.core.room.rule.player.max.trigger
+      ) {
+        await System.show(stack, '堕天使の鎮魂歌', 'インターセプトカードをトリガーゾーンにセット');
+
+        const [cardToSet] = EffectHelper.random(interceptCards, 1);
+        if (cardToSet) {
+          Effect.move(stack, stack.processing, cardToSet, 'trigger');
+        }
+      }
+    }
+  },
+
+  // このユニットがアタックした時、対戦相手の全てのレベル2以上のユニットに6000ダメージを与える。
+  // あなたのレベル2以上のユニットに【スピードムーブ】を与える。
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 対戦相手のレベル2以上のユニット
+    const opponentTargets = opponent.field.filter(unit => unit.lv >= 2);
+
+    // 自分のレベル2以上のユニット
+    const ownTargets = owner.field.filter(unit => unit.lv >= 2);
+
+    // 両方のターゲットがいない場合は何もしない
+    if (opponentTargets.length === 0 && ownTargets.length === 0) {
+      return;
+    }
+
+    // メッセージを条件に応じて構築
+    let message = '';
+    if (opponentTargets.length > 0 && ownTargets.length > 0) {
+      message = '敵のレベル2以上に6000ダメージ\n味方のレベル2以上に【スピードムーブ】を付与';
+    } else if (opponentTargets.length > 0) {
+      message = '敵のレベル2以上に6000ダメージ';
+    } else {
+      message = '味方のレベル2以上に【スピードムーブ】を付与';
+    }
+
+    await System.show(stack, '堕天使の鎮魂歌', message);
+
+    // 対戦相手のレベル2以上のユニットに6000ダメージ
+    if (opponentTargets.length > 0) {
+      opponentTargets.forEach(unit => Effect.damage(stack, stack.processing, unit, 6000));
+    }
+
+    // 自分のレベル2以上のユニットに【スピードムーブ】
+    if (ownTargets.length > 0) {
+      ownTargets.forEach(unit => Effect.speedMove(stack, unit));
+    }
+  },
+};

--- a/src/database/effects/cards/1-2-081.ts
+++ b/src/database/effects/cards/1-2-081.ts
@@ -1,0 +1,32 @@
+import type { Card } from '@/package/core/class/card';
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがフィールドに出た時、全てのレベル1以下のユニットに5000ダメージを与える。
+  checkDrive: (stack: StackWithCard<Card>): boolean => {
+    if (!(stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id)) {
+      return false;
+    }
+
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // レベル1以下のユニットが存在するかチェック
+    const hasTargets = [...owner.field, ...opponent.field].some(unit => unit.lv <= 1);
+
+    return hasTargets;
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 両プレイヤーのレベル1以下のユニット
+    const allTargets = [...owner.field, ...opponent.field].filter(unit => unit.lv <= 1);
+
+    await System.show(stack, 'チェインフレイム', 'レベル1以下に5000ダメージ');
+    allTargets.forEach(unit => Effect.damage(stack, stack.processing, unit, 5000));
+  },
+};

--- a/src/database/effects/cards/1-3-005.ts
+++ b/src/database/effects/cards/1-3-005.ts
@@ -1,0 +1,47 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 対戦相手のトリガーゾーンにカードがない場合、以下の効果が発動する。
+  // このユニットがフィールドに出た時、対戦相手の全てのユニットに2000ダメージを与える。
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 対戦相手のトリガーゾーンにカードがない場合のみ発動
+    if (opponent.trigger.length > 0) {
+      return;
+    }
+
+    const targets = opponent.field;
+
+    if (targets.length === 0) {
+      return;
+    }
+
+    await System.show(stack, 'ガトリングスマッシャー', '敵全体に2000ダメージ');
+    targets.forEach(unit => Effect.damage(stack, stack.processing, unit, 2000));
+  },
+
+  // 対戦相手のトリガーゾーンにカードがない場合、以下の効果が発動する。
+  // このユニットがアタックした時、対戦相手の全てのユニットに3000ダメージを与える。
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 対戦相手のトリガーゾーンにカードがない場合のみ発動
+    if (opponent.trigger.length > 0) {
+      return;
+    }
+
+    const targets = opponent.field;
+
+    if (targets.length === 0) {
+      return;
+    }
+
+    await System.show(stack, 'ガトリングスマッシャー', '敵全体に3000ダメージ');
+    targets.forEach(unit => Effect.damage(stack, stack.processing, unit, 3000));
+  },
+};

--- a/src/database/effects/cards/1-3-006.ts
+++ b/src/database/effects/cards/1-3-006.ts
@@ -1,0 +1,53 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+  // 対戦相手のトリガーゾーンにカードがない場合、以下の効果が発動する。
+  // このユニットがフィールドに出た時、対戦相手のユニットを1体選ぶ。それに3000ダメージを与える。
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 対戦相手のトリガーゾーンにカードがない場合のみ発動
+    if (opponent.trigger.length > 0) {
+      return;
+    }
+
+    // 対戦相手のユニットが選択可能か確認
+    if (EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)) {
+      await System.show(stack, 'クリスマスマジック', '3000ダメージ');
+      const [target] = await EffectHelper.pickUnit(
+        stack,
+        owner,
+        'opponents',
+        '3000ダメージを与えるユニットを選択'
+      );
+      Effect.damage(stack, stack.processing, target, 3000);
+    }
+  },
+
+  // 対戦相手のトリガーゾーンにカードがない場合、以下の効果が発動する。
+  // このユニットがアタックした時、対戦相手のユニットを1体選ぶ。それに4000ダメージを与える。
+  onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 対戦相手のトリガーゾーンにカードがない場合のみ発動
+    if (opponent.trigger.length > 0) {
+      return;
+    }
+
+    // 対戦相手のユニットが選択可能か確認
+    if (EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)) {
+      await System.show(stack, 'クリスマスマジック', '4000ダメージ');
+      const [target] = await EffectHelper.pickUnit(
+        stack,
+        owner,
+        'opponents',
+        '4000ダメージを与えるユニットを選択'
+      );
+      Effect.damage(stack, stack.processing, target, 4000);
+    }
+  },
+};


### PR DESCRIPTION
何でも屋の陳列台
ターボデビル
ブロウ・アップ
威圧
サラマンダー
正拳突き
絶望の天魔アザゼル
チェインフレイム
ラミエル
聖夜のメリィ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **新規カードエフェクト**
  * 複数の新しいカード効果が追加されました。これらのカードは、場に出た時、攻撃時、戦闘時など様々なタイミングでエフェクトが発動します。ダメージ付与、カードドロー、ステータス上昇、特殊キーワード付与など、ゲームプレイに影響する多くの効果が利用可能になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->