### PR TITLE
PR-030.tsの追加

### DIFF
--- a/src/game-data/effects/cards/PR-030.ts
+++ b/src/game-data/effects/cards/PR-030.ts
@@ -1,4 +1,4 @@
-import { Unit } from '@/package/core/class/card';
+import { Unit, Card } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import { PermanentEffect } from '../engine/permanent';
 import type { CardEffects, StackWithCard } from '../schema/types';
@@ -21,8 +21,8 @@ export const effects: CardEffects = {
     const owner = stack.processing.owner;
 
     // 手札が2枚以下の時、このユニットのBPを+4000する
-    PermanentEffect.mount(stack, stack.processing, {
-      effect: (unit, source) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (unit: Card, source) => {
         if (unit instanceof Unit) {
           Effect.modifyBP(stack, stack.processing, unit, 4000, {
             source,
@@ -35,8 +35,8 @@ export const effects: CardEffects = {
     });
 
     // 手札が1枚以下の時、対戦相手のユニットのBPを-1000する
-    PermanentEffect.mount(stack, stack.processing, {
-      effect: (unit, source) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (unit: Card, source) => {
         if (unit instanceof Unit) {
           Effect.modifyBP(stack, stack.processing, unit, -1000, {
             source,
@@ -49,8 +49,8 @@ export const effects: CardEffects = {
     });
 
     // 手札が0枚の時、このユニットに【不滅】を与える
-    PermanentEffect.mount(stack, stack.processing, {
-      effect: (unit, source) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (unit: Card, source) => {
         if (unit instanceof Unit) {
           Effect.keyword(stack, stack.processing, unit, '不滅', {
             source,


### PR DESCRIPTION
コミットが２つありますが、一回目にコミットした方は結局何も変わっていません。一回目のpush時に発生したsuitのコンクリフトの対処法が分からず、一旦mainを全て更新して退避しておいたPR-030.tsを追加して再コミットしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 新カード PR-030 を追加。手札から出撃した際に沈黙効果を付与し、手札枚数に応じた条件付き能力を獲得します。手札2枚以下でBP+4000、手札1枚以下で相手ユニットのBP-1000、手札0枚で不滅能力を付与します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->