### PR TITLE
1-2-003 炎の魔導師ヒトミ 効果修正 Issue#191

### DIFF
--- a/src/game-data/effects/cards/1-2-003.ts
+++ b/src/game-data/effects/cards/1-2-003.ts
@@ -2,6 +2,19 @@ import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
+async function overFlare(stack: StackWithCard): Promise<void> {
+  await System.show(stack, '紅蓮のオーバーフレア', '4000ダメージ');
+
+  const [unit] = await EffectHelper.pickUnit(
+    stack,
+    stack.processing.owner,
+    'opponents',
+    'ダメージを与えるユニットを選択'
+  );
+
+  Effect.damage(stack, stack.processing, unit, 4000, 'effect');
+}
+
 export const effects: CardEffects = {
   onAttack: async (stack: StackWithCard): Promise<void> => {
     if (stack.target instanceof Unit && stack.processing.owner.id === stack.target.owner.id) {
@@ -10,22 +23,15 @@ export const effects: CardEffects = {
     }
   },
 
-  onClockup: async (stack: StackWithCard): Promise<void> => {
+  onClockup: async (stack: StackWithCard<Unit>): Promise<void> => {
     if (
       stack.target instanceof Unit &&
       stack.processing.owner.id === stack.target.owner.id &&
       stack.target.lv === 3 &&
+      stack.processing.id !== stack.target.id &&
       EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
     ) {
-      await System.show(stack, '紅蓮のオーバーフレア', '4000ダメージ');
-      const [unit] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        'opponents',
-        'ダメージを与えるユニットを選択'
-      );
-
-      Effect.damage(stack, stack.processing, unit, 4000, 'effect');
+      await overFlare(stack);
     }
   },
 
@@ -34,6 +40,15 @@ export const effects: CardEffects = {
     if (targets.length > 0) {
       await System.show(stack, '紅蓮のグロウバーン', '敵全体のレベル3以上のユニットに5000ダメージ');
       targets.forEach(unit => Effect.damage(stack, stack.processing, unit, 5000, 'effect'));
+    }
+
+    if (
+      stack.target instanceof Unit &&
+      stack.processing.owner.id === stack.target.owner.id &&
+      stack.target.lv === 3 &&
+      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
+    ) {
+      await overFlare(stack);
     }
   },
 };


### PR DESCRIPTION
1-2-003.ts
・onClockupの条件から、自身を除外するものを削除
・onClockupSelfから、onClockupを呼び出す処理を削除

この修正により、自身がフィールドでLv3になった場合、紅蓮のグロウバーンが発動したのちに紅蓮のオーバーフレアが発動するようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

- クロックアップ関連のスキル発動条件を改善しました。特定条件下でのスキルトリガーの動作を最適化し、より多くの場面で適切に機能するようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->