### PR TITLE
[棘忍のリゼ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/2-3-102.ts
+++ b/src/game-data/effects/cards/2-3-102.ts
@@ -26,11 +26,7 @@ export const effects: CardEffects = {
   // ■綺麗な薔薇には棘がある
   // このユニットがプレイヤーアタックに成功した時、
   // あなたのデッキから1枚ランダムであなたのトリガーゾーンにトリガーカードをセットする
-  checkPlayerAttack: (stack: StackWithCard) => {
-    return stack.source instanceof Unit && stack.source.id === stack.processing.id;
-  },
-
-  onPlayerAttack: async (stack: StackWithCard<Unit>): Promise<void> => {
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     const owner = stack.processing.owner;
 
     // トリガーゾーンに空きがあるか確認


### PR DESCRIPTION
2-3-102　棘忍のリゼ
・プレイヤーアタック成功の判定を自身のみに修正

Fixes #364 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カード効果の攻撃トリガーロジックを改善し、より正確に動作するようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->