### PR TITLE
[シャドーミラー] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-074.ts
+++ b/src/game-data/effects/cards/1-2-074.ts
@@ -7,8 +7,10 @@ export const effects: CardEffects = {
   checkTurnEnd: stack =>
     stack.processing.owner.field.length <= 0 && stack.source.id !== stack.processing.owner.id,
   onTurnEnd: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const triggerCards = owner.trash.filter(card => card.catalog.type === 'trigger');
     await System.show(stack, 'シャドーミラー', 'トリガーカードを2枚回収');
-    EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
+    EffectHelper.random(triggerCards, 2).forEach(card =>
       Effect.move(stack, stack.processing, card, 'hand')
     );
   },


### PR DESCRIPTION
1-2-074　シャドーミラー
・回収対象がトリガーカードだけになるように修正

Fixes #313 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カード1-2-074の能力を調整しました。手札に移動させるカードの選択対象がトリガータイプのカードに限定されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->