### PR TITLE
[原初神ガイア] レビュー指摘反映

### DIFF
--- a/src/game-data/effects/cards/1-3-009.ts
+++ b/src/game-data/effects/cards/1-3-009.ts
@@ -29,7 +29,7 @@ export const effects: CardEffects = {
     const allUnits = stack.core.players.flatMap(p => p.field);
 
     // 自分のターン開始時のみ発動
-    if (owner.id === turnPlayer.id && allUnits.length > 0) {
+    if (owner.id === turnPlayer.id) {
       await System.show(stack, '母なる揺り籠', '全ユニットに3000ダメージ');
 
       // 全てのユニットに3000ダメージを与える
@@ -42,18 +42,14 @@ export const effects: CardEffects = {
   // ■生命の淘汰
   // このユニットが破壊された時、全てのユニットに5000ダメージを与える。
   async onBreakSelf(stack: StackWithCard<Unit>) {
-    // 全てのユニットを取得（自身は破壊済なので除外）
-    const allUnits = stack.core.players
-      .flatMap(p => p.field)
-      .filter(unit => unit.id !== stack.processing.id);
+    // 全てのユニットを取得
+    const allUnits = stack.core.players.flatMap(p => p.field);
 
-    if (allUnits.length > 0) {
-      await System.show(stack, '生命の淘汰', '全ユニットに5000ダメージ');
+    await System.show(stack, '生命の淘汰', '全ユニットに5000ダメージ');
 
-      // 全てのユニットに5000ダメージを与える
-      for (const unit of allUnits) {
-        Effect.damage(stack, stack.processing, unit, 5000);
-      }
+    // 全てのユニットに5000ダメージを与える
+    for (const unit of allUnits) {
+      Effect.damage(stack, stack.processing, unit, 5000);
     }
   },
 };


### PR DESCRIPTION
・自身を含む全体ダメージ系について、対象の存在をチェックしないように修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* カード効果の発動条件を簡素化し、より広い状況で機能するようになりました
* 効果の対象範囲を拡張し、トリガーユニットを含むすべてのユニットが対象となるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->