### PR TITLE
[絶妙な挑発] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-0-069.ts
+++ b/src/game-data/effects/cards/1-0-069.ts
@@ -7,21 +7,23 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // あなたのユニットがフィールドに出た時
   checkDrive: (stack: StackWithCard<Card>): boolean => {
-    return stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id;
+    if (!(stack.target instanceof Unit)) return false;
+    if (stack.target.owner.id !== stack.processing.owner.id) return false;
+
+    // 相手のユニットが選択可能か
+    return EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner);
   },
 
   onDrive: async (stack: StackWithCard<Card>): Promise<void> => {
-    if (EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)) {
-      await System.show(stack, '絶妙な挑発', 'レベルを3にする');
+    await System.show(stack, '絶妙な挑発', 'レベルを3にする');
 
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        'opponents',
-        'レベルを3にするユニットを選択'
-      );
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'opponents',
+      'レベルを3にするユニットを選択'
+    );
 
-      Effect.clock(stack, stack.processing, target, 2, true);
-    }
+    Effect.clock(stack, stack.processing, target, 2, true);
   },
 };


### PR DESCRIPTION
1-0-069　絶妙な挑発
・選択可能チェックをcheck側の処理に移動

Fixes #299 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カード効果の処理ロジックを改善し、対戦相手のユニットをターゲットにする際の検証機能を強化しました。これにより、ゲーム中の効果発動がより確実かつ一貫性のあるものになり、ユーザーエクスペリエンスが向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->