### PR TITLE
[人の業] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-062.ts
+++ b/src/game-data/effects/cards/1-2-062.ts
@@ -16,9 +16,9 @@ export const effects: CardEffects = {
       await System.show(stack, '人の業', '行動権を消費');
       Effect.activate(stack, stack.processing, stack.target, false);
     } else {
-      await System.show(stack, '人の業', 'フィールドに出たユニットを破壊\n1ライフダメージ');
+      await System.show(stack, '人の業', 'フィールドに出たユニットを破壊\n2ライフダメージ');
       Effect.break(stack, stack.processing, stack.target);
-      Effect.modifyLife(stack, stack.processing, stack.target.owner, -1);
+      Effect.modifyLife(stack, stack.processing, stack.target.owner, -2);
     }
   },
 };


### PR DESCRIPTION
・破壊効果発動時のライフダメージを2に修正

Fixes #223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バランス調整**
  * カード効果がフィールドユニットに与えるダメージと、対象プレイヤーへのライフダメージの値を調整しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->