### PR TITLE
[＜ウィルス・攻＞] 相手ユニット攻撃時に効果が発動するよう修正

### DIFF
--- a/src/game-data/effects/cards/＜ウィルス・攻＞.ts
+++ b/src/game-data/effects/cards/＜ウィルス・攻＞.ts
@@ -6,9 +6,9 @@ export const effects: CardEffects = {
   onAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
     const isOpponentUnitAttacked = stack.source.id !== stack.processing.owner.id;
 
-    if (isOpponentUnitAttacked && stack.source instanceof Unit) {
+    if (isOpponentUnitAttacked && stack.target instanceof Unit) {
       await System.show(stack, '＜ウィルス・攻＞', '基本BP+1000');
-      Effect.modifyBP(stack, stack.processing, stack.source, 1000, { isBaseBP: true });
+      Effect.modifyBP(stack, stack.processing, stack.target, 1000, { isBaseBP: true });
     }
   },
 };


### PR DESCRIPTION
・攻撃したユニットが条件判定の対象になるように修正

fixes #190 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 「ウィルス・攻」カードの攻撃時BP効果の適用対象を修正し、攻撃対象ユニットへ正しく適用されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->