### PR TITLE
[ムーンリターナーかぐや] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/2-0-038.ts
+++ b/src/game-data/effects/cards/2-0-038.ts
@@ -4,8 +4,11 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, '月面直帰', '自身を手札に戻す\n紫ゲージ+2');
-    Effect.bounce(stack, stack.processing, stack.processing, 'hand');
-    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 2);
+    const purple = stack.processing.owner.purple ?? 0;
+    if (purple <= 1) {
+      await System.show(stack, '月面直帰', '自身を手札に戻す\n紫ゲージ+2');
+      Effect.bounce(stack, stack.processing, stack.processing, 'hand');
+      await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 2);
+    }
   },
 };


### PR DESCRIPTION
・紫ゲージが1以下の場合のみ、バウンスと紫ゲージ増加が発動するよう修正

Fixes #241 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カード（2-0-038）の効果実行ロジックを修正しました。紫の値が2以上の場合、該当する効果が発動しなくなります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->