### PR TITLE
カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-0-031.ts
+++ b/src/game-data/effects/cards/1-0-031.ts
@@ -3,6 +3,7 @@ import type { StackWithCard } from '../schema/types';
 
 export const effects = {
   onOverclockSelf: async (stack: StackWithCard) => {
+    if (stack.processing.owner.trash.length <= 0) return;
     await System.show(stack, 'リバイブ', '捨札から1枚選んで回収');
     await EffectTemplate.revive(stack, 1);
   },

--- a/src/game-data/effects/cards/1-3-027.ts
+++ b/src/game-data/effects/cards/1-3-027.ts
@@ -69,6 +69,7 @@ export const effects: CardEffects = {
   },
 
   onOverclockSelf: async (stack: StackWithCard) => {
+    if (stack.processing.owner.trash.length <= 0) return;
     await System.show(stack, 'カオスディール', '捨札から選んで回収');
     await EffectTemplate.revive(stack, 1);
   },

--- a/src/game-data/effects/cards/2-0-018.ts
+++ b/src/game-data/effects/cards/2-0-018.ts
@@ -3,6 +3,7 @@ import type { StackWithCard } from '../schema/types';
 
 export const effects = {
   onDriveSelf: async (stack: StackWithCard) => {
+    if (stack.processing.owner.trash.length <= 0) return;
     await System.show(stack, '月蝕の棺', '捨札から1枚選んで回収');
     await EffectTemplate.revive(stack, 1);
   },

--- a/src/game-data/effects/cards/PR-159.ts
+++ b/src/game-data/effects/cards/PR-159.ts
@@ -21,7 +21,8 @@ export const effects: CardEffects = {
     return (
       stack.source instanceof Unit &&
       stack.source.owner.id === stack.processing.owner.id &&
-      stack.source.catalog.color === Color.BLUE
+      stack.source.catalog.color === Color.BLUE &&
+      stack.processing.owner.trash.length > 0
     );
   },
 


### PR DESCRIPTION
1-0-031　見習い魔導士リーナ
・OC時に捨て札0枚だったら何もしないように修正

以下は EffectTemplate.revive 使用箇所について、同様の修正を実施
1-3-027　大魔導士リーナ
2-0-018　邪眼天使サリエル（進化なのでCIP時に捨て札0はありえないはずだが、念の為）
PR-159　求愛のダンス

修正対象外
2-0-337 掘り出し物（捨て札20枚が元々条件に入っているため）

Fixes #297 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 複数のカード効果において、トラッシュが空の状態での不正な処理フローを修正。カード効果がトラッシュの状態を正しく確認するようになり、ゲームロジックの整合性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->