### PR TITLE
[鬼神・スサノオ] メッセージ修正

### DIFF
--- a/src/game-data/effects/cards/1-2-052.ts
+++ b/src/game-data/effects/cards/1-2-052.ts
@@ -12,7 +12,7 @@ export const effects: CardEffects = {
 
   // 召喚時に無我の境地を付与
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, '無我の境地', '【無我の境地】を付与');
+    await System.show(stack, '無我の境地', '対戦相手の効果によって行動権を消費しない');
     Effect.keyword(stack, stack.processing, stack.processing, '無我の境地');
   },
 


### PR DESCRIPTION
1-2-052　鬼神・スサノオ
・【無我の境地】の付与メッセージ表記を「対戦相手の効果によって行動権を消費しない」に修正

Fixes #306 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* カード召喚時に表示されるメッセージテキストを修正しました。効果の説明がより正確に表示されるようになり、ユーザーがカード機能をより適切に理解できるようになります。ゲームプレイの動作に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->