### PR TITLE
カード効果修正

### DIFF
--- a/src/game-data/effects/cards/1-4-305.ts
+++ b/src/game-data/effects/cards/1-4-305.ts
@@ -5,8 +5,32 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   // このユニットがアタックした時
   onAttackSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, '魅入られし従者', '【道化師】を1枚引く');
-    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '道化師' });
+    await EffectHelper.combine(stack, [
+      {
+        title: '狂姫の闊歩',
+        description: '【防御禁止】を与える',
+        effect: async () => {
+          const [target] = await EffectHelper.pickUnit(
+            stack,
+            stack.processing.owner,
+            'opponents',
+            '【防御禁止】を与えるユニットを選択して下さい',
+            1
+          );
+          Effect.keyword(stack, stack.processing, target, '防御禁止', {
+            event: 'turnEnd',
+            count: 1,
+          });
+        },
+        condition: EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
+      },
+      {
+        title: '魅入られし従者',
+        description: '【道化師】を1枚引く',
+        effect: () =>
+          EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '道化師' }),
+      },
+    ]);
   },
 
   // あなたの【道化師】ユニットがアタックした時
@@ -14,6 +38,7 @@ export const effects: CardEffects = {
     if (
       !(stack.target instanceof Unit) ||
       stack.target.owner.id !== stack.processing.owner.id ||
+      stack.target.id === stack.processing.id ||
       !stack.target.catalog.species?.includes('道化師') ||
       !EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
     )


### PR DESCRIPTION
1-4-305　クラウンクイーン
・自身のアタック効果と道化師のアタック効果を同時に処理するように修正

2-0-104　ビッグマシン
・【貫通】付与の基準を基本BPではなく現在BPに修正
・CIP時に自身の効果が優先的に発動するように修正

Fixes #466
Fixes #471 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カード1-4-305：攻撃時に防御禁止状態の付与または魔化師ユニット生成から選択可能な新オプションを追加
  * カード2-0-104：マシン・バースト発動時に敵ユニットを選択して2000ダメージを与える新能力を追加

* **バグ修正**
  * ターゲット選択時の検証ロジックを強化し、無効な選択を防止

<!-- end of auto-generated comment: release notes by coderabbit.ai -->