### PR TITLE
離脱確定中のユニットを破壊してしまう不具合を修正

### DIFF
--- a/src/game-data/effects/engine/effect/damage.ts
+++ b/src/game-data/effects/engine/effect/damage.ts
@@ -82,7 +82,7 @@ export function effectDamage(
     stack.core.room.soundEffect('damage');
   }
 
-  if (target.currentBP <= 0) {
+  if (target.currentBP <= 0 && !target.leaving) {
     effectBreak(stack, source, target, 'damage');
     return true;
   }

--- a/src/package/core/operations/card-operations.ts
+++ b/src/package/core/operations/card-operations.ts
@@ -126,7 +126,7 @@ export function fieldEffectUnmount(core: Core, target: Unit, stack: Stack) {
     .flatMap(player => player.field)
     .forEach(unit => {
       unmount(unit);
-      if (unit.currentBP <= 0 && unit.leaving) Effect.break(stack, unit, unit, 'system'); // システムによってユニットが自壊した扱いにする
+      if (unit.currentBP <= 0 && !unit.leaving) Effect.break(stack, unit, unit, 'system'); // システムによってユニットが自壊した扱いにする
     });
 
   // 非フィールド


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* ユニットのHP(BP)が0以下になった際のエフェクト発動タイミングを修正しました。フィールドを去る最中のユニットに対する不正なエフェクト処理を防止し、ゲームの挙動をより正確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->