### PR TITLE
[妖精王オベロン] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/2-2-031.ts
+++ b/src/game-data/effects/cards/2-2-031.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
       self.owner.trigger.length > 0 &&
       EffectHelper.isUnitSelectable(
         core,
-        (unit: Unit) => unit.owner.id === self.owner.id,
+        (unit: Unit) => unit.owner.id === self.owner.id && unit.catalog.cost >= 3,
         self.owner
       )
     );
@@ -22,7 +22,8 @@ export const effects: CardEffects = {
       '起動・妖精王の覇気',
       'トリガーゾーンを1枚破壊\n【スピードムーブ】を与える'
     );
-    const filter = (unit: Unit) => unit.owner.id === stack.processing.owner.id;
+    const filter = (unit: Unit) =>
+      unit.owner.id === stack.processing.owner.id && unit.catalog.cost >= 3;
     EffectHelper.random(stack.processing.owner.trigger, 1).forEach(card =>
       Effect.move(stack, stack.processing, card, 'trash')
     );


### PR DESCRIPTION
・起動効果によりコスト2以下のユニットを選択できないように修正

Fixes #205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バランス調整**
  * カード効果の発動条件が更新されました。ユニットのコスト3以上という要件が追加され、より限定的な使用場面でのみ効果が発動するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->