### PR TITLE
1-2-030.tsを追加

### DIFF
--- a/src/game-data/effects/cards/1-2-030.ts
+++ b/src/game-data/effects/cards/1-2-030.ts
@@ -1,0 +1,28 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // ■ナガマダヂ、オデ、マモル
+  // あなたのユニットが破壊されるたび、ユニットを１体選ぶ。
+  // ターン終了時までそれのＢＰを＋３０００する。
+
+  onBreak: async (stack: StackWithCard): Promise<void> => {
+    if (!(stack.target instanceof Unit) || stack.target.owner.id !== stack.processing.owner.id)
+      return;
+
+    const targetId = stack.target.id;
+    const filter = (unit: Unit) => unit.id !== targetId;
+
+    if (EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) {
+      await System.show(stack, 'ナガマダヂ、オデ、マモル', 'BP+3000');
+      const [target] = await EffectHelper.pickUnit(
+        stack,
+        stack.processing.owner,
+        filter,
+        'BP+3000するユニットを選択'
+      );
+      Effect.modifyBP(stack, stack.processing, target, 3000, { event: 'turnEnd', count: 1 });
+    }
+  },
+};


### PR DESCRIPTION
1-2-030.ts「イエティ」を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユニットが破壊されたときに、同じプレイヤーに属する別のユニットを選択してブレットポイント(BP)を3,000ポイント増加させることができる新しいカード効果を追加しました。この効果により、破壊されたユニット以外の味方ユニットを強化できるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->