### PR TITLE
[魔導士の館] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-042.ts
+++ b/src/game-data/effects/cards/1-3-042.ts
@@ -15,7 +15,9 @@ export const effects: CardEffects = {
 
   checkBreak: (stack: StackWithCard) => {
     return (
-      stack.target instanceof Unit && stack.target.catalog.species?.includes('魔導士') === true
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.id &&
+      stack.target.catalog.species?.includes('魔導士') === true
     );
   },
 


### PR DESCRIPTION
1-3-042　魔導士の館
・自分の魔導士の破壊でのみ発動するように修正

Fixes #359 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* ブレーク効果の対象条件を修正しました。自分のプレイヤーが所有する魔導士ユニットのみが対象となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->