### PR TITLE
[蒼炎の魔術師ヒトミ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-114.ts
+++ b/src/game-data/effects/cards/1-2-114.ts
@@ -5,17 +5,15 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   // ■ブレイク・クロック
   // このユニット以外のあなたのユニットが破壊されるたび
-  checkBreak: (stack: StackWithCard): boolean => {
-    return (
-      stack.target instanceof Unit &&
-      stack.target.owner.id === stack.processing.owner.id &&
-      stack.target.id !== stack.processing.id
-    );
-  },
-
   onBreak: async (stack: StackWithCard): Promise<void> => {
-    const filter = (unit: Unit) => unit.owner.id === stack.processing.owner.id;
+    if (
+      !(stack.target instanceof Unit) ||
+      stack.target.owner.id !== stack.processing.owner.id ||
+      stack.target.id === stack.processing.id
+    )
+      return;
 
+    const filter = (unit: Unit) => unit.destination !== 'trash' && unit.lv < 3;
     if (EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) {
       await System.show(stack, 'ブレイク・クロック', 'レベル+1');
       const [target] = await EffectHelper.pickUnit(


### PR DESCRIPTION
・破壊されたユニットの条件を修正
・選択できるユニットの条件を修正

#196 にてコメントされた下記の実装を待たず、unit.destination !== 'trash' の指定により破壊済みユニットを選択できないようにした
＞上記を簡単に実装できるよう、UnitPickFilter に配列を指定可能にし、AND条件による絞り込みを容易にする。

Fixes #195
関連 Issue #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ブレーク機能の処理条件を改善し、ターゲット判定ロジックの精度を向上させました。
  * 無効なケースの処理を修正し、より正確なユニット選択フィルタリングを実装しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->