### PR TITLE
[勝者の証] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-077.ts
+++ b/src/game-data/effects/cards/1-2-077.ts
@@ -6,7 +6,7 @@ export const effects: CardEffects = {
   // ■勝者の証
   // あなたのユニットが戦闘に勝利した時
   checkWin: (stack: StackWithCard): boolean => {
-    return stack.target instanceof Unit && stack.target.id === stack.processing.owner.id;
+    return stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id;
   },
 
   onWin: async (stack: StackWithCard): Promise<void> => {


### PR DESCRIPTION
1-2-077　勝者の証
・勝利ユニットのIDではなく、その所有者のIDを判定するように修正

Fixes #309 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 特定のカード効果における勝利判定ロジックの動作を修正しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->