### PR TITLE
[アムネシア] カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-3-061.ts
+++ b/src/game-data/effects/cards/1-3-061.ts
@@ -28,13 +28,8 @@ export const effects: CardEffects = {
         break;
       }
       case 3: {
-        await System.show(
-          stack,
-          'アムネシア',
-          '【沈黙】を与え破壊する\n捨札からユニットカードを1枚回収'
-        );
+        await System.show(stack, 'アムネシア', '【沈黙】を付与\n捨札からユニットカードを1枚回収');
         Effect.keyword(stack, stack.processing, target, '沈黙');
-        Effect.break(stack, stack.processing, target, 'effect');
         const [salvage] = EffectHelper.random(
           stack.processing.owner.trash.filter(card => card instanceof Unit)
         );


### PR DESCRIPTION
1-3-061　アムネシア
・LV3の効果から相手破壊の効果を削除

Fixes #361 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カード1-3-061の効果が調整されました。対象ユニットへの破壊効果が削除され、【沈黙】の付与とゴミ箱からのユニットカード回収のみが実行されるように変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->