### PR TITLE
[鏡合わせの祈り] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-263.ts
+++ b/src/game-data/effects/cards/1-3-263.ts
@@ -22,6 +22,8 @@ export const effects: CardEffects = {
 
   // checkDriveメソッド
   checkDrive: (stack: StackWithCard) => {
+    if (stack.source.id !== stack.processing.owner.id) return false;
+
     const ownerTrash = stack.processing.owner.trash.filter(
       card => card.catalog.cost <= 4 && card.catalog.type === 'unit'
     );


### PR DESCRIPTION
1-3-263　鏡合わせの祈り
・自分のユニットが場に出た時のみ発動するように条件を修正

Fixes #367 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * カード処理のロジックを改善し、妥当性チェックの精度を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->