### PR TITLE
[混沌神カオス] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/2-0-133.ts
+++ b/src/game-data/effects/cards/2-0-133.ts
@@ -7,9 +7,9 @@ export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard) => {
     const purple = stack.processing.owner.purple;
     if (purple && purple > 0) {
-      await System.show(stack, '無限の混沌', '敵全体に[紫ゲージ×1000]ダメージ');
+      await System.show(stack, '無限の混沌', '敵全体に[紫ゲージ×2000]ダメージ');
       stack.processing.owner.opponent.field.forEach(unit =>
-        Effect.damage(stack, stack.processing, unit, 1000 * purple)
+        Effect.damage(stack, stack.processing, unit, 2000 * purple)
       );
       await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -purple);
     }


### PR DESCRIPTION
・ダメージ値を紫ゲージ*2000に修正

Fixes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バランス調整

* **カード効果の強化**
  * 特定のカードが紫ゲージを発動した際に敵全体に与えるダメージが増加しました。ダメージ倍率が従来の1000倍から2000倍に変更され、対応するバトルメッセージも更新されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->