### PR TITLE
[アームズドラゴン] 戦闘時効果の永続化を修正

### DIFF
--- a/src/game-data/effects/cards/1-2-122.ts
+++ b/src/game-data/effects/cards/1-2-122.ts
@@ -52,7 +52,6 @@ export const effects: CardEffects = {
 
     // BPを増加（ターン終了まで）
     Effect.modifyBP(stack, stack.processing, stack.processing, bpIncrease, {
-      source: { unit: stack.processing.id, effectCode: 'アームズ・バトルシフト' },
       event: 'turnEnd',
       count: 1,
     });


### PR DESCRIPTION
・戦闘時のBP上昇がターンエンドまでになるように修正

fixes #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストに含まれるのは内部的な改善のみとなり、エンドユーザーに対して目立った変更や新機能はありません。

**該当するカテゴリなし**

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->