### PR TITLE
新規カード追加

### DIFF
--- a/src/game-data/effects/cards/2-1-103.ts
+++ b/src/game-data/effects/cards/2-1-103.ts
@@ -1,0 +1,41 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  onDrive: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 相手のユニットが出た時のみ処理
+    if (!(stack.target instanceof Unit && stack.target.owner.id === opponent.id)) return;
+
+    if (
+      EffectHelper.isUnitSelectable(stack.core, 'owns', stack.processing.owner) &&
+      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
+    ) {
+      await System.show(
+        stack,
+        '代償の篝火',
+        '自分のユニットに1000ダメージ\n相手のユニットに1000ダメージ'
+      );
+      const [ownTarget] = await EffectHelper.pickUnit(
+        stack,
+        owner,
+        'owns',
+        '1000ダメージを与えるユニットを選択'
+      );
+
+      const [opponentTarget] = await EffectHelper.pickUnit(
+        stack,
+        owner,
+        'opponents',
+        '1000ダメージを与えるユニットを選択'
+      );
+
+      // 選択したユニットに1000ダメージ
+      Effect.damage(stack, stack.processing, ownTarget, 1000);
+      Effect.damage(stack, stack.processing, opponentTarget, 1000);
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-3-221.ts
+++ b/src/game-data/effects/cards/2-3-221.ts
@@ -1,0 +1,45 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+import { Delta } from '@/package/core/class/delta';
+import { PermanentEffect } from '../engine/permanent';
+import { Color } from '@/submodule/suit/constant';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    await System.show(
+      stack,
+      '翠龍の眼光＆秩序の盾',
+      'コスト1のユニットを出せない\n対戦相手の効果によるダメージを受けない'
+    );
+    Effect.keyword(stack, stack.processing, stack.processing, '秩序の盾');
+  },
+
+  // このユニットが破壊された時、あなたの手札の緑属性カードからランダムで1枚のコストを-1する。
+  onBreakSelf: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const greenCards = owner.hand.filter(card => card.catalog.color === Color.GREEN);
+
+    if (greenCards.length > 0) {
+      const [selectedCard] = EffectHelper.random(greenCards, 1);
+      if (selectedCard) {
+        await System.show(stack, '砕かれた翠の輝き', '緑属性カードのコスト-1');
+        Effect.modifyCost(selectedCard, -1);
+      }
+    }
+  },
+
+  // 対戦相手は手札からコスト1のユニットをフィールドに出すことができない。
+  fieldEffect: (stack: StackWithCard<Unit>): void => {
+    PermanentEffect.mount(stack.processing, {
+      targets: ['opponents', 'hand'],
+      effect: (unit, source) => {
+        if (unit instanceof Unit) {
+          unit.delta.push(new Delta({ type: 'banned' }, { source }));
+        }
+      },
+      condition: target => target instanceof Unit && target.catalog.cost === 1,
+      effectCode: '翠龍の眼光',
+    });
+  },
+};

--- a/src/game-data/effects/cards/PR-243.ts
+++ b/src/game-data/effects/cards/PR-243.ts
@@ -1,0 +1,39 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+import { Delta } from '@/package/core/class/delta';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) => {
+    return stack.source.id === stack.processing.owner.opponent.id;
+  },
+
+  onTurnStart: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    await System.show(
+      stack,
+      '時の妖精フォロン',
+      'コスト2以下のユニットを出せない\nジョーカーゲージ-20%\nCP+2\nトリガーカードを1枚引く'
+    );
+
+    // 対戦相手の手札にあるコスト2以下のユニット
+    const bannedUnits = opponent.hand.filter(
+      unit => unit instanceof Unit && unit.catalog.cost <= 2
+    );
+    // ターン終了時までフィールドに出すことができない。
+    bannedUnits.forEach(unit =>
+      unit.delta.push(new Delta({ type: 'banned' }, { event: 'turnEnd', count: 1 }))
+    );
+
+    // ジョーカーゲージを20%減少させる
+    Effect.modifyJokerGauge(stack, stack.processing, owner, -20);
+
+    // CPを+2
+    Effect.modifyCP(stack, stack.processing, owner, 2);
+
+    // トリガーカードを1枚引く
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] });
+  },
+};


### PR DESCRIPTION
・2-1-103 戦線のヘカテー
・2-3-221 エメラルドドラゴン
・PR-243 時の妖精フォロン
(エメドラとフォロンはbanned関数とかが実装されたら修正するかも）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **3枚の新しいカード効果を実装**
  * カード「2-1-103」：ドライブ時に相手のユニット1体と自分のユニット1体に1000ダメージを与える効果を追加
  * カード「2-3-221」：ドライブ時のシールド付与、破壊時の手札コスト軽減、相手のコスト1ユニット使用制限の複数効果を追加
  * カード「PR-243」：ターン開始時に相手の低コストユニット制限、ジョーカーゲージ調整、CP増加、強化効果を発動する効果を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->