### PR TITLE
[封札の煉獄炎] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-141.ts
+++ b/src/game-data/effects/cards/1-2-141.ts
@@ -5,29 +5,47 @@ import { Effect } from '../engine/effect';
 import { EffectHelper } from '../engine/helper';
 
 export const effects: CardEffects = {
-  // ユニットの生存チェックを兼ねる
-  checkDrive: stack =>
-    stack.processing.owner.opponent.field.some(unit => unit.id === stack.target?.id),
-  onDrive: async (stack: StackWithCard) => {
-    if (stack.target instanceof Unit) {
-      switch (stack.processing.lv) {
-        case 1:
-        case 2: {
-          await System.show(
-            stack,
-            '封札の煉獄炎',
-            '3000ダメージ\nデッキから1枚トリガーゾーンにセット'
-          );
-          Effect.damage(stack, stack.processing, stack.target, 3000);
-          EffectHelper.random(stack.processing.owner.deck).forEach(card =>
-            Effect.move(stack, stack.processing, card, 'trigger')
-          );
-          break;
-        }
-        case 3: {
-          await System.show(stack, '封札の煉獄炎', '10000ダメージ');
-          Effect.damage(stack, stack.processing, stack.target, 10000);
-        }
+  checkDrive: (stack: StackWithCard) => {
+    const target = stack.target;
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (!(target instanceof Unit)) return false;
+    if (!(target.owner.id === opponent.id)) return false;
+
+    return target.lv <= 2 || opponent.field.some(unit => unit.id === target.id);
+  },
+
+  onDrive: async (stack: StackWithCard<Unit>) => {
+    const target = stack.target;
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (!(target instanceof Unit)) return;
+
+    switch (target.lv) {
+      case 1:
+      case 2: {
+        await EffectHelper.combine(stack, [
+          {
+            title: '封札の煉獄炎',
+            description: '3000ダメージ',
+            effect: () => Effect.damage(stack, stack.processing, target, 3000),
+            condition: opponent.field.some(unit => unit.id === target.id),
+          },
+          {
+            title: '封札の煉獄炎',
+            description: 'デッキから1枚トリガーゾーンにセット',
+            effect: () =>
+              EffectHelper.random(owner.deck).forEach(card =>
+                Effect.move(stack, stack.processing, card, 'trigger')
+              ),
+          },
+        ]);
+        break;
+      }
+      case 3: {
+        await System.show(stack, '封札の煉獄炎', '10000ダメージ');
+        Effect.damage(stack, stack.processing, target, 10000);
+        break;
       }
     }
   },


### PR DESCRIPTION
1-2-141　封札の煉獄炎
・レベル毎の効果について、相手ユニットのレベルを参照するように修正
・ダメージ効果とトリガーセット効果の処理を分離するように修正
・レベル1,2の効果は無条件で発動できるように修正

Fixes #317 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * カード効果の内部実装を改善し、型安全性と可読性を向上させました。コードの堅牢性を強化し、保守性を高めています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->