### PR TITLE
新規カード追加

### DIFF
--- a/src/game-data/effects/cards/1-3-043.ts
+++ b/src/game-data/effects/cards/1-3-043.ts
@@ -1,0 +1,60 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+import { Color } from '@/submodule/suit/constant/color';
+
+export const effects: CardEffects = {
+  // あなたのユニットがフィールドに出た時
+  checkDrive: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+    return (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id &&
+      owner.field.some(unit => unit.id === stack.target?.id)
+    );
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    if (!(stack.target instanceof Unit)) return;
+
+    // 属性に応じた以下の効果を与える
+    switch (stack.target.catalog.color) {
+      case Color.RED: {
+        await System.show(stack, '虹色のキャンバス', '【不屈】を付与\n基本BP+1000');
+        Effect.keyword(stack, stack.processing, stack.target, '不屈');
+        break;
+      }
+      case Color.YELLOW: {
+        await System.show(stack, '虹色のキャンバス', '【貫通】を付与\n基本BP+1000');
+        Effect.keyword(stack, stack.processing, stack.target, '貫通');
+        break;
+      }
+      case Color.BLUE: {
+        await System.show(stack, '虹色のキャンバス', '【スピードムーブ】を付与\n基本BP+1000');
+        Effect.speedMove(stack, stack.target);
+        break;
+      }
+      case Color.GREEN: {
+        await System.show(stack, '虹色のキャンバス', '【無我の境地】を付与\n基本BP+1000');
+        Effect.keyword(stack, stack.processing, stack.target, '無我の境地');
+        break;
+      }
+      case Color.PURPLE: {
+        await System.show(
+          stack,
+          '虹色のキャンバス',
+          '【次元干渉／コスト3】を付与\n紫ゲージ+1\n基本BP+1000'
+        );
+        Effect.keyword(stack, stack.processing, stack.target, '次元干渉', { cost: 3 });
+        break;
+      }
+    }
+    // 基本BPを+1000する
+    Effect.modifyBP(stack, stack.processing, stack.target, 1000, { isBaseBP: true });
+
+    // 紫属性の場合は追加であなたの紫ゲージを+1する
+    if (stack.target.catalog.color === Color.PURPLE) {
+      await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-3-124.ts
+++ b/src/game-data/effects/cards/1-3-124.ts
@@ -1,0 +1,26 @@
+// ■ドクターラボ\nあなたの【機械】ユニットがフィールドに出た時、それの基本BPを+1000し、【加護】を与える。
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたの【機械】ユニットがフィールドに出た時
+  checkDrive: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+    return (
+      stack.target instanceof Unit &&
+      stack.target.owner.id === owner.id &&
+      !!stack.target.catalog.species?.includes('機械') &&
+      owner.field.some(unit => unit.id === stack.target?.id)
+    );
+  },
+
+  onDrive: async (stack: StackWithCard): Promise<void> => {
+    if (!(stack.target instanceof Unit)) return;
+    await System.show(stack, 'ドクターラボ', '基本BP+1000\n【加護】を付与');
+
+    // それの基本BPを+1000し、【加護】を与える
+    Effect.modifyBP(stack, stack.processing, stack.target, 1000, { isBaseBP: true });
+    Effect.keyword(stack, stack.processing, stack.target, '加護');
+  },
+};

--- a/src/game-data/effects/cards/1-4-014.ts
+++ b/src/game-data/effects/cards/1-4-014.ts
@@ -1,0 +1,50 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+import { Color } from '@/submodule/suit/constant/color';
+
+export const effects: CardEffects = {
+  // このユニットがフィールドに出た時、あなたのフィールドに［青／緑］属性のユニットがいる場合、それぞれ以下の効果が発動する。
+  // ●［青］対戦相手のレベル2以上のユニットを1体選ぶ。それを破壊する。
+  // ●［緑］このユニットの基本BPを+3000する。
+  onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
+    const self = stack.processing;
+    const owner = self.owner;
+
+    // フィールドに青属性のユニットがいるかチェック
+    const hasBlueUnit = owner.field.some(unit => unit.catalog.color === Color.BLUE);
+
+    // フィールドに緑属性のユニットがいるかチェック
+    const hasGreenUnit = owner.field.some(unit => unit.catalog.color === Color.GREEN);
+
+    // 青属性の効果：選択可能なユニットがいるかチェック
+    const filter = (unit: Unit) => unit.owner.id === owner.opponent.id && unit.lv >= 2;
+    const canSelectOpponent =
+      hasBlueUnit && EffectHelper.isUnitSelectable(stack.core, filter, owner);
+
+    await EffectHelper.combine(stack, [
+      // 青属性の効果
+      {
+        title: 'エレメント・ジェミニ',
+        description: 'レベル2以上のユニットを1体破壊',
+        effect: async () => {
+          const [target] = await EffectHelper.pickUnit(
+            stack,
+            owner,
+            filter,
+            '破壊するユニットを選択'
+          );
+          Effect.break(stack, self, target);
+        },
+        condition: canSelectOpponent,
+      },
+      // 緑属性の効果
+      {
+        title: 'エレメント・ジェミニ',
+        description: '基本BP+3000',
+        effect: () => Effect.modifyBP(stack, self, self, 3000, { isBaseBP: true }),
+        condition: hasGreenUnit,
+      },
+    ]);
+  },
+};

--- a/src/game-data/effects/cards/2-0-349.ts
+++ b/src/game-data/effects/cards/2-0-349.ts
@@ -1,0 +1,57 @@
+// ■タイタンの撃砕
+// あなたのユニットがアタックした時、対戦相手のコスト3以下のユニットを1体選ぶ。それの行動権を消費する。
+// あなたのターン開始時、対戦相手のユニットを1体選ぶ。それに【呪縛】を与える。
+import { Unit } from '@/package/core/class/card';
+import { Effect, EffectHelper, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  // あなたのユニットがアタックした時
+  checkAttack: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 対戦相手のコスト3以下のユニットが存在する
+    const filter = (unit: Unit) => unit.owner.id === opponent.id && unit.catalog.cost <= 3;
+
+    return owner.id === stack.source.id && EffectHelper.isUnitSelectable(stack.core, filter, owner);
+  },
+
+  onAttack: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    const filter = (unit: Unit) => unit.owner.id === opponent.id && unit.catalog.cost <= 3;
+
+    await System.show(stack, 'タイタンの撃砕', 'コスト3以下のユニットの行動権を消費');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      filter,
+      '行動権を消費するユニットを選択'
+    );
+    Effect.activate(stack, stack.processing, target, false);
+  },
+
+  // あなたのターン開始時
+  checkTurnStart: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+
+    return (
+      owner.id === stack.source.id && EffectHelper.isUnitSelectable(stack.core, 'opponents', owner)
+    );
+  },
+
+  onTurnStart: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    await System.show(stack, 'タイタンの撃砕', '【呪縛】を付与');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'opponents',
+      '【呪縛】を付与するユニットを選択'
+    );
+    Effect.keyword(stack, stack.processing, target, '呪縛');
+  },
+};

--- a/src/game-data/effects/cards/PR-106.ts
+++ b/src/game-data/effects/cards/PR-106.ts
@@ -1,0 +1,37 @@
+import { Unit } from '@/package/core/class/card';
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  checkBattle: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    // 戦闘中の自ユニットを特定
+    const ownUnit = [stack.source, stack.target].find(
+      (object): object is Unit => object instanceof Unit && object.owner.id === owner.id
+    );
+
+    // ユニットが存在し、フィールドにまだいる場合のみ発動
+    return (
+      !!ownUnit && owner.field.some(unit => unit.id === ownUnit.id) && opponent.field.length > 0
+    );
+  },
+
+  onBattle: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+
+    // 戦闘中の自ユニットを特定
+    const [target] = [stack.source, stack.target].filter(
+      (object): object is Unit => object instanceof Unit && object.owner.id === owner.id
+    );
+
+    if (!target) return;
+
+    await System.show(stack, '蜀漢の英雄・趙雲', 'BP+4000\n敵全体の基本BP+1000');
+    Effect.modifyBP(stack, stack.processing, target, 4000, { event: 'turnEnd', count: 1 });
+    owner.opponent.field.forEach(unit =>
+      Effect.modifyBP(stack, stack.processing, unit, 1000, { isBaseBP: true })
+    );
+  },
+};

--- a/src/game-data/effects/cards/PR-113.ts
+++ b/src/game-data/effects/cards/PR-113.ts
@@ -1,0 +1,39 @@
+import { Effect, System } from '..';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  checkAttack: (stack: StackWithCard): boolean => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    const isOwnerAttack = owner.id === stack.source.id;
+    const isOpponentAttack = opponent.id === stack.source.id;
+    const hasCost4Over = opponent.field.some(unit => unit.catalog.cost >= 4);
+    const hasCost3Over = opponent.field.some(unit => unit.catalog.cost >= 3);
+
+    // あなたのユニットがアタックした時、対戦相手のコスト4以上のユニットが存在する
+    // 対戦相手のユニットがアタックした時、対戦相手のコスト3以上のユニットが存在する
+    return (isOwnerAttack && hasCost4Over) || (isOpponentAttack && hasCost3Over);
+  },
+
+  onAttack: async (stack: StackWithCard): Promise<void> => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
+    const isOwnerAttack = owner.id === stack.source.id;
+    const isOpponentAttack = opponent.id === stack.source.id;
+
+    // あなたのユニットがアタックした時
+    if (isOwnerAttack) {
+      await System.show(stack, 'ホーリーサイクロン', 'コスト4以上のユニットの行動権を消費');
+      const cost4OverUnits = opponent.field.filter(unit => unit.catalog.cost >= 4);
+      cost4OverUnits.forEach(unit => Effect.activate(stack, stack.processing, unit, false));
+    }
+    // 対戦相手のユニットがアタックした時
+    if (isOpponentAttack) {
+      await System.show(stack, 'ホーリーサイクロン', 'コスト3以上のユニットの行動権を消費');
+      const cost3OverUnits = opponent.field.filter(unit => unit.catalog.cost >= 3);
+      cost3OverUnits.forEach(unit => Effect.activate(stack, stack.processing, unit, false));
+    }
+  },
+};


### PR DESCRIPTION
1-3-043 虹色キャンパス
1-3-124 ドクターラボ
1-4-014 相克のジェミニ
2-0-349 タイタンの撃砕
PR-106 蜀漢の英雄・趙雲
PR-113 ホーリーサイクロン

Fixes #500 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* 複数の新しいカード効果を追加しました：
  * 色に応じた条件付きバフ効果
  * 機械ユニットへの保護キーワード付与
  * フィールドの構成に基づく条件付き効果（ユニット破壊・攻撃力上昇）
  * ターン開始時と攻撃時の複合トリガー効果
  * 戦闘中の攻撃力強化効果
  * 対戦相手ユニットの行動消費効果

<!-- end of auto-generated comment: release notes by coderabbit.ai -->