### PR TITLE
[蛮王ベリアル] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-0-013.ts
+++ b/src/game-data/effects/cards/1-0-013.ts
@@ -10,6 +10,9 @@ export const effects: CardEffects = {
 
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     const opponent = stack.processing.owner.opponent;
+    if (opponent.field.length === 0) {
+      return;
+    }
 
     await System.show(stack, '憤怒の炎', '対戦相手のユニット全体に3000ダメージ');
 


### PR DESCRIPTION
1-0-013　蛮王ベリアル
・敵ユニットの存在チェックを追加

Fixes #337 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カード1-0-013の動作を調整。相手がフィールドに生物を配置していない場合、不要なシステムメッセージと処理をスキップするようになりました。相手が生物を持つ場合の動作に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->