### PR TITLE
[久遠の秘術] 誤記修正

### DIFF
--- a/src/game-data/effects/cards/1-3-063.ts
+++ b/src/game-data/effects/cards/1-3-063.ts
@@ -12,7 +12,7 @@ export const effects: CardEffects = {
     await System.show(
       stack,
       '久遠の秘術',
-      '手札を1枚選んで消滅\n蒼属性のインターセプトカードを2枚引く'
+      '手札を1枚選んで消滅\n青属性のインターセプトカードを2枚引く'
     );
     const [target] = await EffectHelper.selectCard(
       stack,


### PR DESCRIPTION
1-3-063　久遠の秘術
・効果メッセージの記述を「青属性」に修正

Fixes #362 