### PR TITLE
[トリガー・コネクト] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-046.ts
+++ b/src/game-data/effects/cards/1-3-046.ts
@@ -9,10 +9,10 @@ export const effects = {
     const owner = stack.processing.owner;
     const player = stack.target.owner;
 
-    // インターセプト使用者とカード所有者が同じか
+    // トリガーカード使用者が自分か
     const isSamePlayer = owner.id === player.id;
-    // 対象のインターセプトが捨札に存在するか
-    const isOnTrash = player.trash.some(c => c.id === stack.source.id);
+    // 対象のトリガーカードが捨札に存在するか
+    const isOnTrash = player.trash.some(c => c.id === stack.target?.id);
 
     return isSamePlayer && isOnTrash;
   },
@@ -20,11 +20,11 @@ export const effects = {
   onTrigger: async (stack: Stack) => {
     if (!(stack.target instanceof Card)) throw new Error('不正なオブジェクトが指定されました');
 
-    await System.show(stack, 'トリガー・コネクト', '発動したインターセプトを回収');
+    await System.show(stack, 'トリガー・コネクト', '発動したトリガーカードを回収');
     const owner = stack.target.owner;
-    const target = owner.trash.find(c => c.id === stack.source.id);
+    const target = owner.trash.find(c => c.id === stack.target?.id);
 
-    // 捨札から削除
+    // 捨札から回収
     if (target && stack.processing) {
       Effect.move(stack, stack.processing, target, 'hand');
     }


### PR DESCRIPTION
1-3-046　トリガー・コネクト
・墓地チェックの条件を修正
・発動メッセージを「トリガーカードを回収」に修正

Fixes #360 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * トリガーカードの捨札からの回収処理に関するロジックを修正しました。捨札に存在する対象カードの判定がより正確になり、ゲーム中にトリガーカードが期待通りに回収されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->