### PR TITLE
[海王ポセイドン] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-037.ts
+++ b/src/game-data/effects/cards/1-2-037.ts
@@ -30,7 +30,11 @@ export const effects: CardEffects = {
       const triggerCards = stack.processing.owner.trigger;
 
       if (triggerCards.length > 0) {
-        await System.show(stack, '海底の宝物庫', 'トリガーカードを破壊\n相手ユニットを破壊');
+        await System.show(
+          stack,
+          '海底の宝物庫',
+          'トリガーゾーンのカードを破壊\n相手ユニットを破壊'
+        );
 
         // トリガーゾーンからランダムで1枚選択して破壊
         const randomTriggers = EffectHelper.random(triggerCards, 1);


### PR DESCRIPTION
1-2-037　海王ポセイドン
・相手アタック時の攻撃ユニット存在チェックを追加
・相手アタック時の効果説明文を修正

Fixes #305 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カード効果のメッセージ表示をより正確に更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->