### PR TITLE
[デーメーテール] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-2-049.ts
+++ b/src/game-data/effects/cards/1-2-049.ts
@@ -23,7 +23,7 @@ export const effects: CardEffects = {
         }
       },
       targets: ['self'],
-      condition: unit => unit.lv == 1,
+      condition: unit => unit.lv === 1,
       effectCode: '大地の掟',
     });
 


### PR DESCRIPTION
1-2-049　デーメーテール
・自身がレベル1の時のみ秩序の盾を付与するように修正
・秩序の盾についてのメッセージ表示を修正

Fixes #289 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カード1-2-049の説明文を更新し、シールド習得がレベル1で発動することを明確化しました。
  * フィールド効果の動作を修正し、レベル1ユニットのみを対象とする条件を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->