### PR TITLE
[＜ウィルス・焔＞] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/＜ウィルス・焔＞.ts
+++ b/src/game-data/effects/cards/＜ウィルス・焔＞.ts
@@ -12,13 +12,13 @@ export const effects: CardEffects = {
     if (
       isOpponentUnitDriven &&
       hasRedCardAtLeast5InTrash &&
-      EffectHelper.isUnitSelectable(stack.core, 'owns', stack.processing.owner)
+      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner.opponent)
     ) {
       await System.show(stack, '＜ウィルス・焔＞', '1000ダメージ');
       const [target] = await EffectHelper.pickUnit(
         stack,
-        stack.processing.owner,
-        'owns',
+        stack.processing.owner.opponent,
+        'opponents',
         'ダメージを与えるユニットを選択'
       );
       if (target) {


### PR DESCRIPTION
・効果対象の選択を対戦相手が行うように修正

Fixes #204 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 「ウィルス・焔」カードの効果対象が敵ユニットに正しく変更されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->