### PR TITLE
[赤誠の沖田] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-104.ts
+++ b/src/game-data/effects/cards/1-3-104.ts
@@ -19,7 +19,7 @@ export const effects: CardEffects = {
       )
     ) {
       await System.show(stack, '口伝・真如剣', 'トリガーゾーンにあるカードを1枚破壊');
-      const [target] = EffectHelper.random(stack.processing.owner.trigger);
+      const [target] = EffectHelper.random(stack.processing.owner.opponent.trigger);
       if (target) Effect.move(stack, stack.processing, target, 'trash');
     }
   },


### PR DESCRIPTION
・トリガーゾーン破壊の対象を対戦相手に修正

Fixes #206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カード効果における対象選択の基準を修正しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->