### PR TITLE
新規カード追加

### DIFF
--- a/src/game-data/effects/cards/1-0-028.ts
+++ b/src/game-data/effects/cards/1-0-028.ts
@@ -1,0 +1,17 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  //このユニットが破壊された時
+  onBreakSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // あなたの捨札にあるユニットカードを1枚ランダムで手札に加える
+    const owner = stack.processing.owner;
+    const trashUnits = owner.trash.filter(card => card instanceof Unit);
+    const [reviveCard] = EffectHelper.random(trashUnits, 1);
+    if (reviveCard) {
+      await System.show(stack, 'リバイブ', 'ユニットカードを回収');
+      Effect.move(stack, stack.processing, reviveCard, 'hand');
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-0-110.ts
+++ b/src/game-data/effects/cards/1-0-110.ts
@@ -1,0 +1,10 @@
+import { Unit } from '@/package/core/class/card';
+import { EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  onPlayerAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(stack, 'インターセプトドロー', 'インターセプトカードを1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['intercept'] });
+  },
+};

--- a/src/game-data/effects/cards/1-1-088.ts
+++ b/src/game-data/effects/cards/1-1-088.ts
@@ -1,0 +1,29 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがフィールドに出た時
+  checkDrive(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+    if (!(stack.target instanceof Unit)) return false;
+    if (stack.target.owner.id !== owner.id) return false;
+
+    // 捨札にトリガーカードがあるか確認
+    const triggerCards = owner.trash.filter(card => card.catalog.type === 'trigger');
+    return triggerCards.length > 0;
+  },
+
+  // あなたの捨札にあるトリガーカードを1枚ランダムで手札に加える
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+    const triggerCards = owner.trash.filter(card => card.catalog.type === 'trigger');
+
+    await System.show(stack, '黄昏の奇術師', 'トリガーカードを回収');
+
+    // ランダムで1枚選んで手札に加える
+    EffectHelper.random(triggerCards, 1).forEach(card => {
+      Effect.move(stack, stack.processing, card, 'hand');
+    });
+  },
+};

--- a/src/game-data/effects/cards/1-2-102.ts
+++ b/src/game-data/effects/cards/1-2-102.ts
@@ -1,0 +1,36 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+// あなたの【不死】ユニットが破壊されるたび、対戦相手の全てのユニットに2000ダメージを与える。
+const effect = async (stack: StackWithCard<Unit>) => {
+  const owner = stack.processing.owner;
+  const opponent = owner.opponent;
+  const brokenUnit = stack.target;
+
+  // 破壊されたのが自分の【不死】ユニットか確認
+  if (
+    !(brokenUnit instanceof Unit) ||
+    brokenUnit.owner.id !== owner.id ||
+    !brokenUnit.catalog.species?.includes('不死')
+  ) {
+    return;
+  }
+
+  // 対戦相手のフィールドにユニットがいるか確認
+  if (opponent.field.length === 0) return;
+
+  await System.show(stack, '怨念爆弾', '敵全体に2000ダメージ');
+  opponent.field.forEach(unit => {
+    Effect.damage(stack, stack.processing, unit, 2000);
+  });
+};
+
+export const effects: CardEffects = {
+  onBreakSelf: effect,
+  onBreak: async (stack: StackWithCard<Unit>): Promise<void> => {
+    if (stack.target instanceof Unit && stack.processing.id !== stack.target.id) {
+      await effect(stack);
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-3-004.ts
+++ b/src/game-data/effects/cards/1-3-004.ts
@@ -1,0 +1,32 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // 戦闘時の効果
+  onBattleSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // このユニットがアタック中かチェック
+    if (stack.target && stack.source.id === stack.processing.id) {
+      // 戦闘中の相手ユニットを特定
+      const opponent = stack.target;
+
+      if (opponent instanceof Unit) {
+        await System.show(stack, '罪炎の魔具', '相手ユニットと同じBPになる');
+        const diff = opponent.currentBP - stack.processing.currentBP;
+        Effect.modifyBP(stack, stack.processing, stack.processing, diff, {
+          event: 'turnEnd',
+          count: 1,
+        });
+      }
+    }
+  },
+
+  // 自身が破壊された時に発動する効果
+  onBreakSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const [target] = EffectHelper.random(stack.processing.owner.opponent.trigger);
+    if (target) {
+      await System.show(stack, '罪と罰', 'トリガーゾーンを1枚破壊');
+      Effect.move(stack, stack.processing, target, 'trash');
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-3-069.ts
+++ b/src/game-data/effects/cards/1-3-069.ts
@@ -1,0 +1,32 @@
+import { Unit, Card } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // 対戦相手の効果によってあなたのユニットがダメージを受けた時
+  checkDamage: (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    return (
+      stack.source instanceof Card &&
+      stack.source.owner.id === opponent.id &&
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id
+    );
+  },
+
+  onDamage: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    await System.show(stack, 'バーンカウンター', 'BP+10000\nカードを1枚引く');
+    // 全てのユニットのBPを+10000
+    owner.field.forEach(unit => {
+      Effect.modifyBP(stack, stack.processing, unit, 10000, {
+        event: 'turnEnd',
+        count: 1,
+      });
+    });
+
+    // カードを1枚引く
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/game-data/effects/cards/2-1-036.ts
+++ b/src/game-data/effects/cards/2-1-036.ts
@@ -1,0 +1,38 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがプレイヤーアタックに成功した時
+  checkPlayerAttack: (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (!(stack.source instanceof Unit)) return false;
+    if (stack.source.owner.id !== owner.id) return false;
+
+    return EffectHelper.isUnitSelectable(stack.core, 'owns', owner) && opponent.field.length > 0;
+  },
+
+  onPlayerAttack: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    await System.show(stack, '秘密兵器', 'ユニットを破壊\n敵全体に[破壊したユニットのBP]ダメージ');
+    // 自分のユニットを1体選択
+    const [selectedUnit] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'owns',
+      '破壊する自分のユニットを選択'
+    );
+
+    const damage = selectedUnit.currentBP;
+    // 選択したユニットを破壊
+    Effect.break(stack, stack.processing, selectedUnit);
+
+    // 破壊したユニットのBP分ダメージ
+    opponent.field.forEach(unit => {
+      Effect.damage(stack, stack.processing, unit, damage);
+    });
+  },
+};


### PR DESCRIPTION
1-0-028 スカルウォーカー
1-0-110 青海のドーリス
1-1-088 黄昏の奇術師
1-2-102 地獄のシャレコウベ
1-3-004 エビルシスター
1-3-069 バーンカウンター
2-1-036 秘密兵器

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複数のカードに新しい効果能力を追加しました。ユニット破壊時の回収、攻撃時の強化発動、トリガーカード回復、敵ユニットへのダメージ伝播、戦闘時のBP調整、ダメージ受信時の強化効果など、ゲームプレイの戦略性を広げる効果が実装されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->