### PR TITLE
[隠秘のスコーピオ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/2-1-023.ts
+++ b/src/game-data/effects/cards/2-1-023.ts
@@ -28,7 +28,8 @@ export const effects: CardEffects = {
     if (
       !(stack.target instanceof Unit) ||
       stack.target.owner.id !== stack.processing.owner.id ||
-      stack.target.id === stack.processing.id
+      stack.target.id === stack.processing.id ||
+      !stack.target.catalog.species?.includes('忍者')
     )
       return;
     await System.show(stack, '夜陰にまぎれて', '紫ゲージ+1');


### PR DESCRIPTION
・破壊されたユニットが忍者の場合のみ紫ゲージが増加するように修正

Fixes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * カード効果の適用条件を修正し、対象の種族属性を正しく検証するようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->