### PR TITLE
[人剣のイサミ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/2-3-014.ts
+++ b/src/game-data/effects/cards/2-3-014.ts
@@ -60,6 +60,8 @@ export const effects: CardEffects = {
 
   // When destroyed
   onBreakSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (!EffectHelper.isBreakByEffect(stack)) return;
+
     // Find cost 4 or lower samurai units in trash
     const targets = stack.processing.owner.trash.filter(
       card =>


### PR DESCRIPTION
2-3-014　人剣のイサミ
・自身の破壊時に、それが効果による破壊かをチェックするように修正

Fixes #366 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カード「2-3-014」のエフェクト発動条件を修正しました。エフェクトが原因で破壊される場合のみ、コスト4以下のサムライユニットに対する効果が正常に機能するようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->