### PR TITLE
[アームズドラゴン] CIP効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-122.ts
+++ b/src/game-data/effects/cards/1-2-122.ts
@@ -28,13 +28,8 @@ export const effects: CardEffects = {
         'BPを1/2にするユニットを選択'
       );
 
-      // 対象の基本BPを取得して半分に（端数切り上げ）
-      const baseBP = target.bp;
-      const halfBP = Math.ceil(baseBP / 2);
-      const bpReduction = baseBP - halfBP; // 減少量を計算
-
-      // BPを減少させる
-      Effect.modifyBP(stack, stack.processing, target, -bpReduction, {
+      // BPを半分に減少させる
+      Effect.modifyBP(stack, stack.processing, target, -(target.bp / 2), {
         isBaseBP: true,
       });
     }

--- a/src/game-data/effects/cards/2-3-019.ts
+++ b/src/game-data/effects/cards/2-3-019.ts
@@ -23,7 +23,7 @@ export const effects: CardEffects = {
 
     // 敵全体の基本BPを1/2にする（基本BPの半分を減算）
     opponentUnits.forEach(unit => {
-      Effect.modifyBP(stack, stack.processing, unit, -Math.floor(unit.bp / 2), {
+      Effect.modifyBP(stack, stack.processing, unit, -(unit.bp / 2), {
         isBaseBP: true,
       });
     });


### PR DESCRIPTION
・BP半減の対象を現在BPから基本BPに修正し、端数切り上げにする

Fixes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ゲームバランス調整**
  * カード効果の能力値（BP）減少計算ロジックを調整しました。減少量の計算方法を変更し、ゲーム内の特定のカード効果の挙動がより正確になりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->