### PR TITLE
[マスティマ] プレイヤーアタック時能力の条件修正

### DIFF
--- a/src/game-data/effects/cards/2-0-041.ts
+++ b/src/game-data/effects/cards/2-0-041.ts
@@ -48,6 +48,9 @@ export const effects: CardEffects = {
 
   // プレイヤーアタック時効果
   onPlayerAttack: async (stack: StackWithCard<Unit>) => {
+    // プレイヤーアタックを受けたのが自分でない場合は発動しない
+    if (stack.target?.id !== stack.processing.owner.id) return;
+
     const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id && unit.lv >= 2;
     if (!EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) return;
     await System.show(stack, '信仰の歪み', 'ユニットを破壊\n紫ゲージ+1');


### PR DESCRIPTION
・相手ユニットのプレイヤーアタック時に効果が発動しないよう修正

fixes #189 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カードエフェクトの発動条件を修正し、特定のシナリオでの不正な発動を防止しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->