### PR TITLE
[天空の楽園] 誤字修正

### DIFF
--- a/src/game-data/effects/cards/1-1-028.ts
+++ b/src/game-data/effects/cards/1-1-028.ts
@@ -9,7 +9,7 @@ export const effects: CardEffects = {
   },
 
   onDrive: async (stack: StackWithCard): Promise<void> => {
-    await System.show(stack, '天使の楽園', '【天使】を1枚引く');
+    await System.show(stack, '天空の楽園', '【天使】を1枚引く');
     EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '天使' });
   },
 
@@ -22,7 +22,7 @@ export const effects: CardEffects = {
   },
 
   onPlayerAttack: async (stack: StackWithCard) => {
-    await System.show(stack, '天使の楽園', '属性の異なる【天使】を2枚引く');
+    await System.show(stack, '天空の楽園', '属性の異なる【天使】を2枚引く');
     const colors = EffectHelper.shuffle([
       Color.RED,
       Color.YELLOW,


### PR DESCRIPTION
1-1-028　天空の楽園
・効果名称を「天空の楽園」に修正

Fixes #301 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ゲームカードの表示テキストを修正しました。カード効果で「天使の楽園」から「天空の楽園」に表記を統一し、正確性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->