### PR TITLE
[白虎][玄武][青龍] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-016.ts
+++ b/src/game-data/effects/cards/1-3-016.ts
@@ -21,25 +21,30 @@ export const effects: CardEffects = {
     // ブラック白虎がいるかどうかをチェック
     const hasBlackByakko = hasFourGodCard(stack, 'ブラック白虎');
 
-    // ブラック白虎がいる場合、【四聖獣】ユニットを1枚引く
-    if (hasBlackByakko) {
-      await System.show(
-        stack,
-        '四聖の共鳴',
-        'コスト4のユニットを引く\n【四聖獣】ユニットを1枚引く'
-      );
-      // 四聖獣ユニットを引く（EffectTemplateのreinforcementsを使用）
-      EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '四聖獣' });
-    } else {
-      await System.show(stack, '四聖の共鳴', 'コスト4のユニットを引く');
-    }
-
-    // コスト4のユニットカードをランダムで1枚手札に加える
-    const [card] = EffectHelper.random(
-      stack.processing.owner.deck.filter(card => card.catalog.cost === 4 && card instanceof Unit),
-      1
-    );
-    if (card) Effect.move(stack, stack.processing, card, 'hand');
+    await EffectHelper.combine(stack, [
+      // コスト4のユニットカードをランダムで1枚手札に加える
+      {
+        title: '四聖の共鳴',
+        description: 'コスト4のユニットを引く',
+        effect: () => {
+          const [card] = EffectHelper.random(
+            stack.processing.owner.deck.filter(
+              card => card.catalog.cost === 4 && card instanceof Unit
+            ),
+            1
+          );
+          if (card) Effect.move(stack, stack.processing, card, 'hand');
+        },
+      },
+      // ブラック白虎がいる場合、【四聖獣】ユニットを1枚引く
+      {
+        title: '四聖の共鳴',
+        description: '【四聖獣】ユニットを1枚引く',
+        effect: () =>
+          EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '四聖獣' }),
+        condition: hasBlackByakko,
+      },
+    ]);
   },
 
   // このユニットがブロックした時、ターン終了時までこのユニットのBPを+［あなたのフィールドにいる【四聖獣】ユニット×2000］する。

--- a/src/game-data/effects/cards/1-3-222.ts
+++ b/src/game-data/effects/cards/1-3-222.ts
@@ -13,45 +13,61 @@ export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     // ブラック青龍がいるかどうかをチェック
     const hasBlackSeiryu = hasFourGodCard(stack, 'ブラック青龍');
-    // デッキの上から3枚を取得（存在する場合）
-    const deckTop3 = stack.processing.owner.deck.slice(0, 3);
 
-    // ブラック青龍がいる場合、デッキから3枚見て1枚選んで手札に加えて残りは捨てる
-    if (hasBlackSeiryu && deckTop3.length === 3) {
-      await System.show(
-        stack,
-        '四聖の共鳴',
-        'コスト4のユニットを引く\nデッキから3枚見て1枚選び残りは捨てる'
-      );
-
-      if (deckTop3.length > 0) {
-        // プレイヤーに選択を促す
-        const [choice] = await System.prompt(stack, stack.processing.owner.id, {
-          title: '手札に加えるカードを選択してください',
-          type: 'card',
-          items: deckTop3,
-          count: 1,
-        });
-
-        // 選んだカードを手札に加え、残りを捨札に送る
-        for (const card of deckTop3) {
-          if (card.id === choice) {
-            Effect.move(stack, stack.processing, card, 'hand');
-          } else {
-            Effect.move(stack, stack.processing, card, 'trash');
-          }
-        }
-      }
-    } else {
-      await System.show(stack, '四聖の共鳴', 'コスト4のユニットを引く');
-    }
-
-    // コスト4のユニットカードをランダムで1枚手札に加える
-    const [card] = EffectHelper.random(
-      stack.processing.owner.deck.filter(card => card.catalog.cost === 4 && card instanceof Unit),
-      1
+    // デッキ内のコスト4であるユニット
+    const cost4Units = stack.processing.owner.deck.filter(
+      card => card.catalog.cost === 4 && card instanceof Unit
     );
-    if (card) Effect.move(stack, stack.processing, card, 'hand');
+
+    // デッキの残り枚数を計算する
+    // 現在デッキ枚数 - （デッキにコスト4のユニットがあれば 1、無ければ 0）
+    const countDeck = stack.processing.owner.deck.length - (cost4Units.length > 0 ? 1 : 0);
+
+    // 手札の空き枚数を計算する
+    // ルールでの手札上限値 - 現在手札枚数 - （デッキにコスト4のユニットがあれば 1、無ければ 0）
+    const countHandBlank =
+      stack.core.room.rule.player.max.hand -
+      stack.processing.owner.hand.length -
+      (cost4Units.length > 0 ? 1 : 0);
+
+    await EffectHelper.combine(stack, [
+      // コスト4のユニットカードをランダムで1枚手札に加える
+      {
+        title: '四聖の共鳴',
+        description: 'コスト4のユニットを引く',
+        effect: () => {
+          const [card] = EffectHelper.random(cost4Units, 1);
+          if (card) Effect.move(stack, stack.processing, card, 'hand');
+        },
+      },
+      // ブラック青龍がいる場合、デッキから3枚見て1枚選んで手札に加えて残りは捨てる
+      {
+        title: '四聖の共鳴',
+        description: 'デッキから3枚見て1枚選び残りは捨てる',
+        effect: async () => {
+          // デッキの上から3枚を取得
+          const deckTop3 = stack.processing.owner.deck.slice(0, 3);
+
+          // プレイヤーに選択を促す
+          const [choice] = await System.prompt(stack, stack.processing.owner.id, {
+            title: '手札に加えるカードを選択してください',
+            type: 'card',
+            items: deckTop3,
+            count: 1,
+          });
+
+          // 選んだカードを手札に加え、残りを捨札に送る
+          for (const card of deckTop3) {
+            if (card.id === choice) {
+              Effect.move(stack, stack.processing, card, 'hand');
+            } else {
+              Effect.move(stack, stack.processing, card, 'trash');
+            }
+          }
+        },
+        condition: hasBlackSeiryu && countDeck >= 3 && countHandBlank > 0,
+      },
+    ]);
   },
 
   // このユニットが破壊された時、コスト4のユニットカードを1枚ランダムで手札に加える。


### PR DESCRIPTION
1-3-016　白虎
・EffectHelper.combineを使用し、効果の発動順を修正

1-3-119　玄武
・EffectHelper.combineを使用し、効果の発動順を修正
・効果の発動条件を厳密化
・効果メッセージをブラック玄武と統一

1-3-222　青龍
・EffectHelper.combineを使用し、効果の発動順を修正
・効果の発動条件を厳密化

Fixes #357 
Fixes #386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善・最適化**
  * 複数のゲームカードのエフェクト処理を改善しました。カード効果の実行ロジックがより効率的に統合され、ゲームプレイの流れがスムーズになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->