### PR TITLE
[グラウンド・へヴィ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-140.ts
+++ b/src/game-data/effects/cards/1-2-140.ts
@@ -9,7 +9,14 @@ export const effects: CardEffects = {
 
   //自身のユニットが出た時
   checkDrive: (stack: StackWithCard): boolean => {
-    return stack.processing.owner.id === stack.source.id;
+    const owner = stack.processing.owner;
+    if (owner.id !== stack.source.id) return false;
+
+    const hasHand = owner.hand.length > 0;
+    const hasField = owner.field.length > 0;
+    const targetOnField = owner.field.some(u => u.id === stack.target?.id);
+
+    return (!hasHand && hasField) || (hasHand && targetOnField);
   },
 
   onDrive: async (stack: StackWithCard<Unit>) => {


### PR DESCRIPTION
1-2-140　グラウンド・へヴィ
・効果対象の生存チェックを追加（自手札の枚数を考慮）

Fixes #316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ゲーム効果の発動条件を修正しました。手札の有無やフィールド上のカード配置に応じた条件判定に改善され、より正確なトリガー判定が可能になりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->