### PR TITLE
[統率者ヴィシュヌ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-4-032.ts
+++ b/src/game-data/effects/cards/1-4-032.ts
@@ -1,4 +1,4 @@
-import { Unit } from '@/package/core/class/card';
+import { Unit, Card } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
@@ -14,18 +14,28 @@ export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     const opponent = stack.processing.owner.opponent;
 
-    await System.show(stack, '森羅万象の理', '【秩序の盾】【固着】\n敵全体の基本BPを-2000');
-
-    // キーワード能力を付与
-    Effect.keyword(stack, stack.processing, stack.processing, '秩序の盾');
-    Effect.keyword(stack, stack.processing, stack.processing, '固着');
-
-    // 相手全てのユニットの基本BPを-2000する
-    for (const unit of opponent.field) {
-      Effect.modifyBP(stack, stack.processing, unit, -2000, {
-        isBaseBP: true,
-      });
-    }
+    await EffectHelper.combine(stack, [
+      {
+        title: '森羅万象の理',
+        description: '【秩序の盾】【固着】',
+        effect: () => {
+          Effect.keyword(stack, stack.processing, stack.processing, '秩序の盾');
+          Effect.keyword(stack, stack.processing, stack.processing, '固着');
+        },
+      },
+      {
+        title: '森羅万象の理',
+        description: '敵全体の基本BPを-2000',
+        effect: () => {
+          for (const unit of opponent.field) {
+            Effect.modifyBP(stack, stack.processing, unit, -2000, {
+              isBaseBP: true,
+            });
+          }
+        },
+        condition: opponent.field.length > 0,
+      },
+    ]);
   },
 
   // 相手ユニットがアタックした時の効果
@@ -33,11 +43,11 @@ export const effects: CardEffects = {
     const owner = stack.processing.owner;
 
     // 相手のユニットがアタックした時のみ発動
-    if (stack.source instanceof Unit && stack.source.owner.id !== owner.id) {
+    if (stack.target instanceof Unit && stack.target.owner.id !== owner.id) {
       await System.show(stack, '安寧なる世のために', '敵の基本BPを-1000');
 
       // アタックしたユニットの基本BPを-1000する
-      Effect.modifyBP(stack, stack.processing, stack.source, -1000, {
+      Effect.modifyBP(stack, stack.processing, stack.target, -1000, {
         isBaseBP: true,
       });
     }
@@ -50,10 +60,10 @@ export const effects: CardEffects = {
 
     // 自分のトリガーカードが相手の効果によって破壊された時のみ発動
     if (
-      stack.source instanceof Unit &&
+      stack.source instanceof Card &&
       stack.source.owner.id !== owner.id &&
       stack.target &&
-      stack.target instanceof Unit &&
+      stack.target instanceof Card &&
       stack.target.owner.id === owner.id
     ) {
       // 相手のユニットが存在する場合のみ処理


### PR DESCRIPTION
1-4-032　統率者ヴィシュヌ
・相手ユニットがいない時に、全体BP-2000の効果が発動しないように修正
・相手ユニットの攻撃に反応するように条件を修正
・トリガーゾーンの破壊された対象がインターセプトやトリガーであっても効果が発動するように修正

Fixes #363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カードエフェクトの検出ロジックおよびダメージ対象の処理を調整しました。
  * 特定のカードの能力発動時における判定条件を修正しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->