### PR TITLE
カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-1-054.ts
+++ b/src/game-data/effects/cards/1-1-054.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
@@ -10,7 +11,7 @@ export const effects: CardEffects = {
   onBreakSelf: async (stack: StackWithCard) => {
     const owner = stack.processing.owner;
     const dragonUnits = owner.hand.filter(
-      card => card.catalog.type === 'unit' && card.catalog.species?.includes('ドラゴン')
+      card => card instanceof Unit && card.catalog.species?.includes('ドラゴン')
     );
 
     if (dragonUnits.length > 0) {

--- a/src/game-data/effects/cards/2-1-031.ts
+++ b/src/game-data/effects/cards/2-1-031.ts
@@ -3,7 +3,7 @@ import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
-  checkAttack: async (stack: StackWithCard) => {
+  checkAttack: (stack: StackWithCard) => {
     return (
       stack.processing.owner.id !== stack.source.id &&
       stack.processing.owner.field.length <= 4 &&

--- a/src/game-data/effects/cards/2-3-021.ts
+++ b/src/game-data/effects/cards/2-3-021.ts
@@ -19,6 +19,7 @@ export const effects: CardEffects = {
   },
 
   onIntercept: async (stack: StackWithCard) => {
+    if (stack.processing.owner.id !== stack.source.id) return;
     const [target] = EffectHelper.random(stack.processing.owner.opponent.trigger);
     if (stack.option?.type === 'lv' && stack.option.value >= 2 && target) {
       await System.show(stack, 'ネオンアロー', 'トリガーゾーンを1枚破壊');

--- a/src/game-data/effects/cards/2-3-049.ts
+++ b/src/game-data/effects/cards/2-3-049.ts
@@ -5,7 +5,8 @@ export const effects: CardEffects = {
   checkDrive: (stack: StackWithCard) => {
     return (
       EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner) &&
-      (stack.processing.owner.purple ?? 0) >= 3
+      (stack.processing.owner.purple ?? 0) >= 3 &&
+      stack.processing.owner.id === stack.source.id
     );
   },
 

--- a/src/game-data/effects/cards/PR-021.ts
+++ b/src/game-data/effects/cards/PR-021.ts
@@ -17,6 +17,6 @@ export const effects: CardEffects = {
     });
 
     // 捨札に送られる代わりに手札に戻る
-    Effect.move(stack, stack.processing, stack.processing, 'hand');
+    Effect.bounce(stack, stack.processing, stack.processing, 'hand');
   },
 };

--- a/src/game-data/effects/cards/PR-227.ts
+++ b/src/game-data/effects/cards/PR-227.ts
@@ -11,7 +11,7 @@ export const effects: CardEffects = {
   // 実際の効果本体
   // 関数名に self は付かない
   onDrive: async (stack: StackWithCard): Promise<void> => {
-    await System.show(stack, 'テトラクトュス', 'コスト7以上のユニットを2️枚引く');
+    await System.show(stack, 'テトラクトュス', 'コスト7以上のユニットを2枚引く');
     EffectHelper.random(
       stack.processing.owner.deck.filter(card => card instanceof Unit && card.catalog.cost >= 7),
       2


### PR DESCRIPTION
1-1-054　ギャウルス
・破壊時のコストダウン対象に進化ユニットが含まれるように修正

2-1-031　レトロゲーム
・使用条件チェック関数の async を削除

2-3-021　乱撃のテトラ
・自分のインターセプト使用時のみ発動するように修正

2-3-049　シャドーウィドウ
・自分の召喚時のみ使用できるように修正

RP-021　フェニックス・ニケ
・複製されたフェニックス・ニケが破壊された時に、bounceを適用するように修正

PR-227　テトラクテュス
・効果メッセージの”2”の文字を修正

Fixed #437 
Fixed #438
Fixed #439
Fixed #440
Fixed #441 
Fixed #442 
