### PR TITLE
連撃効果を持つユニットを修正

### DIFF
--- a/src/game-data/effects/cards/2-0-022.ts
+++ b/src/game-data/effects/cards/2-0-022.ts
@@ -1,7 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Color } from '@/submodule/suit/constant/color';
+import { GREEN_COMBO } from '../engine/helper/combo';
 
 export const effects: CardEffects = {
   // ■連撃・豪熱の息吹
@@ -9,11 +9,10 @@ export const effects: CardEffects = {
   // 対戦相手のユニットを1体選ぶ。それの基本BPを-5000する。
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     // 連撃条件確認: このターンにコスト2以上の緑属性のカードを使用しているか
-    const hasUsedGreenCardThisTurn = stack.core.histories.some(
-      history =>
-        history.card.id !== stack.processing.id && // このユニット以外
-        history.card.catalog.color === Color.GREEN && // 緑属性
-        history.card.catalog.cost >= 2 // コスト2以上
+    const hasUsedGreenCardThisTurn = EffectHelper.combo(
+      stack.core,
+      stack.processing,
+      GREEN_COMBO(2)
     );
 
     // 対戦相手のユニットが存在するか確認

--- a/src/game-data/effects/cards/2-0-120.ts
+++ b/src/game-data/effects/cards/2-0-120.ts
@@ -1,19 +1,14 @@
 import { Unit } from '@/package/core/class/card';
-import { Effect } from '..';
+import { Effect, EffectHelper } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { System } from '../engine/system';
-import { Color } from '@/submodule/suit/constant/color';
+import { GREEN_COMBO } from '../engine/helper/combo';
 
 export const effects: CardEffects = {
   // ユニット: 連撃・翔翼乱舞
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
     // このターンにコスト2以上の緑属性のカードを使用しているかチェック
-    const usedGreenCards = stack.core.histories.some(
-      history =>
-        history.card.id !== stack.processing.id && // このユニット以外
-        history.card.catalog.color === Color.GREEN && // 緑属性
-        history.card.catalog.cost >= 2 // コスト2以上
-    );
+    const usedGreenCards = EffectHelper.combo(stack.core, stack.processing, GREEN_COMBO(2));
 
     if (usedGreenCards) {
       await System.show(stack, '連撃・翔翼乱舞', '味方全体の基本BP+1000\n敵全体の基本BP-1000');

--- a/src/game-data/effects/cards/PR-086.ts
+++ b/src/game-data/effects/cards/PR-086.ts
@@ -1,8 +1,9 @@
 import type { Card } from '@/package/core/class/card';
 import { Unit } from '@/package/core/class/card';
-import { Effect, EffectTemplate, System } from '..';
+import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { Color } from '@/submodule/suit/constant/color';
+import { GREEN_COMBO } from '../engine/helper/combo';
 
 export const effects: CardEffects = {
   // このユニットがフィールドに出た時、このユニットに【秩序の盾】を付与する。
@@ -11,12 +12,10 @@ export const effects: CardEffects = {
     const self = stack.processing;
 
     // 連撃条件確認: このターンにコスト2以上の緑属性のカードを使用しているか
-    const hasUsedGreenCardThisTurn = stack.core.histories.some(
-      history =>
-        history.card.owner.id === self.owner.id && // あなたのカード
-        history.card.id !== self.id && // このユニット以外
-        history.card.catalog.color === Color.GREEN && // 緑属性
-        history.card.catalog.cost >= 2 // コスト2以上
+    const hasUsedGreenCardThisTurn = EffectHelper.combo(
+      stack.core,
+      stack.processing,
+      GREEN_COMBO(2)
     );
 
     // メッセージ構築と表示


### PR DESCRIPTION
2-0-022　プラウドドラゴン
2-0-120　飛翔のジズ
PR-086　南風のニンリル
・連撃の判定に EffectHelper.combo を使用するように修正

（グラインドビートル、収奪のトリニティは修正済みだったため対象外）

Fixes #298 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ゲーム内部のコンディション評価ロジックを最適化しました。複数のカード効果について、評価メカニズムを改善しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->