### PR TITLE
カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-0-019.ts
+++ b/src/game-data/effects/cards/1-0-019.ts
@@ -1,24 +1,20 @@
 import type { Unit } from '@/package/core/class/card';
-import { Effect, System } from '..';
+import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     const owner = stack.processing.owner;
-    const opponent = owner.opponent;
-    const isOnField = opponent.field.length > 0;
 
-    if (isOnField) {
+    if (EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)) {
       await System.show(stack, 'ジャンプーダンス', '手札に戻す');
-      const [choice] = await System.prompt(stack, owner.id, {
-        title: '手札に戻すユニットを選択',
-        type: 'unit',
-        items: opponent.field,
-      });
-
-      const target = opponent.field.find(unit => unit.id === choice) ?? opponent.field[0];
-      if (!target) throw new Error('対戦相手のフィールドにユニットが存在しません');
-
+      const [target] = await EffectHelper.pickUnit(
+        stack,
+        owner,
+        'opponents',
+        '手札に戻すユニットを選択'
+      );
+      if (!target) return;
       Effect.bounce(stack, stack.processing, target, 'hand');
     }
   },


### PR DESCRIPTION
1-0-019　ジャンプー
・加護を考慮した選択メソッドを使用するように修正

Fixes #296 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * カード効果の実装を簡潔化しました。選択フローが改善され、ターゲットが選択されない場合の処理がより効率的になりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->