### PR TITLE
カード追加 バク・ダルマン（1-0-003.SP-053）

### DIFF
--- a/src/database/effects/cards/1-0-003.ts
+++ b/src/database/effects/cards/1-0-003.ts
@@ -1,0 +1,23 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../classes/types';
+
+export const effects: CardEffects = {
+    //■ドッカーンッ！
+    //このユニットがオーバークロックした時、対戦相手の全てのユニットに3000ダメージを与える。
+
+    onOverclockSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+        const owner = stack.processing.owner;
+        const enemyUnits = owner.opponent.field;
+
+        if (enemyUnits.length === 0) {
+            return;
+        }
+        await System.show(stack, 'ドッカーンッ！', '敵全体に2000ダメージ');
+
+        enemyUnits.forEach((unit) => {
+            Effect.damage(stack, stack.processing, unit, 2000);
+        });
+    }
+
+};

--- a/src/database/effects/cards/SP-053.ts
+++ b/src/database/effects/cards/SP-053.ts
@@ -1,0 +1,1 @@
+export { effects } from './1-0-003';


### PR DESCRIPTION
バク･ダルマンの追加です。
オーバークロック時、対戦相手にユニットが存在しない場合は処理を行わずにreturnしています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 新しいカード効果が追加されました。自身がオーバークロック時に敵フィールド上のすべてのユニットに対して2000ダメージを与えます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->