### PR TITLE
[トリックオアトリート] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-1-092.ts
+++ b/src/game-data/effects/cards/1-1-092.ts
@@ -26,7 +26,7 @@ export const effects: CardEffects = {
 
   // あなたのユニットが戦闘によって対戦相手のユニットを破壊した時、インターセプトカードを1枚引く。
   checkWin(stack: StackWithCard) {
-    return stack.source instanceof Unit && stack.source.owner.id === stack.processing.owner.id;
+    return stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id;
   },
 
   async onWin(stack: StackWithCard) {


### PR DESCRIPTION
1-1-092　トリックオアトリート
・戦闘勝利時の効果が発動できるように判定対象を修正

Fixes #304 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* **バグ修正**
  * ゲームの勝利判定ロジックを改善しました。プレイヤーのユニットが相手のユニットを破壊した場合の判定が正しく機能するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->