### PR TITLE
[プロメテウス] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-021.ts
+++ b/src/game-data/effects/cards/1-2-021.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
   // あなたのターン終了時、このユニットのレベルを-1する
   onTurnEnd: async (stack: StackWithCard<Unit>): Promise<void> => {
     // 自分のターンの終了時に発動
-    if (stack.processing.owner.id === stack.core.getTurnPlayer().id) {
+    if (stack.processing.owner.id === stack.core.getTurnPlayer().id && stack.processing.lv > 1) {
       await System.show(stack, '永久の苦しみ', 'レベル-1');
       Effect.clock(stack, stack.processing, stack.processing, -1);
     }


### PR DESCRIPTION
・自身がLV1の時に、クロックダウン能力が発動しないように修正

Fixes #192 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ゲームカードの効果が調整されました。ユニットのレベルが1の場合、さらなるレベル低下が発生しなくなりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->