### PR TITLE
[ブラック玄武] 自身に固着を付与

### DIFF
--- a/src/game-data/effects/cards/2-3-219.ts
+++ b/src/game-data/effects/cards/2-3-219.ts
@@ -8,9 +8,10 @@ export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     await System.show(
       stack,
-      '北斗玄天＆翠檄黒叡智',
-      '四聖獣ユニットに【秩序の盾】を付与\nカードを1枚引きコスト-2'
+      '北斗玄天',
+      '【固着】\n四聖獣ユニットに【秩序の盾】を付与\nカードを1枚引きコスト-2'
     );
+    Effect.keyword(stack, stack.processing, stack.processing, '固着');
 
     // カードを1枚引く
     const card = EffectTemplate.draw(stack.processing.owner, stack.core);


### PR DESCRIPTION
・CIPで固着を付与し、CIPの表示メッセージを修正

Fixes #218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ゲームバランス調整**
  * 特定のカードの効果表示テキストを簡潔に更新しました。
  * カードに「固着」キーワード効果を新たに追加しました。カードの基本機能（ドローとコスト削減）は変更されていません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->