### PR TITLE
[封札の死壊石] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-147.ts
+++ b/src/game-data/effects/cards/1-2-147.ts
@@ -5,31 +5,47 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   // カードが発動可能であるかを調べ、発動条件を満たしていれば true を、そうでなければ false を返す。
   checkDrive: (stack: StackWithCard) => {
-    return (
-      stack.processing.owner.id !== stack.source.id &&
-      stack.target instanceof Unit &&
-      stack.target.owner.field.some(unit => unit.id === stack.target?.id)
-    );
+    const target = stack.target;
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (!(target instanceof Unit)) return false;
+    if (!(target.owner.id === opponent.id)) return false;
+
+    return target.lv <= 2 || opponent.field.some(unit => unit.id === target.id);
   },
 
   // 実際の効果本体
   // 関数名に self は付かない
   onDrive: async (stack: StackWithCard): Promise<void> => {
-    if (!(stack.target instanceof Unit)) return;
+    const target = stack.target;
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (!(target instanceof Unit)) return;
 
-    switch (stack.target.lv) {
+    switch (target.lv) {
       case 1:
       case 2: {
-        await System.show(stack, '封札の死壊石', 'レベル+1\n捨札からユニットカードを回収');
-        Effect.clock(stack, stack.processing, stack.target, 1);
-        EffectHelper.random(
-          stack.processing.owner.trash.filter(card => card instanceof Unit)
-        ).forEach(unit => Effect.move(stack, stack.processing, unit, 'hand'));
+        await EffectHelper.combine(stack, [
+          {
+            title: '封札の死壊石',
+            description: 'レベル+1',
+            effect: () => Effect.clock(stack, stack.processing, target, 1),
+            condition: opponent.field.some(unit => unit.id === target.id),
+          },
+          {
+            title: '封札の死壊石',
+            description: '捨札からユニットカードを回収',
+            effect: () =>
+              EffectHelper.random(owner.trash.filter(card => card instanceof Unit)).forEach(unit =>
+                Effect.move(stack, stack.processing, unit, 'hand')
+              ),
+          },
+        ]);
         break;
       }
       case 3: {
         await System.show(stack, '封札の死壊石', 'ユニットを破壊する');
-        Effect.break(stack, stack.processing, stack.target, 'effect');
+        Effect.break(stack, stack.processing, target, 'effect');
         break;
       }
     }


### PR DESCRIPTION
1-2-147　封札の死壊石
・クロックアップ効果とユニット回収効果の処理を分離するように修正
・レベル1,2の効果は無条件で発動できるように修正

Fixes #318 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ゲームカードの効果判定及び実行ロジックを改善し、より正確な動作を実現しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->