### PR TITLE
[聖なる領域] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-087.ts
+++ b/src/game-data/effects/cards/1-2-087.ts
@@ -8,7 +8,7 @@ export const effects: CardEffects = {
   onTurnStart: async (stack: StackWithCard) => {
     await System.show(stack, '聖なる領域', '味方全体に【加護】を付与');
     stack.processing.owner.field.forEach(unit =>
-      Effect.keyword(stack, stack.processing, unit, '加護')
+      Effect.keyword(stack, stack.processing, unit, '加護', { event: 'turnEnd', count: 1 })
     );
   },
 };


### PR DESCRIPTION
1-2-087　聖なる領域
・効果の発動期間にターン終了までの指定を追加

Fixes #311 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ゲーム調整**
  * カード「1-2-087」のアライ効果の処理が更新されました。ターン開始時のキーワード効果の適用方法が調整されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->