### PR TITLE
新規カード追加

### DIFF
--- a/src/game-data/effects/cards/1-1-048.ts
+++ b/src/game-data/effects/cards/1-1-048.ts
@@ -1,0 +1,52 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // このユニットがフィールドに出た時
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const self = stack.processing;
+    const opponent = self.owner.opponent;
+    const opponentUnits = opponent.field;
+
+    await EffectHelper.combine(stack, [
+      {
+        title: '不動の呪詛',
+        description: '敵全体に【呪縛】を与える',
+        effect: () => {
+          opponentUnits.forEach(unit => Effect.keyword(stack, self, unit, '呪縛'));
+        },
+        condition: opponentUnits.length > 0,
+      },
+      {
+        title: '破壊効果耐性',
+        description: '対戦相手の効果によって破壊されない',
+        effect: () => Effect.keyword(stack, self, self, '破壊効果耐性'),
+      },
+    ]);
+  },
+
+  // 対戦相手のターン開始時
+  onTurnStart: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    // 対戦相手のターン時のみ発動
+    if (stack.source.id !== opponent.id) return;
+
+    // 対戦相手のユニットが存在するか確認
+    if (EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)) {
+      await System.show(stack, '守神の覇気', '行動権を消費');
+
+      // 対象を1体選択
+      const [target] = await EffectHelper.pickUnit(
+        stack,
+        owner,
+        'opponents',
+        '行動権を消費するユニットを選択'
+      );
+
+      // 行動権を消費
+      Effect.activate(stack, stack.processing, target, false);
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-4-034.ts
+++ b/src/game-data/effects/cards/1-4-034.ts
@@ -1,0 +1,41 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, EffectTemplate } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがフィールドに出た時
+  checkDrive: (stack: StackWithCard) => {
+    return stack.target instanceof Unit && stack.processing.owner.id === stack.target.owner.id;
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+    if (!(stack.target instanceof Unit)) return;
+
+    const isGiantUnit = stack.target.catalog.species?.includes('巨人');
+    const giantUnits = owner.field.filter(unit => unit.catalog.species?.includes('巨人'));
+
+    await EffectHelper.combine(stack, [
+      // 【巨人】ユニットがフィールドに出た時
+      // あなたの【巨人】ユニットの基本BPを+2000する
+      {
+        title: '巨人の集落',
+        description: '【巨人】ユニットの基本BP+2000',
+        effect: () => {
+          giantUnits.forEach(unit => {
+            Effect.modifyBP(stack, stack.processing, unit, 2000, { isBaseBP: true });
+          });
+        },
+        condition: isGiantUnit && giantUnits.length > 0,
+      },
+      // 【巨人】ユニット以外のユニットがフィールドに出た時
+      // 【巨人】ユニットのカードを1枚ランダムで手札に加える。
+      {
+        title: '巨人の集落',
+        description: '【巨人】を1枚引く',
+        effect: () => EffectTemplate.reinforcements(stack, owner, { species: '巨人' }),
+        condition: !isGiantUnit,
+      },
+    ]);
+  },
+};

--- a/src/game-data/effects/cards/1-4-317.ts
+++ b/src/game-data/effects/cards/1-4-317.ts
@@ -1,0 +1,24 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // このユニットがプレイヤーアタックに成功した時
+  onPlayerAttackSelf: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    // 対戦相手よりあなたのライフが少ない場合
+    if (owner.life.current < opponent.life.current) {
+      // 対戦相手に追加で1ライフダメージを与える
+      await System.show(stack, '土壇場の奮起', '1ライフダメージ');
+      Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -1);
+    }
+  },
+
+  // このユニットがオーバークロックした時
+  onOverclockSelf: async (stack: StackWithCard<Unit>) => {
+    // あなたのCPを+2する
+    await System.show(stack, '大地の恩寵', 'CP+2');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, 2);
+  },
+};

--- a/src/game-data/effects/cards/2-1-127.ts
+++ b/src/game-data/effects/cards/2-1-127.ts
@@ -1,0 +1,33 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectTemplate, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットが戦闘によって破壊された時
+  checkBreak(stack: StackWithCard): boolean {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (!(stack.target instanceof Unit)) return false;
+    if (!(stack.source instanceof Unit)) return false;
+
+    return (
+      stack.target.owner.id === owner.id &&
+      stack.option?.type === 'break' &&
+      stack.option.cause === 'battle' &&
+      opponent.field.some(unit => unit.id === stack.source.id)
+    );
+  },
+
+  onBreak: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (!(stack.source instanceof Unit)) return;
+
+    // 戦闘中の相手ユニットを破壊する
+    await System.show(stack, '道連れ', '戦闘中の相手ユニットを破壊\n相手はカードを1枚引く');
+    Effect.break(stack, stack.processing, stack.source);
+
+    // 対戦相手はカードを1枚引く
+    EffectTemplate.draw(opponent, stack.core);
+  },
+};

--- a/src/game-data/effects/cards/2-1-129.ts
+++ b/src/game-data/effects/cards/2-1-129.ts
@@ -1,0 +1,45 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットが戦闘した時、そのユニットが戦闘中の相手ユニットよりBPが低い場合
+  checkBattle: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+
+    // 戦闘中の自ユニットを特定
+    const ownUnit = [stack.source, stack.target].find(
+      (object): object is Unit => object instanceof Unit && object.owner.id === owner.id
+    );
+    // 戦闘中の相手ユニットを特定
+    const opponentUnit = [stack.source, stack.target].find(
+      (object): object is Unit => object instanceof Unit && object.owner.id !== owner.id
+    );
+    // ユニットが存在し、フィールドにまだいる場合のみ発動
+    // 自ユニットが相手ユニットよりBPが低い場合
+    return (
+      !!ownUnit &&
+      !!opponentUnit &&
+      ownUnit.currentBP < opponentUnit.currentBP &&
+      owner.field.some(unit => unit.id === ownUnit.id)
+    );
+  },
+
+  // 戦闘終了時までそれに【不滅】を与える
+  onBattle: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+
+    // 戦闘中の自ユニットを特定
+    const [target] = [stack.source, stack.target].filter(
+      (object): object is Unit => object instanceof Unit && object.owner.id === owner.id
+    );
+
+    if (!target) return;
+
+    await System.show(stack, 'ハニートラップ', '【不滅】を付与');
+    Effect.keyword(stack, stack.processing, target, '不滅', {
+      event: 'turnEnd',
+      count: 1,
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-1-138.ts
+++ b/src/game-data/effects/cards/2-1-138.ts
@@ -1,0 +1,29 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  // あなたのユニットがブロックした時、あなたのフィールドにユニットが4体以下の場合
+  checkBlock: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+
+    return (
+      stack.target instanceof Unit && stack.target.owner.id === owner.id && owner.field.length <= 4
+    );
+  },
+
+  // それをあなたのフィールドに【複製】し、【加護】を与える
+  onBlock: async (stack: StackWithCard<Unit>) => {
+    const owner = stack.processing.owner;
+    if (!(stack.target instanceof Unit)) return;
+
+    await System.show(stack, '聖なる法具', '【複製】して【加護】を付与');
+
+    // 複製する
+    const clone = await Effect.clone(stack, stack.processing, stack.target, owner);
+    // 複製したユニットに加護を付与
+    if (clone) {
+      Effect.keyword(stack, stack.processing, clone, '加護');
+    }
+  },
+};

--- a/src/game-data/effects/cards/PR-158.ts
+++ b/src/game-data/effects/cards/PR-158.ts
@@ -1,0 +1,29 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがアタックした時
+  checkAttack: (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    if (opponent.field.length === 0) return false;
+
+    //自プレイヤーが攻撃宣言した時のみ発動可能
+    return stack.source.id === owner.id;
+  },
+
+  onAttack: async (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    await System.show(
+      stack,
+      'エレクトリックファング',
+      '敵全体の行動権を消費\n[対戦相手のユニット数×1]ライフダメージ'
+    );
+
+    opponent.field.forEach(unit => Effect.activate(stack, stack.processing, unit, false));
+    // ライフダメージを受ける
+    const damage = opponent.field.length * -1;
+    Effect.modifyLife(stack, stack.processing, owner, damage);
+  },
+};

--- a/src/game-data/effects/cards/PR-175.ts
+++ b/src/game-data/effects/cards/PR-175.ts
@@ -1,0 +1,31 @@
+import { Intercept } from '@/package/core/class/card';
+import { Effect, EffectTemplate, EffectHelper } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのターン終了時、あなたの紫ゲージが3以上の場合
+  checkTurnEnd: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+    return stack.source.id === owner.id && (owner.purple ?? 0) >= 3;
+  },
+
+  // あなたはカードを1枚引く
+  // このインターセプトカードを5回使用した時、対戦相手に1ライフダメージを与える
+  onTurnEnd: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    await EffectHelper.combine(stack, [
+      {
+        title: 'オークション',
+        description: 'カードを1枚引く',
+        effect: () => EffectTemplate.draw(owner, stack.core),
+      },
+      {
+        title: 'オークション',
+        description: '1ライフダメージ',
+        effect: () => Effect.modifyLife(stack, stack.processing, opponent, -1),
+        condition: stack.processing instanceof Intercept && stack.processing.remain === 0,
+      },
+    ]);
+  },
+};


### PR DESCRIPTION
1-1-048 守神・不動明王
1-4-034 巨人の集落
1-4-317 オオヤマツミ
2-1-127 道連れ
2-1-129 ハニートラップ
2-1-138 聖なる法具
PR-158 エレエレクトリックファング
PR-175 オークション

Fixes #485 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 8種類の新しいカードを追加しました。各カードは固有の効果を備えており、ドライブ時、ターン開始時、攻撃時、バトル時、ブロック時などのタイミングで特別な能力を発動します。新たな戦略の幅が広がります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->