### PR TITLE
[大魔導士リーナ] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-027.ts
+++ b/src/game-data/effects/cards/1-3-027.ts
@@ -64,8 +64,8 @@ export const effects: CardEffects = {
       '破壊するユニットを選択して下さい'
     );
 
-    if (opponentTarget) Effect.break(stack, stack.processing, opponentTarget, 'effect');
     if (undeadTarget) Effect.break(stack, stack.processing, undeadTarget, 'effect');
+    if (opponentTarget) Effect.break(stack, stack.processing, opponentTarget, 'effect');
   },
 
   onOverclockSelf: async (stack: StackWithCard) => {


### PR DESCRIPTION
1-3-027　大魔導士リーナ
・アタック時の、相手LV2の破壊と、自不死の破壊について、自不死の破壊が先に行われるように修正

Fixes #358 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カード効果の適用順序を調整し、ゲームプレイの一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->