### PR TITLE
[はにわ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-012.ts
+++ b/src/game-data/effects/cards/1-3-012.ts
@@ -1,39 +1,46 @@
 import { Unit } from '@/package/core/class/card';
-import { Effect, EffectHelper, EffectTemplate, System } from '..';
+import { Effect, EffectHelper, EffectTemplate } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
   // ■富の採掘
-  // このユニットがフィールドに出た時、【機械】ユニットのカードを1枚ランダムで手札に加え、対戦相手のコスト2以下のユニットを1体選ぶ。それの行動権を消費する。
+  // このユニットがフィールドに出た時、【機械】ユニットのカードを1枚ランダムで手札に加え
+  // 対戦相手のコスト2以下のユニットを1体選ぶ。それの行動権を消費する。
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     const owner = stack.processing.owner;
 
-    // 機械ユニットを1枚ランダムで手札に追加
-    await System.show(stack, '富の採掘', '【機械】ユニットを1枚引く');
-    EffectTemplate.reinforcements(stack, owner, {
-      species: '機械',
-      type: ['unit', 'advanced_unit'],
-    });
-
     // 対戦相手のコスト2以下のユニットをフィルタリング
-    const filter = (unit: Unit) =>
-      unit.owner.id === stack.processing.owner.opponent.id && unit.catalog.cost <= 2;
+    const filter = (unit: Unit) => unit.owner.id === owner.opponent.id && unit.catalog.cost <= 2;
 
-    if (EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) {
-      await System.show(stack, '富の採掘', '行動権を消費');
+    await EffectHelper.combine(stack, [
+      // 機械ユニットを1枚ランダムで手札に追加
+      {
+        title: '富の採掘',
+        description: '【機械】ユニットを1枚引く',
+        effect: () =>
+          EffectTemplate.reinforcements(stack, owner, {
+            species: '機械',
+            type: ['unit', 'advanced_unit'],
+          }),
+      },
+      // 行動権を消費
+      {
+        title: '富の採掘',
+        description: '行動権を消費',
+        effect: async () => {
+          const [target] = await EffectHelper.pickUnit(
+            stack,
+            owner,
+            filter,
+            '行動権を消費するユニットを選択'
+          );
 
-      // ユニットを1体選択
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        owner,
-        filter,
-        '行動権を消費するユニットを選択'
-      );
-
-      if (target) {
-        // 行動権を消費
-        Effect.activate(stack, stack.processing, target, false);
-      }
-    }
+          if (target) {
+            Effect.activate(stack, stack.processing, target, false);
+          }
+        },
+        condition: EffectHelper.isUnitSelectable(stack.core, filter, owner),
+      },
+    ]);
   },
 };


### PR DESCRIPTION
1-3-012　はにわ
・EffectHelper.combineを使用して処理を統合

Fixes #354 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **カード調整**
  * カード1-3-012の効果フローを改善しました。機械ユニット獲得と相手ユニット処理がスムーズに実行されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->