### PR TITLE
狂戦士の保有をアタック時に調べる

### DIFF
--- a/src/package/core/operations/game-flow.ts
+++ b/src/package/core/operations/game-flow.ts
@@ -310,16 +310,15 @@ export async function turnChange(
   await resolveStack(core);
 
   // 狂戦士 アタックさせる
-  for (const unit of core
-    .getTurnPlayer()
-    .field.filter(
-      unit =>
-        unit.hasKeyword('狂戦士') &&
-        !unit.hasKeyword('攻撃禁止') &&
-        !unit.hasKeyword('行動制限') &&
-        unit.active
-    )) {
-    await attack(core, unit);
+  const field = [...core.getTurnPlayer().field];
+  for (const unit of field) {
+    if (
+      unit.hasKeyword('狂戦士') &&
+      !unit.hasKeyword('行動制限') &&
+      !unit.hasKeyword('攻撃禁止') &&
+      unit.active
+    )
+      await attack(core, unit);
   }
 
   // defrost


### PR DESCRIPTION
[システム]: 狂戦士の自動アタックが止まらない
Fixes #481