### PR TITLE
[原初神ガイア] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-009.ts
+++ b/src/game-data/effects/cards/1-3-009.ts
@@ -8,8 +8,7 @@ export const effects: CardEffects = {
   async onDriveSelf(stack: StackWithCard<Unit>) {
     // 全てのユニットを取得
     const allUnits = stack.core.players
-      .map(p => p.field)
-      .flat()
+      .flatMap(p => p.field)
       .filter(unit => unit.id !== stack.processing.id);
 
     if (allUnits.length > 0) {
@@ -27,7 +26,7 @@ export const effects: CardEffects = {
     const turnPlayer = stack.core.getTurnPlayer();
 
     // 全てのユニットを取得
-    const allUnits = stack.core.players.map(p => p.field).flat();
+    const allUnits = stack.core.players.flatMap(p => p.field);
 
     // 自分のターン開始時のみ発動
     if (owner.id === turnPlayer.id && allUnits.length > 0) {
@@ -45,8 +44,7 @@ export const effects: CardEffects = {
   async onBreakSelf(stack: StackWithCard<Unit>) {
     // 全てのユニットを取得（自身は破壊済なので除外）
     const allUnits = stack.core.players
-      .map(p => p.field)
-      .flat()
+      .flatMap(p => p.field)
       .filter(unit => unit.id !== stack.processing.id);
 
     if (allUnits.length > 0) {


### PR DESCRIPTION
1-3-009　原初神ガイア
・効果対象のユニット存在チェックを追加
（ターン開始時の方は自身が必ず存在しているので不要だとは思うが、念のために追加）

Fixes #356 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 特定のカード効果の処理ロジックを改善し、ユニットが存在しない状況でのエラーを防止しました。
  * カード破壊時の効果適用において、自分自身へのダメージを除外するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->