### PR TITLE
2-2-126.tsの修正

### DIFF
--- a/src/game-data/effects/cards/2-2-126.ts
+++ b/src/game-data/effects/cards/2-2-126.ts
@@ -4,7 +4,7 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard): Promise<void> => {
     if (stack.processing.owner.trigger.length > 0) {
-      await System.show(stack, 'GO！GO！アルカナパレード♪　', '紫ゲージ+[トリガーゾーンの枚数×1]');
+      await System.show(stack, 'GO!GO!アルカナパレード♪', '紫ゲージ+[トリガーゾーンの枚数×1]');
       await Effect.modifyPurple(
         stack,
         stack.processing,
@@ -15,6 +15,8 @@ export const effects: CardEffects = {
   },
 
   onTurnEnd: async (stack: StackWithCard): Promise<void> => {
+    if (stack.processing.owner.id !== stack.core.getTurnPlayer().id) return;
+
     const intercept = stack.processing.owner.deck.filter(card => card.catalog.type === 'intercept');
     if (
       intercept.length > 0 &&


### PR DESCRIPTION
2-2-126 遊魔戦姫プルソン
相手のターン終了時にも効果が発動していたのを修正　fixes #446 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **バグ修正**
  * カード2-2-126の表示メッセージを更新しました。
  * ターン終了時の処理でターン所有者の確認ロジックを改善し、正確な動作を保証するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->