### PR TITLE
[クラウンクイーン] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-4-305.ts
+++ b/src/game-data/effects/cards/1-4-305.ts
@@ -3,26 +3,33 @@ import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
-  // 自身が召喚された時に発動する効果を記述
+  // このユニットがアタックした時
   onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     await System.show(stack, '魅入られし従者', '【道化師】を1枚引く');
     EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '道化師' });
   },
 
-  // 自身以外が召喚された時に発動する効果を記述
-  // 味方ユニットであるかの判定などを忘れない
+  // あなたの【道化師】ユニットがアタックした時
   onAttack: async (stack: StackWithCard): Promise<void> => {
-    if (stack.target instanceof Unit && stack.processing.owner.id === stack.target.owner.id) {
-      await System.show(stack, '狂姫の闊歩', '【防御禁止】を与える');
-      const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id;
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        filter,
-        '【防御禁止】を与えるユニットを選択して下さい',
-        1
-      );
-      Effect.keyword(stack, stack.processing, target, '防御禁止');
-    }
+    if (
+      !(stack.target instanceof Unit) ||
+      stack.target.owner.id !== stack.processing.owner.id ||
+      !stack.target.catalog.species?.includes('道化師') ||
+      !EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
+    )
+      return;
+
+    await System.show(stack, '狂姫の闊歩', '【防御禁止】を与える');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'opponents',
+      '【防御禁止】を与えるユニットを選択して下さい',
+      1
+    );
+    Effect.keyword(stack, stack.processing, target, '防御禁止', {
+      event: 'turnEnd',
+      count: 1,
+    });
   },
 };


### PR DESCRIPTION
・アタック時効果が道化師ユニットに限定されるように修正
・効果発動前に選択チェックを実装
・防御禁止付与の期間をターン終了時までに修正

Fixes #253 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ゲーム調整**
  * カード ID 1-4-305 の効果ロジックを調整しました。ターゲット選択条件を改善し、効果の適用方法を変更しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->