### PR TITLE
1-2-112 白夜刀のカンナ 効果修正 Issue#194

### DIFF
--- a/src/game-data/effects/cards/1-2-112.ts
+++ b/src/game-data/effects/cards/1-2-112.ts
@@ -8,6 +8,9 @@ export const effects: CardEffects = {
   },
 
   onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    //すでにレベルが最大の場合は発動しない
+    if (stack.processing.lv >= 3) return;
+
     await System.show(stack, '無我夢中の鍛錬', 'レベル+1');
     Effect.clock(stack, stack.processing, stack.processing, 1);
   },


### PR DESCRIPTION
1-2-112.ts
・onPlayerAttackSelfで、自身のレベルを確認し、3以上なら早期リターンするように変更。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ゲーム効果が最大レベルに到達した際に発動しなくなりました。以前の動作では常に効果が表示され実行されていましたが、最大レベルに達すると発動をスキップするように修正されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->