### PR TITLE
[サイクロプス] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-032.ts
+++ b/src/game-data/effects/cards/1-2-032.ts
@@ -1,4 +1,4 @@
-import { Unit } from '@/package/core/class/card';
+import { Unit, Card } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
@@ -24,7 +24,7 @@ export const effects: CardEffects = {
   // 劣化した魔術鉄鎖：効果によって対戦相手が手札を捨てた時に行動権を回復
   onHandes: async (stack: StackWithCard<Unit>): Promise<void> => {
     // targetとsourceがCardオブジェクトであることを確認
-    if (!(stack.source instanceof Unit && stack.target instanceof Unit)) {
+    if (!(stack.source instanceof Card && stack.target instanceof Card)) {
       return;
     }
 


### PR DESCRIPTION
・任意のカードタイプによるハンデス効果によって行動権が回復するように修正
・ハンデス効果により捨てられたカードのタイプが何であっても行動権が回復するように修正

Fixes #209