### PR TITLE
カードを追加

### DIFF
--- a/src/game-data/effects/cards/1-0-008.ts
+++ b/src/game-data/effects/cards/1-0-008.ts
@@ -6,6 +6,8 @@ import type { Unit } from '@/package/core/class/card';
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
     await System.show(stack, '聖女の加護', 'ブロックされない');
-    Effect.keyword(stack, stack.processing, stack.processing, '次元干渉', { cost: 0 });
+    Effect.keyword(stack, stack.processing, stack.processing, '次元干渉', {
+      condition: () => true,
+    });
   },
 };

--- a/src/game-data/effects/cards/1-0-052.ts
+++ b/src/game-data/effects/cards/1-0-052.ts
@@ -1,0 +1,24 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(
+      stack,
+      '貫通＆不屈',
+      'ブロックを貫通してプレイヤーにダメージを与える\nターン終了時に行動権を回復'
+    );
+    Effect.keyword(stack, stack.processing, stack.processing, '不屈');
+    Effect.keyword(stack, stack.processing, stack.processing, '貫通');
+  },
+
+  onOverclockSelf: async (stack: StackWithCard<Unit>) => {
+    if (stack.processing.owner.opponent.field.length === 0) return;
+    await System.show(stack, 'オーラブレード', '敵全体の基本BP-3000');
+    stack.processing.owner.opponent.field.forEach(unit =>
+      Effect.modifyBP(stack, stack.processing, unit, -3000, { isBaseBP: true })
+    );
+  },
+};

--- a/src/game-data/effects/cards/1-0-056.ts
+++ b/src/game-data/effects/cards/1-0-056.ts
@@ -1,0 +1,13 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBreak: (stack: StackWithCard) =>
+    stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id,
+  onBreak: async (stack: StackWithCard) => {
+    await System.show(stack, '不穏な霧', 'CP+2');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, 2);
+  },
+};

--- a/src/game-data/effects/cards/1-0-136.ts
+++ b/src/game-data/effects/cards/1-0-136.ts
@@ -1,0 +1,16 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.processing.owner.id === stack.source.id &&
+    stack.processing.owner.opponent.hand.length > 0,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '迷子', '手札を1枚破壊');
+    EffectHelper.random(stack.processing.owner.opponent.hand).forEach(card =>
+      Effect.break(stack, stack.processing, card)
+    );
+  },
+};

--- a/src/game-data/effects/cards/1-0-136.ts
+++ b/src/game-data/effects/cards/1-0-136.ts
@@ -9,8 +9,8 @@ export const effects: CardEffects = {
     stack.processing.owner.opponent.hand.length > 0,
   onDrive: async (stack: StackWithCard) => {
     await System.show(stack, '迷子', '手札を1枚破壊');
-    EffectHelper.random(stack.processing.owner.opponent.hand).forEach(card =>
-      Effect.break(stack, stack.processing, card)
-    );
+    EffectHelper.random(stack.processing.owner.opponent.hand).forEach(card => {
+      Effect.break(stack, stack.processing, card);
+    });
   },
 };

--- a/src/game-data/effects/cards/1-1-086.ts
+++ b/src/game-data/effects/cards/1-1-086.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(stack, '不屈', 'ターン終了時に行動権を回復');
+    Effect.keyword(stack, stack.processing, stack.processing, '不屈');
+  },
+
+  onTurnStart: async (stack: StackWithCard<Unit>) => {
+    if (stack.processing.owner.id !== stack.source.id) return;
+    await System.show(stack, 'グロウアップ', '基本BP+1000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, 1000, { isBaseBP: true });
+  },
+
+  onBlockSelf: async (stack: StackWithCard) => {
+    await System.show(stack, 'オーバーフロー', 'CP-3');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner.opponent, -3);
+  },
+};

--- a/src/game-data/effects/cards/1-1-098.ts
+++ b/src/game-data/effects/cards/1-1-098.ts
@@ -1,0 +1,21 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkAttack: (stack: StackWithCard) =>
+    stack.target instanceof Unit &&
+    stack.target.owner.id === stack.processing.owner.id &&
+    stack.target.owner.field.some(unit => unit.id === stack.target?.id),
+  onAttack: async (stack: StackWithCard) => {
+    await System.show(stack, '浮遊術', 'ブロックされない');
+    if (stack.target instanceof Unit) {
+      Effect.keyword(stack, stack.processing, stack.target, '次元干渉', {
+        condition: () => true,
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-2-086.ts
+++ b/src/game-data/effects/cards/1-2-086.ts
@@ -1,0 +1,30 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit, type Card } from '@/package/core/class/card';
+import { Color } from '@/submodule/suit/constant';
+
+const getYellowFilter = (self: Card) => (unit: Unit) =>
+  unit.catalog.color === Color.YELLOW && unit.owner.id === self.owner.id;
+
+export const effect: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    EffectHelper.isUnitSelectable(
+      stack.core,
+      getYellowFilter(stack.processing),
+      stack.processing.owner
+    ) && stack.processing.owner.opponent.field.some(unit => unit.id === stack.target?.id),
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '熾天使の片翼', '手札に戻す');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      getYellowFilter(stack.processing),
+      '手札に戻すユニットを選択'
+    );
+    [stack.target, target].forEach(unit => {
+      if (unit instanceof Unit) Effect.bounce(stack, stack.processing, unit, 'hand');
+    });
+  },
+};

--- a/src/game-data/effects/cards/1-2-086.ts
+++ b/src/game-data/effects/cards/1-2-086.ts
@@ -8,7 +8,7 @@ import { Color } from '@/submodule/suit/constant';
 const getYellowFilter = (self: Card) => (unit: Unit) =>
   unit.catalog.color === Color.YELLOW && unit.owner.id === self.owner.id;
 
-export const effect: CardEffects = {
+export const effects: CardEffects = {
   checkDrive: (stack: StackWithCard) =>
     EffectHelper.isUnitSelectable(
       stack.core,

--- a/src/game-data/effects/cards/1-2-098.ts
+++ b/src/game-data/effects/cards/1-2-098.ts
@@ -1,0 +1,12 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (_stack: StackWithCard) => true,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '大いなる世界', 'CP-12');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, -12);
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner.opponent, -12);
+  },
+};

--- a/src/game-data/effects/cards/1-3-057.ts
+++ b/src/game-data/effects/cards/1-3-057.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id && stack.processing.owner.delete.length > 0,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '神札再生', '消滅から1枚回収');
+    const [target] = await EffectHelper.selectCard(
+      stack,
+      stack.processing.owner,
+      stack.processing.owner.delete,
+      '手札に加えるカードを選択'
+    );
+    // 手札が上限に達している場合、消滅から捨札に送られる
+    Effect.move(stack, stack.processing, target, 'hand');
+  },
+};

--- a/src/game-data/effects/cards/1-3-125.ts
+++ b/src/game-data/effects/cards/1-3-125.ts
@@ -1,0 +1,14 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.processing.owner.field.length + stack.processing.owner.opponent.field.length > 0,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '皆既日食', '全ユニットの行動権を回復');
+    [...stack.processing.owner.field, ...stack.processing.owner.opponent.field].forEach(unit =>
+      Effect.activate(stack, stack.processing, unit, true)
+    );
+  },
+};

--- a/src/game-data/effects/cards/1-3-125.ts
+++ b/src/game-data/effects/cards/1-3-125.ts
@@ -4,6 +4,7 @@ import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/type
 
 export const effects: CardEffects = {
   checkDrive: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
     stack.processing.owner.field.length + stack.processing.owner.opponent.field.length > 0,
   onDrive: async (stack: StackWithCard) => {
     await System.show(stack, '皆既日食', '全ユニットの行動権を回復');

--- a/src/game-data/effects/cards/1-3-255.ts
+++ b/src/game-data/effects/cards/1-3-255.ts
@@ -12,7 +12,7 @@ export const effects: CardEffects = {
     if (stack.target instanceof Unit) {
       Effect.keyword(stack, stack.processing, stack.target, '次元干渉', {
         condition: (self, blocker) => (self?.currentBP ?? 0) < (blocker?.currentBP ?? 0),
-        event: 'turnEnd',
+        event: '_postBattle',
         count: 1,
       });
     }

--- a/src/game-data/effects/cards/1-3-255.ts
+++ b/src/game-data/effects/cards/1-3-255.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkAttack: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    stack.processing.owner.field.some(unit => unit.id === stack.target?.id),
+  onAttack: async (stack: StackWithCard) => {
+    await System.show(stack, 'タルンカッペ', 'BP以下のユニットにしかブロックされない');
+    if (stack.target instanceof Unit) {
+      Effect.keyword(stack, stack.processing, stack.target, '次元干渉', {
+        condition: (self, blocker) => (self?.currentBP ?? 0) < (blocker?.currentBP ?? 0),
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-3-256.ts
+++ b/src/game-data/effects/cards/1-3-256.ts
@@ -1,0 +1,14 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) => stack.source.id !== stack.processing.owner.id,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '聖光による庇護', '味方全体のBP+5000\n対戦相手のライフ+1');
+    stack.processing.owner.field.forEach(unit =>
+      Effect.modifyBP(stack, stack.processing, unit, 5000, { event: 'turnEnd', count: 1 })
+    );
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, 1);
+  },
+};

--- a/src/game-data/effects/cards/1-4-216.ts
+++ b/src/game-data/effects/cards/1-4-216.ts
@@ -1,7 +1,7 @@
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
-import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
   // 自身が召喚された時に発動する効果を記述
@@ -56,15 +56,11 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: async (stack: StackWithCard): Promise<void> => {
-    stack.processing.owner.opponent.hand.forEach(card => {
-      if (
-        !card.delta.some(
-          delta => delta.effect.type === 'banned' && delta.source?.unit === stack.processing.id
-        ) &&
-        card.catalog.cost >= 7
-      ) {
-        card.delta.push(new Delta({ type: 'banned' }, { source: { unit: stack.processing.id } }));
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
+      targets: ['opponents', 'hand'],
+      condition: card => card.catalog.cost >= 7,
+      effectCode: '神制の耀矢',
     });
   },
 };

--- a/src/game-data/effects/cards/1-4-216.ts
+++ b/src/game-data/effects/cards/1-4-216.ts
@@ -59,7 +59,7 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost >= 7,
+      condition: card => card.catalog.cost >= 7 && card instanceof Unit,
       effectCode: '神制の耀矢',
     });
   },

--- a/src/game-data/effects/cards/1-4-258.ts
+++ b/src/game-data/effects/cards/1-4-258.ts
@@ -1,0 +1,29 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Card, Unit } from '@/package/core/class/card';
+
+const getSelfUnderCost3Filter = (self: Card) => (unit: Unit) =>
+  self.owner.id === unit.owner.id && unit.catalog.cost <= 3;
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    stack.processing.owner.field.length <= 4 &&
+    EffectHelper.isUnitSelectable(
+      stack.core,
+      getSelfUnderCost3Filter(stack.processing),
+      stack.processing.owner
+    ),
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '大天使の息吹', 'コスト3以下を【複製】');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      getSelfUnderCost3Filter(stack.processing),
+      '【複製】するユニットを選択'
+    );
+    await Effect.clone(stack, stack.processing, target, stack.processing.owner);
+  },
+};

--- a/src/game-data/effects/cards/1-4-261.ts
+++ b/src/game-data/effects/cards/1-4-261.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    EffectHelper.isUnitSelectable(stack.core, 'owns', stack.processing.owner),
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, 'ペイン・シャドウ', 'ユニットを破壊する');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'owns',
+      '破壊するユニットを選択'
+    );
+    Effect.break(stack, stack.processing, target);
+  },
+};

--- a/src/game-data/effects/cards/2-0-012.ts
+++ b/src/game-data/effects/cards/2-0-012.ts
@@ -1,7 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
@@ -33,22 +33,12 @@ export const effects: CardEffects = {
     Effect.keyword(stack, stack.processing, stack.processing, '進化禁止');
   },
 
-  fieldEffect: (stack: StackWithCard) => {
-    stack.processing.owner.opponent.hand
-      .filter(
-        card =>
-          card.catalog.cost >= 6 &&
-          !card.delta.find(delta => delta.source?.unit === stack.processing.id)
-      )
-      .forEach(card =>
-        card.delta.push(
-          new Delta(
-            { type: 'banned' },
-            {
-              source: { unit: stack.processing.id },
-            }
-          )
-        )
-      );
+  fieldEffect: async (stack: StackWithCard): Promise<void> => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
+      targets: ['opponents', 'hand'],
+      condition: card => card.catalog.cost >= 7,
+      effectCode: '神制の耀矢',
+    });
   },
 };

--- a/src/game-data/effects/cards/2-0-012.ts
+++ b/src/game-data/effects/cards/2-0-012.ts
@@ -50,7 +50,7 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost >= 6,
+      condition: card => card.catalog.cost >= 6 && card instanceof Unit,
       effectCode: '神征の楔',
     });
   },

--- a/src/game-data/effects/cards/2-0-012.ts
+++ b/src/game-data/effects/cards/2-0-012.ts
@@ -1,5 +1,5 @@
 import { Unit } from '@/package/core/class/card';
-import { Effect, EffectHelper, System } from '..';
+import { Effect, EffectHelper } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
@@ -11,34 +11,47 @@ export const effects: CardEffects = {
     const opponentTargets = stack.processing.owner.opponent.field;
     const targets = [...ownerTargets, ...opponentTargets];
 
-    if (targets.length > 0) {
-      if (ownerTargets.length >= 2) {
-        await System.show(
-          stack,
-          '神怒の豪雷＆進化禁止',
-          '進化することができない\n自身以外を消滅\n基本BP+2000\n【加護】を得る'
-        );
-        Effect.modifyBP(stack, stack.processing, stack.processing, 2000, { isBaseBP: true });
-        Effect.keyword(stack, stack.processing, stack.processing, '加護');
-      } else {
-        await System.show(stack, '神怒の豪雷＆進化禁止', '進化することができない\n自身以外を消滅');
-      }
-      EffectHelper.exceptSelf(stack.core, stack.processing, unit =>
-        Effect.delete(stack, stack.processing, unit)
-      );
-    } else {
-      await System.show(stack, '進化禁止', '進化することができない');
-    }
-
-    Effect.keyword(stack, stack.processing, stack.processing, '進化禁止');
+    await EffectHelper.combine(stack, [
+      {
+        title: '神怒の豪雷',
+        description: '自身以外を消滅',
+        effect: () => {
+          EffectHelper.exceptSelf(stack.core, stack.processing, unit =>
+            Effect.delete(stack, stack.processing, unit)
+          );
+        },
+        condition: targets.length > 0,
+      },
+      {
+        title: '神怒の豪雷',
+        description: '基本BP+2000\n【加護】を得る',
+        effect: () => {
+          Effect.modifyBP(stack, stack.processing, stack.processing, 2000, { isBaseBP: true });
+          Effect.keyword(stack, stack.processing, stack.processing, '加護');
+        },
+        condition: ownerTargets.length >= 2,
+      },
+      {
+        title: '進化禁止',
+        description: '進化することができない',
+        effect: () => {
+          Effect.keyword(stack, stack.processing, stack.processing, '進化禁止');
+        },
+      },
+      {
+        title: '神征の楔',
+        description: 'コスト6以上をフィールドに出せない',
+        effect: () => {},
+      },
+    ]);
   },
 
   fieldEffect: async (stack: StackWithCard): Promise<void> => {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost >= 7,
-      effectCode: '神制の耀矢',
+      condition: card => card.catalog.cost >= 6,
+      effectCode: '神征の楔',
     });
   },
 };

--- a/src/game-data/effects/cards/2-0-042.ts
+++ b/src/game-data/effects/cards/2-0-042.ts
@@ -1,0 +1,48 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit, type Card } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    await System.show(stack, '従順な眷属＆滾るステップ', 'BP+[紫ゲージ×500]\n【加護】を得る');
+  },
+  onAttackSelf: async (stack: StackWithCard) => {
+    if (
+      (stack.processing.owner.purple ?? 0) < 3 ||
+      stack.processing.owner.opponent.field.length === 0
+    )
+      return;
+    await System.show(stack, 'デッドリーダンス', '敵全体の基本BP-1000');
+    stack.processing.owner.opponent.field.forEach(unit =>
+      Effect.modifyBP(stack, stack.processing, unit, -1000, { isBaseBP: true })
+    );
+  },
+  fieldEffect: (stack: StackWithCard<Unit>) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '加護', { source });
+      },
+      effectCode: '滾るステップ',
+      targets: ['self'],
+      condition: (target: Card) => (target.owner.purple ?? 0) <= 4,
+    });
+
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.modifyBP(
+            stack,
+            stack.processing,
+            target,
+            (stack.processing.owner.purple ?? 0) * 500,
+            { source }
+          );
+      },
+      effectCode: '従順な眷属',
+      targets: ['owns'],
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-0-046.ts
+++ b/src/game-data/effects/cards/2-0-046.ts
@@ -1,0 +1,27 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) => {
+    const target = stack.target;
+    if (stack.source.id !== stack.processing.owner.id || !(target instanceof Unit)) return false;
+
+    return target.catalog.species?.includes('英雄')
+      ? stack.processing.owner.field.some(unit => unit.id === target.id)
+      : true;
+  },
+  onDrive: async (stack: StackWithCard) => {
+    if (!(stack.target instanceof Unit)) return;
+    if (stack.target.catalog.species?.includes('英雄')) {
+      await System.show(stack, '受け継がれし英雄譚', '基本BP+2000\n【不屈】を付与');
+      Effect.modifyBP(stack, stack.processing, stack.target, 2000, { isBaseBP: true });
+      Effect.keyword(stack, stack.processing, stack.target, '不屈');
+    } else {
+      await System.show(stack, '受け継がれし英雄譚', '【英雄】を1枚引く');
+      EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '英雄' });
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-0-134.ts
+++ b/src/game-data/effects/cards/2-0-134.ts
@@ -1,0 +1,18 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) => stack.source.id === stack.processing.owner.id,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, 'グランドライブラリ', '同属性のインターセプトカードを1枚引く');
+    const target = stack.target instanceof Unit ? stack.target : undefined;
+    EffectHelper.random(
+      stack.processing.owner.deck.filter(
+        card => card.catalog.type === 'intercept' && card.catalog.color === target?.catalog.color
+      )
+    ).forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+  },
+};

--- a/src/game-data/effects/cards/2-0-220.ts
+++ b/src/game-data/effects/cards/2-0-220.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    if (
+      (stack.processing.owner.purple ?? 0) < 4 ||
+      stack.processing.owner.field.length + stack.processing.owner.opponent.field.length === 1
+    )
+      return;
+    await System.show(stack, 'せんじん再臨', '自身以外のユニットを破壊\n紫ゲージ-4');
+    EffectHelper.exceptSelf(stack.core, stack.processing, unit =>
+      Effect.break(stack, stack.processing, unit)
+    );
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -4);
+  },
+};

--- a/src/game-data/effects/cards/2-0-220.ts
+++ b/src/game-data/effects/cards/2-0-220.ts
@@ -8,7 +8,7 @@ export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
     if (
       (stack.processing.owner.purple ?? 0) < 4 ||
-      stack.processing.owner.field.length + stack.processing.owner.opponent.field.length === 1
+      stack.processing.owner.field.length + stack.processing.owner.opponent.field.length <= 1
     )
       return;
     await System.show(stack, 'せんじん再臨', '自身以外のユニットを破壊\n紫ゲージ-4');

--- a/src/game-data/effects/cards/2-0-302.ts
+++ b/src/game-data/effects/cards/2-0-302.ts
@@ -1,0 +1,23 @@
+import { Unit } from '@/package/core/class/card';
+import { System } from '../engine/system';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  onPlayerAttackSelf: async (stack: StackWithCard) => {
+    const targets = stack.processing.owner.opponent.field.filter(unit =>
+      unit.hasKeyword('防御禁止')
+    );
+    if (targets.length > 0) {
+      await System.show(stack, 'ご褒美よ！', '【防御禁止】に5000ダメージ');
+    }
+  },
+  onPlayerAttack: async (stack: StackWithCard) => {
+    if (
+      stack.source instanceof Unit &&
+      stack.source.owner.id !== stack.processing.owner.id &&
+      stack.source.owner.field.some(unit => unit.id === stack.source.id)
+    ) {
+      await System.show(stack, 'まってなさい！', '【防御禁止】を付与');
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-0-302.ts
+++ b/src/game-data/effects/cards/2-0-302.ts
@@ -1,6 +1,8 @@
 import { Unit } from '@/package/core/class/card';
 import { System } from '../engine/system';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { Effect } from '@/game-data/effects/engine/effect';
 
 export const effects: CardEffects = {
   onPlayerAttackSelf: async (stack: StackWithCard) => {
@@ -9,15 +11,24 @@ export const effects: CardEffects = {
     );
     if (targets.length > 0) {
       await System.show(stack, 'ご褒美よ！', '【防御禁止】に5000ダメージ');
+      targets.forEach(unit => Effect.damage(stack, stack.processing, unit, 5000));
     }
   },
   onPlayerAttack: async (stack: StackWithCard) => {
     if (
       stack.source instanceof Unit &&
       stack.source.owner.id !== stack.processing.owner.id &&
-      stack.source.owner.field.some(unit => unit.id === stack.source.id)
+      stack.source.owner.field.some(unit => unit.id === stack.source.id) &&
+      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
     ) {
       await System.show(stack, 'まってなさい！', '【防御禁止】を付与');
+      const [target] = await EffectHelper.pickUnit(
+        stack,
+        stack.processing.owner,
+        'opponents',
+        '【防御禁止】を与えるユニットを選択'
+      );
+      Effect.keyword(stack, stack.processing, target, '防御禁止');
     }
   },
 };

--- a/src/game-data/effects/cards/2-1-056.ts
+++ b/src/game-data/effects/cards/2-1-056.ts
@@ -1,0 +1,41 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBattle: (stack: StackWithCard) =>
+    [stack.source, stack.target].some(object =>
+      stack.processing.owner.field.some(unit => unit.id === object?.id)
+    ),
+  onBattle: async (stack: StackWithCard) => {
+    await System.show(
+      stack,
+      'オーバードーズ',
+      'ターン終了時までBP+[紫ゲージ×4000]\n基本BP-[紫ゲージ×2000]'
+    );
+
+    // 戦闘中の自ユニットを特定
+    const ownUnit = [stack.source, stack.target].find(
+      (object): object is Unit =>
+        object instanceof Unit && object.owner.id === stack.processing.owner.id
+    );
+
+    if (ownUnit) {
+      Effect.modifyBP(
+        stack,
+        stack.processing,
+        ownUnit,
+        (stack.processing.owner.purple ?? 0) * 4000,
+        { event: 'turnEnd', count: 1 }
+      );
+      Effect.modifyBP(
+        stack,
+        stack.processing,
+        ownUnit,
+        (stack.processing.owner.purple ?? 0) * -2000,
+        { isBaseBP: true }
+      );
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-1-108.ts
+++ b/src/game-data/effects/cards/2-1-108.ts
@@ -1,7 +1,7 @@
-import { Unit } from '@/package/core/class/card';
+import { Trigger, Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard) => {
@@ -9,22 +9,13 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard) => {
-    stack.processing.owner.opponent.trigger
-      .filter(
-        card =>
-          card.catalog.type === 'trigger' &&
-          !card.delta.find(delta => delta.source?.unit === stack.processing.id)
-      )
-      .forEach(card =>
-        card.delta.push(
-          new Delta(
-            { type: 'banned' },
-            {
-              source: { unit: stack.processing.id },
-            }
-          )
-        )
-      );
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Trigger) Effect.ban(stack, stack.processing, target, { source });
+      },
+      targets: ['opponents', 'trigger'],
+      effectCode: '王頂よりの威光',
+    });
   },
 
   onBlockSelf: async (stack: StackWithCard<Unit>) => {

--- a/src/game-data/effects/cards/2-2-046.ts
+++ b/src/game-data/effects/cards/2-2-046.ts
@@ -1,0 +1,28 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    (stack.processing.owner.field.length <= 4 &&
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.id &&
+      stack.target.catalog.species?.includes('武身') &&
+      stack.processing.owner.deck.some(
+        card =>
+          card instanceof Unit && card.catalog.cost <= 5 && card.catalog.species?.includes('武身')
+      )) ||
+    false,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '結集セシ化身タチ', 'デッキから【武身】を【特殊召喚】');
+    const [target] = EffectHelper.random(
+      stack.processing.owner.deck.filter(
+        card =>
+          card instanceof Unit && card.catalog.species?.includes('武身') && card.catalog.cost <= 5
+      )
+    );
+    if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
+  },
+};

--- a/src/game-data/effects/cards/2-2-150.ts
+++ b/src/game-data/effects/cards/2-2-150.ts
@@ -1,0 +1,37 @@
+import { Effect, EffectHelper, System } from '@/game-data/effects';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnEnd: (stack: StackWithCard) => stack.source.id === stack.processing.owner.id,
+  onTurnEnd: async (stack: StackWithCard) => {
+    const choice = await EffectHelper.choice(
+      stack,
+      stack.processing.owner,
+      '選略・ウロボロスの刻印',
+      [
+        { id: '1', description: '紫ゲージ+2' },
+        {
+          id: '2',
+          description: '捨札から2枚回収\n紫ゲージ-1',
+          condition: (stack.processing.owner.purple ?? 0) >= 1,
+        },
+      ]
+    );
+
+    switch (choice) {
+      case '1': {
+        await System.show(stack, '選略・ウロボロスの刻印', '紫ゲージ+2');
+        await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 2);
+        break;
+      }
+      case '2': {
+        await System.show(stack, '選略・ウロボロスの刻印', '捨札から2枚回収\n紫ゲージ-1');
+        EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
+          Effect.move(stack, stack.processing, card, 'hand')
+        );
+        await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
+        break;
+      }
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-2-150.ts
+++ b/src/game-data/effects/cards/2-2-150.ts
@@ -26,9 +26,9 @@ export const effects: CardEffects = {
       }
       case '2': {
         await System.show(stack, '選略・ウロボロスの刻印', '捨札から2枚回収\n紫ゲージ-1');
-        EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
-          Effect.move(stack, stack.processing, card, 'hand')
-        );
+        EffectHelper.random(stack.processing.owner.trash, 2).forEach(card => {
+          Effect.move(stack, stack.processing, card, 'hand');
+        });
         await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
         break;
       }

--- a/src/game-data/effects/cards/2-2-150.ts
+++ b/src/game-data/effects/cards/2-2-150.ts
@@ -13,7 +13,8 @@ export const effects: CardEffects = {
         {
           id: '2',
           description: '捨札から2枚回収\n紫ゲージ-1',
-          condition: (stack.processing.owner.purple ?? 0) >= 1,
+          condition:
+            (stack.processing.owner.purple ?? 0) >= 1 && stack.processing.owner.trash.length >= 2,
         },
       ]
     );

--- a/src/game-data/effects/cards/2-3-104.ts
+++ b/src/game-data/effects/cards/2-3-104.ts
@@ -1,0 +1,35 @@
+import { Effect } from '../engine/effect';
+import { EffectHelper } from '../engine/helper';
+import { System } from '../engine/system';
+import { EffectTemplate } from '../engine/templates';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    if (
+      EffectHelper.isVirusInjectable(stack.processing.owner) &&
+      EffectHelper.isVirusInjectable(stack.processing.owner.opponent)
+    ) {
+      await System.show(
+        stack,
+        'Ｗフォース＜ウィルス・炎＞',
+        'お互いのフィールドに＜ウィルス・炎＞を【特殊召喚】'
+      );
+      for (const player of [stack.processing.owner, stack.processing.owner.opponent]) {
+        await EffectTemplate.virusInject(stack, player, 'ウィルス・炎');
+      }
+    }
+  },
+  onDamage: async (stack: StackWithCard) => {
+    if (
+      stack.core.getTurnPlayer().id !== stack.processing.owner.id &&
+      stack.option?.type === 'damage' &&
+      stack.option.cause === 'effect'
+    ) {
+      await System.show(stack, 'アヴェスタ―の残焔', '敵全体に2000ダメージ');
+      stack.processing.owner.opponent.field.forEach(unit =>
+        Effect.damage(stack, stack.processing, unit, 2000)
+      );
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-3-104.ts
+++ b/src/game-data/effects/cards/2-3-104.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@/package/core/class/card';
 import { Effect } from '../engine/effect';
 import { EffectHelper } from '../engine/helper';
 import { System } from '../engine/system';
@@ -23,6 +24,8 @@ export const effects: CardEffects = {
   onDamage: async (stack: StackWithCard) => {
     if (
       stack.core.getTurnPlayer().id !== stack.processing.owner.id &&
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.id &&
       stack.option?.type === 'damage' &&
       stack.option.cause === 'effect'
     ) {

--- a/src/game-data/effects/cards/2-3-104.ts
+++ b/src/game-data/effects/cards/2-3-104.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
         'お互いのフィールドに＜ウィルス・炎＞を【特殊召喚】'
       );
       for (const player of [stack.processing.owner, stack.processing.owner.opponent]) {
-        await EffectTemplate.virusInject(stack, player, 'ウィルス・炎');
+        await EffectTemplate.virusInject(stack, player, '＜ウィルス・炎＞');
       }
     }
   },

--- a/src/game-data/effects/cards/2-3-124.ts
+++ b/src/game-data/effects/cards/2-3-124.ts
@@ -1,6 +1,7 @@
 import { Effect } from '@/game-data/effects/engine/effect';
 import { EffectHelper } from '@/game-data/effects/engine/helper';
 import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
 import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
 import type { Unit } from '@/package/core/class/card';
 
@@ -25,5 +26,9 @@ export const effects: CardEffects = {
     );
     Effect.keyword(stack, stack.processing, target, '強制防御');
     Effect.modifyBP(stack, stack.processing, target, 2000, { isBaseBP: true });
+  },
+  onBreakSelf: async (stack: StackWithCard) => {
+    await System.show(stack, 'お茶会への招待状', '【天使】を1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '天使' });
   },
 };

--- a/src/game-data/effects/cards/2-3-124.ts
+++ b/src/game-data/effects/cards/2-3-124.ts
@@ -1,0 +1,29 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+const getAngelFilter = (self: Unit) => (unit: Unit) =>
+  (unit.owner.id === self.owner.id && unit.catalog.species?.includes('天使')) || false;
+
+export const effects: CardEffects = {
+  isBootable: (core, self) => {
+    return EffectHelper.isUnitSelectable(core, getAngelFilter(self), self.owner);
+  },
+  onBootSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(
+      stack,
+      '起動・アフタヌーンブレイカー',
+      '【天使】の基本BP+2000\n【強制防御】を付与'
+    );
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      getAngelFilter(stack.processing),
+      '基本BPを+2000し【強制防御】を付与するユニットを選択'
+    );
+    Effect.keyword(stack, stack.processing, target, '強制防御');
+    Effect.modifyBP(stack, stack.processing, target, 2000, { isBaseBP: true });
+  },
+};

--- a/src/game-data/effects/cards/2-3-130.ts
+++ b/src/game-data/effects/cards/2-3-130.ts
@@ -1,0 +1,24 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(
+      stack,
+      '禁忌の呪法＆泡沫夢幻の刻',
+      'トリガーゾーンのインターセプトカードを使用できない\nデスカウンター[3]を得る'
+    );
+    Effect.death(stack, stack.processing, stack.processing, 3);
+  },
+  fieldEffect: (stack: StackWithCard) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
+      effectCode: '禁忌の呪法',
+      condition: card => stack.core.getTurnPlayer().id !== card.owner.id,
+      targets: ['opponents', 'trigger'],
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-3-130.ts
+++ b/src/game-data/effects/cards/2-3-130.ts
@@ -2,7 +2,7 @@ import { Effect } from '@/game-data/effects/engine/effect';
 import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { System } from '@/game-data/effects/engine/system';
 import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
-import type { Unit } from '@/package/core/class/card';
+import { Intercept, type Unit } from '@/package/core/class/card';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
@@ -17,7 +17,8 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       effectCode: '禁忌の呪法',
-      condition: card => stack.core.getTurnPlayer().id !== card.owner.id,
+      condition: card =>
+        stack.core.getTurnPlayer().id !== card.owner.id && card instanceof Intercept,
       targets: ['opponents', 'trigger'],
     });
   },

--- a/src/game-data/effects/cards/2-3-144.ts
+++ b/src/game-data/effects/cards/2-3-144.ts
@@ -11,7 +11,7 @@ export const effects: CardEffects = {
       ...stack.processing.owner.field,
       ...stack.processing.owner.hand,
       ...stack.processing.owner.opponent.field,
-      stack.processing.owner.opponent.hand,
+      ...stack.processing.owner.opponent.hand,
     ].forEach(card => {
       if (card instanceof Unit) Effect.clock(stack, stack.processing, card, -2);
     });

--- a/src/game-data/effects/cards/2-3-144.ts
+++ b/src/game-data/effects/cards/2-3-144.ts
@@ -1,0 +1,19 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkTurnEnd: (stack: StackWithCard) => stack.source.id === stack.processing.owner.id,
+  onTurnEnd: async (stack: StackWithCard) => {
+    await System.show(stack, 'すやすやスリーピング', '手札とフィールドのユニットのレベル-2');
+    [
+      ...stack.processing.owner.field,
+      ...stack.processing.owner.hand,
+      ...stack.processing.owner.opponent.field,
+      stack.processing.owner.opponent.hand,
+    ].forEach(card => {
+      if (card instanceof Unit) Effect.clock(stack, stack.processing, card, -2);
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-3-152.ts
+++ b/src/game-data/effects/cards/2-3-152.ts
@@ -1,0 +1,22 @@
+import master from '@/game-data/catalog';
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) => stack.source.id !== stack.processing.owner.id,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, 'アンデッドパレード', 'ランダムな【不死】を3枚作成');
+    [stack.processing.owner, stack.processing.owner.opponent].forEach(player => {
+      EffectHelper.repeat(3, () => {
+        const [card] = EffectHelper.random(
+          Array.from(master.values()).filter(catalog => catalog.species?.includes('不死'))
+        );
+        if (card?.id) {
+          Effect.make(stack, player, card?.id);
+        }
+      });
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-3-152.ts
+++ b/src/game-data/effects/cards/2-3-152.ts
@@ -8,11 +8,12 @@ export const effects: CardEffects = {
   checkTurnStart: (stack: StackWithCard) => stack.source.id !== stack.processing.owner.id,
   onTurnStart: async (stack: StackWithCard) => {
     await System.show(stack, 'アンデッドパレード', 'ランダムな【不死】を3枚作成');
+    const undeads = Array.from(master.values()).filter(catalog =>
+      catalog.species?.includes('不死')
+    );
     [stack.processing.owner, stack.processing.owner.opponent].forEach(player => {
       EffectHelper.repeat(3, () => {
-        const [card] = EffectHelper.random(
-          Array.from(master.values()).filter(catalog => catalog.species?.includes('不死'))
-        );
+        const [card] = EffectHelper.random(undeads);
         if (card?.id) {
           Effect.make(stack, player, card?.id);
         }

--- a/src/game-data/effects/cards/2-3-213.ts
+++ b/src/game-data/effects/cards/2-3-213.ts
@@ -1,0 +1,59 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    const bp8000filter = (unit: Unit) =>
+      unit.owner.id === stack.processing.owner.opponent.id && unit.currentBP >= 8000;
+    const choice = await EffectHelper.choice(
+      stack,
+      stack.processing.owner,
+      '選略・究極のしもやけ',
+      [
+        {
+          id: '1',
+          description: 'BP8000以上のユニットを破壊',
+          condition: EffectHelper.isUnitSelectable(
+            stack.core,
+            bp8000filter,
+            stack.processing.owner
+          ),
+        },
+        {
+          id: '2',
+          description: 'CP-3\nユニットを破壊',
+          condition: EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
+        },
+      ]
+    );
+
+    switch (choice) {
+      case '1': {
+        await System.show(stack, '選略・究極のしもやけ', 'BP8000以上のユニットを破壊');
+        const [target] = await EffectHelper.pickUnit(
+          stack,
+          stack.processing.owner,
+          bp8000filter,
+          '破壊するユニットを選択'
+        );
+        Effect.break(stack, stack.processing, target);
+        break;
+      }
+      case '2': {
+        await System.show(stack, '選略・究極のしもやけ', 'CP-3\nユニットを破壊');
+        const [target] = await EffectHelper.pickUnit(
+          stack,
+          stack.processing.owner,
+          'opponents',
+          '破壊するユニットを選択'
+        );
+        Effect.break(stack, stack.processing, target);
+        Effect.modifyCP(stack, stack.processing, stack.processing.owner, -3);
+        break;
+      }
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-3-213.ts
+++ b/src/game-data/effects/cards/2-3-213.ts
@@ -25,7 +25,9 @@ export const effects: CardEffects = {
         {
           id: '2',
           description: 'CP-3\nユニットを破壊',
-          condition: EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
+          condition:
+            stack.processing.owner.cp.current >= 3 &&
+            EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
         },
       ]
     );

--- a/src/game-data/effects/cards/2-3-221.ts
+++ b/src/game-data/effects/cards/2-3-221.ts
@@ -29,11 +29,11 @@ export const effects: CardEffects = {
   },
 
   // 対戦相手は手札からコスト1のユニットをフィールドに出すことができない。
-  fieldEffect: async (stack: StackWithCard): Promise<void> => {
+  fieldEffect: (stack: StackWithCard) => {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost === 1,
+      condition: card => card instanceof Unit && card.catalog.cost === 1,
       effectCode: '翠龍の眼光',
     });
   },

--- a/src/game-data/effects/cards/2-3-221.ts
+++ b/src/game-data/effects/cards/2-3-221.ts
@@ -1,7 +1,6 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
 import { PermanentEffect } from '../engine/permanent';
 import { Color } from '@/submodule/suit/constant';
 
@@ -30,15 +29,11 @@ export const effects: CardEffects = {
   },
 
   // 対戦相手は手札からコスト1のユニットをフィールドに出すことができない。
-  fieldEffect: (stack: StackWithCard<Unit>): void => {
+  fieldEffect: async (stack: StackWithCard): Promise<void> => {
     PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      effect: (unit, source) => {
-        if (unit instanceof Unit) {
-          unit.delta.push(new Delta({ type: 'banned' }, { source }));
-        }
-      },
-      condition: target => target instanceof Unit && target.catalog.cost === 1,
+      condition: card => card.catalog.cost === 1,
       effectCode: '翠龍の眼光',
     });
   },

--- a/src/game-data/effects/cards/2-3-231.ts
+++ b/src/game-data/effects/cards/2-3-231.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
     stack.target.catalog.cost >= 5,
   onDrive: async (stack: StackWithCard) => {
     await System.show(stack, 'LIVEラリー', '[LIVEラリー]を作成\n対戦相手のトリガーゾーンにセット');
-    Effect.make(stack, stack.processing.owner, '2-3-231', 'trigger');
+    Effect.make(stack, stack.processing.owner.opponent, '2-3-231', 'trigger');
   },
   checkTurnEnd: (stack: StackWithCard) => {
     return stack.source.id === stack.processing.owner.id;

--- a/src/game-data/effects/cards/2-3-231.ts
+++ b/src/game-data/effects/cards/2-3-231.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.processing.owner.id === stack.source.id &&
+    stack.target instanceof Unit &&
+    stack.target.catalog.cost >= 5,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, 'LIVEラリー', '[LIVEラリー]を作成\n対戦相手のトリガーゾーンにセット');
+    Effect.make(stack, stack.processing.owner, '2-3-231', 'trigger');
+  },
+  checkTurnEnd: (stack: StackWithCard) => {
+    return stack.source.id === stack.processing.owner.id;
+  },
+  onTurnEnd: async (stack: StackWithCard) => {
+    await System.show(stack, 'LIVEラリー', '1ライフダメージ');
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner, -1);
+  },
+};

--- a/src/game-data/effects/cards/2-3-235.ts
+++ b/src/game-data/effects/cards/2-3-235.ts
@@ -1,0 +1,51 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+import { Color } from '@/submodule/suit/constant';
+
+/** colorsの中で最も多い属性を返す。同数の属性が複数ある場合は undefined を返す */
+const getDominantColor = (colors: number[]): number | undefined => {
+  const colorCount = colors.reduce<Record<string, number>>((acc, color) => {
+    acc[color] = (acc[color] ?? 0) + 1;
+    return acc;
+  }, {});
+  const maxCount = Math.max(...Object.values(colorCount));
+  const topColors = Object.entries(colorCount).filter(([, count]) => count === maxCount);
+  if (topColors.length !== 1) return undefined;
+  return Number(topColors[0]?.[0]);
+};
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    stack.processing.owner.field.length <= 4 &&
+    getDominantColor(stack.processing.owner.field.map(unit => unit.catalog.color)) !== undefined,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, 'フルーツバスケット', '[フルーツガール]を【特殊召喚】');
+    const color = getDominantColor(stack.processing.owner.field.map(unit => unit.catalog.color));
+
+    switch (color) {
+      case Color.RED: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-004'));
+        break;
+      }
+      case Color.YELLOW: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-009'));
+        break;
+      }
+      case Color.BLUE: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-014'));
+        break;
+      }
+      case Color.GREEN: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-019'));
+        break;
+      }
+      case Color.PURPLE: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-025'));
+        break;
+      }
+    }
+  },
+};

--- a/src/game-data/effects/cards/PR-024.ts
+++ b/src/game-data/effects/cards/PR-024.ts
@@ -1,0 +1,24 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    const beastFilter = (unit: Unit) =>
+      unit.owner.id !== stack.processing.owner.id && unit.catalog.species?.includes('獣');
+    if (!EffectHelper.isUnitSelectable(stack.core, beastFilter, stack.processing.owner)) return;
+
+    await System.show(stack, '黄金の拳', '【獣】を1体破壊\nカードを1枚引く');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      beastFilter,
+      '破壊する【獣】を選択'
+    );
+    Effect.break(stack, stack.processing, target);
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/game-data/effects/cards/PR-096.ts
+++ b/src/game-data/effects/cards/PR-096.ts
@@ -1,0 +1,18 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkAttack: (stack: StackWithCard) =>
+    stack.target instanceof Unit &&
+    stack.target.owner.id === stack.processing.owner.id &&
+    stack.target.owner.field.some(unit => unit.id === stack.target?.id),
+  onAttack: async (stack: StackWithCard) => {
+    await System.show(stack, '幻想の里', 'ブロックされない\nライフ+1');
+    if (stack.target instanceof Unit) {
+      Effect.keyword(stack, stack.processing, stack.target, '次元干渉', { condition: () => true });
+    }
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, 1);
+  },
+};

--- a/src/game-data/effects/cards/PR-111.ts
+++ b/src/game-data/effects/cards/PR-111.ts
@@ -1,0 +1,37 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await EffectHelper.combine(stack, [
+      {
+        title: '貫通',
+        description: 'ブロックを貫通しプレイヤーにダメージを与える',
+        effect: () => Effect.keyword(stack, stack.processing, stack.processing, '貫通'),
+      },
+      {
+        title: '全てを喰らう激流',
+        description: '全ユニットに【強制防御】を付与',
+        effect: () =>
+          [...stack.processing.owner.field, ...stack.processing.owner.opponent.field].forEach(
+            unit => Effect.keyword(stack, stack.processing, unit, '強制防御')
+          ),
+      },
+      {
+        title: '全てを喰らう激流',
+        description: '【スピードムーブ】を得る',
+        effect: () => Effect.speedMove(stack, stack.processing),
+        condition:
+          stack.processing.owner.field.filter(unit => unit.catalog.species?.includes('ドラゴン'))
+            .length >= 3,
+      },
+    ]);
+  },
+  onBreakSelf: async (stack: StackWithCard) => {
+    await System.show(stack, '水竜の至宝', 'CP+2');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, 2);
+  },
+};

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -1,0 +1,51 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+import { Color } from '@/submodule/suit/constant';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await EffectHelper.combine(stack, [
+      {
+        title: 'マイクロバースト',
+        description: '紫属性のインターセプトカードを1枚セット\n紫ゲージ+1',
+        condition: (stack.processing.owner.purple ?? 0) <= 2,
+        effect: async () => {
+          if (stack.processing.owner.trigger.length < stack.core.room.rule.player.max.trigger) {
+            EffectHelper.random(
+              stack.processing.owner.deck.filter(
+                card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
+              )
+            ).forEach(card => Effect.move(stack, stack.processing, card, 'trigger'));
+          }
+          await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
+        },
+      },
+      {
+        title: '栄光の凱歌',
+        description: 'BP+3000\n【不屈】を得る',
+        effect: () => {},
+      },
+    ]);
+  },
+  onAttack: async (stack: StackWithCard) => {
+    if (stack.source.id === stack.processing.owner.id) return;
+    await System.show(stack, 'マイクロバースト', '紫ゲージ+1');
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
+  },
+  fieldEffect: (stack: StackWithCard) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit) {
+          Effect.modifyBP(stack, stack.processing, target, 3000, { source });
+          Effect.keyword(stack, stack.processing, target, '不屈', { source });
+        }
+      },
+      effectCode: '栄光の凱歌',
+      targets: ['self'],
+    });
+  },
+};

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -14,15 +14,13 @@ export const effects: CardEffects = {
         description: '紫属性のインターセプトカードを1枚セット\n紫ゲージ+1',
         condition: (stack.processing.owner.purple ?? 0) <= 2,
         effect: async () => {
-          if (stack.processing.owner.trigger.length < stack.core.room.rule.player.max.trigger) {
-            EffectHelper.random(
-              stack.processing.owner.deck.filter(
-                card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
-              )
-            ).forEach(card => {
-              Effect.move(stack, stack.processing, card, 'trigger');
-            });
-          }
+          EffectHelper.random(
+            stack.processing.owner.deck.filter(
+              card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
+            )
+          ).forEach(card => {
+            Effect.move(stack, stack.processing, card, 'trigger');
+          });
           await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
         },
       },

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -44,6 +44,7 @@ export const effects: CardEffects = {
           Effect.keyword(stack, stack.processing, target, '不屈', { source });
         }
       },
+      condition: target => (target.owner.purple ?? 0) >= 3,
       effectCode: '栄光の凱歌',
       targets: ['self'],
     });

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -19,7 +19,9 @@ export const effects: CardEffects = {
               stack.processing.owner.deck.filter(
                 card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
               )
-            ).forEach(card => Effect.move(stack, stack.processing, card, 'trigger'));
+            ).forEach(card => {
+              Effect.move(stack, stack.processing, card, 'trigger');
+            });
           }
           await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
         },

--- a/src/game-data/effects/cards/PR-149.ts
+++ b/src/game-data/effects/cards/PR-149.ts
@@ -1,0 +1,17 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBreak: (stack: StackWithCard) =>
+    stack.target instanceof Unit &&
+    stack.target.owner.id === stack.processing.owner.id &&
+    (stack.processing.owner.purple ?? 0) >= 3,
+  onBreak: async (stack: StackWithCard) => {
+    await System.show(stack, '丑の刻参り', '1ライフダメージ\nカードを1枚引く');
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -1);
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/game-data/effects/cards/PR-170.ts
+++ b/src/game-data/effects/cards/PR-170.ts
@@ -1,0 +1,25 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    await System.show(stack, 'ダークチャージ', '紫ゲージ+1');
+  },
+  onModifyPurple: async (stack: StackWithCard) => {
+    if (
+      stack.target?.id !== stack.processing.owner.id ||
+      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
+    )
+      return;
+    await System.show(stack, '怪火の機術', '2000ダメージ');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'opponents',
+      'ダメージを与えるユニットを選択'
+    );
+    Effect.damage(stack, stack.processing, target, 2000);
+  },
+};

--- a/src/game-data/effects/cards/PR-170.ts
+++ b/src/game-data/effects/cards/PR-170.ts
@@ -6,6 +6,7 @@ import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/type
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard) => {
     await System.show(stack, 'ダークチャージ', '紫ゲージ+1');
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
   },
   onModifyPurple: async (stack: StackWithCard) => {
     if (

--- a/src/game-data/effects/cards/PR-170.ts
+++ b/src/game-data/effects/cards/PR-170.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
   onModifyPurple: async (stack: StackWithCard) => {
     if (
       stack.target?.id !== stack.processing.owner.id ||
-      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
+      !EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
     )
       return;
     await System.show(stack, '怪火の機術', '2000ダメージ');

--- a/src/game-data/effects/cards/PR-180.ts
+++ b/src/game-data/effects/cards/PR-180.ts
@@ -1,0 +1,26 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onIntercept: async (stack: StackWithCard<Unit>) => {
+    if (stack.source.id !== stack.processing.owner.id) return;
+    await System.show(stack, '紫電の溢力', '基本BP+2000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, 2000, { isBaseBP: true });
+  },
+  isBootable: (core, self) => {
+    return (
+      self.owner.hand.length < core.room.rule.player.max.hand &&
+      self.owner.trash.some(card => card.catalog.type === 'intercept')
+    );
+  },
+  onBootSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(stack, '起動・破滅の輪廻', '基本BP-3000\n捨札からインターセプトカードを回収');
+    Effect.modifyBP(stack, stack.processing, stack.processing, -3000, { isBaseBP: true });
+    EffectHelper.random(
+      stack.processing.owner.trash.filter(card => card.catalog.type === 'intercept')
+    ).forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+  },
+};

--- a/src/game-data/effects/cards/PR-200.ts
+++ b/src/game-data/effects/cards/PR-200.ts
@@ -7,8 +7,8 @@ export const effects: CardEffects = {
     if (stack.processing.owner.opponent.hand.length === 0) return;
 
     await System.show(stack, 'スウィート・リトル・ブレス', '手札のレベル-2');
-    stack.processing.owner.opponent.hand.forEach(card =>
-      Effect.clock(stack, stack.processing, card, -2)
-    );
+    stack.processing.owner.opponent.hand.forEach(card => {
+      Effect.clock(stack, stack.processing, card, -2);
+    });
   },
 };

--- a/src/game-data/effects/cards/PR-200.ts
+++ b/src/game-data/effects/cards/PR-200.ts
@@ -1,0 +1,14 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    if (stack.processing.owner.opponent.hand.length === 0) return;
+
+    await System.show(stack, 'スウィート・リトル・ブレス', '手札のレベル-2');
+    stack.processing.owner.opponent.hand.forEach(card =>
+      Effect.clock(stack, stack.processing, card, -2)
+    );
+  },
+};

--- a/src/game-data/effects/cards/PR-203.ts
+++ b/src/game-data/effects/cards/PR-203.ts
@@ -1,0 +1,33 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    if (!EffectHelper.isVirusInjectable(stack.processing.owner.opponent)) return;
+    await System.show(stack, 'フォース＜ウィルス・蝕＞', '＜ウィルス・蝕＞を【特殊召喚】');
+    await EffectTemplate.virusInject(stack, stack.processing.owner.opponent, '＜ウィルス・蝕＞');
+  },
+  onTurnEnd: async (stack: StackWithCard) => {
+    const targets = stack.processing.owner.deck.filter(card => card.catalog.type === 'intercept');
+    if (
+      stack.source.id !== stack.processing.owner.id ||
+      stack.processing.owner.hand.length >= stack.core.room.rule.player.max.hand ||
+      (stack.processing.owner.purple ?? 0) < 3 ||
+      targets.length === 0
+    )
+      return;
+
+    await System.show(
+      stack,
+      'マルブリッサの神術',
+      'インターセプトカードを1枚引きレベル+1\n紫ゲージ-1'
+    );
+    EffectHelper.random(targets).forEach(card =>
+      Effect.move(stack, stack.processing, card, 'hand')
+    );
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
+  },
+};

--- a/src/game-data/effects/cards/PR-203.ts
+++ b/src/game-data/effects/cards/PR-203.ts
@@ -25,9 +25,10 @@ export const effects: CardEffects = {
       'マルブリッサの神術',
       'インターセプトカードを1枚引きレベル+1\n紫ゲージ-1'
     );
-    EffectHelper.random(targets).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'hand')
-    );
+    EffectHelper.random(targets).forEach(card => {
+      Effect.move(stack, stack.processing, card, 'hand');
+      Effect.clock(stack, stack.processing, card, 1);
+    });
     await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
   },
 };

--- a/src/game-data/effects/cards/PR-239.ts
+++ b/src/game-data/effects/cards/PR-239.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBattle: (stack: StackWithCard) =>
+    [stack.source, stack.target].some(
+      object => object instanceof Unit && object.owner.field.some(unit => unit.id === object?.id)
+    ),
+  onBattle: async (stack: StackWithCard) => {
+    await System.show(stack, '望まぬ争い', '【不滅】とデスカウンター[1]を付与');
+    if (stack.target instanceof Unit) {
+      Effect.death(stack, stack.processing, stack.target, 1);
+      Effect.keyword(stack, stack.processing, stack.target, '不滅');
+    }
+    if (stack.source instanceof Unit) {
+      Effect.death(stack, stack.processing, stack.source, 1);
+      Effect.keyword(stack, stack.processing, stack.source, '不滅');
+    }
+  },
+};

--- a/src/game-data/effects/cards/PR-242.ts
+++ b/src/game-data/effects/cards/PR-242.ts
@@ -1,6 +1,5 @@
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
   checkTurnStart: (stack: StackWithCard) => {
@@ -19,9 +18,7 @@ export const effects: CardEffects = {
     );
     stack.processing.owner.opponent.hand
       .filter(card => card.catalog.cost >= 7)
-      .forEach(card =>
-        card.delta.push(new Delta({ type: 'banned' }, { event: 'turnEnd', count: 1 }))
-      );
+      .forEach(card => Effect.ban(stack, stack.processing, card, { event: 'turnEnd', count: 1 }));
 
     if (intercepts.length > 0) {
       const [target] = await EffectHelper.selectCard(

--- a/src/game-data/effects/cards/PR-242.ts
+++ b/src/game-data/effects/cards/PR-242.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
@@ -17,7 +18,7 @@ export const effects: CardEffects = {
       `コスト7以上をフィールドに出せない${intercepts.length > 0 ? '\nインターセプトカードを選んで引く' : ''}`
     );
     stack.processing.owner.opponent.hand
-      .filter(card => card.catalog.cost >= 7)
+      .filter(card => card.catalog.cost >= 7 && card instanceof Unit)
       .forEach(card => Effect.ban(stack, stack.processing, card, { event: 'turnEnd', count: 1 }));
 
     if (intercepts.length > 0) {

--- a/src/game-data/effects/cards/PR-243.ts
+++ b/src/game-data/effects/cards/PR-243.ts
@@ -1,7 +1,6 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
   checkTurnStart: (stack: StackWithCard) => {
@@ -18,14 +17,10 @@ export const effects: CardEffects = {
       'コスト2以下のユニットを出せない\nジョーカーゲージ-20%\nCP+2\nトリガーカードを1枚引く'
     );
 
-    // 対戦相手の手札にあるコスト2以下のユニット
-    const bannedUnits = opponent.hand.filter(
-      unit => unit instanceof Unit && unit.catalog.cost <= 2
-    );
-    // ターン終了時までフィールドに出すことができない。
-    bannedUnits.forEach(unit =>
-      unit.delta.push(new Delta({ type: 'banned' }, { event: 'turnEnd', count: 1 }))
-    );
+    // 対戦相手の手札にあるコスト2以下のユニットを使用不能に
+    opponent.hand
+      .filter(unit => unit instanceof Unit && unit.catalog.cost <= 2)
+      .forEach(unit => Effect.ban(stack, stack.processing, unit, { event: 'turnEnd', count: 1 }));
 
     // ジョーカーゲージを20%減少させる
     Effect.modifyJokerGauge(stack, stack.processing, owner, -20);

--- a/src/game-data/effects/cards/SP-052.ts
+++ b/src/game-data/effects/cards/SP-052.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    EffectHelper.isUnitSelectable(stack.core, 'owns', stack.processing.owner),
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '自然の声', '基本BP-5000\nカードを1枚引く');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'owns',
+      '基本BPを-するユニットを選択'
+    );
+    Effect.modifyBP(stack, stack.processing, target, -5000, { isBaseBP: true });
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/game-data/effects/engine/effect.ts
+++ b/src/game-data/effects/engine/effect.ts
@@ -296,7 +296,7 @@ export class Effect {
   static clock(
     stack: Stack,
     source: Card,
-    target: Unit,
+    target: Card,
     value: number,
     withoutOverClock: boolean = false
   ): void {

--- a/src/game-data/effects/engine/effect.ts
+++ b/src/game-data/effects/engine/effect.ts
@@ -34,6 +34,7 @@ import {
   type ModifyBPOption,
   type KeywordOptionParams,
 } from './effect/index';
+import { effectBan } from '@/game-data/effects/engine/effect/ban';
 
 export type { ModifyBPOption, KeywordOptionParams };
 
@@ -523,5 +524,18 @@ export class Effect {
     option: { source: DeltaSource } & { calculator: DeltaCalculator }
   ) {
     target.delta.push(new Delta({ type: 'dynamic-cost', diff: option.calculator(target) }, option));
+  }
+
+  /**
+   * 対象のカードを使用不能にする
+   *
+   * @param stack - Stack
+   * @param source - 効果の発生元
+   * @param target - 使用不能にするカード
+   * @param options -
+   * @returns
+   */
+  static ban(stack: Stack, source: Card, target: Card, options: DeltaConstructorOptionParams) {
+    return effectBan(stack, source, target, options);
   }
 }

--- a/src/game-data/effects/engine/effect/ban.ts
+++ b/src/game-data/effects/engine/effect/ban.ts
@@ -1,0 +1,20 @@
+import type { Card } from '@/package/core/class/card';
+import { Delta, type DeltaConstructorOptionParams } from '@/package/core/class/delta';
+import type { Stack } from '@/package/core/class/stack';
+
+export function effectBan(
+  _stack: Stack,
+  _source: Card,
+  target: Card,
+  option?: DeltaConstructorOptionParams
+) {
+  // カードが操作可能領域にあるか
+  const isInOperableArea =
+    target.owner.hand.some(card => card.id === target.id) ||
+    target.owner.trigger.some(card => card.id === target.id);
+  if (!isInOperableArea) return;
+
+  // Deltaを作成
+  const delta = new Delta({ type: 'banned' }, option);
+  target.delta.push(delta);
+}

--- a/src/game-data/effects/engine/effect/clock.ts
+++ b/src/game-data/effects/engine/effect/clock.ts
@@ -1,12 +1,12 @@
 import type { Stack } from '@/package/core/class/stack';
-import type { Card, Unit } from '@/package/core/class/card';
+import { Unit, type Card } from '@/package/core/class/card';
 import { effectBreak } from './break';
 import { effectKeyword } from './keyword';
 
 export function effectClock(
   stack: Stack,
   source: Card,
-  target: Unit,
+  target: Card,
   value: number,
   withoutOverClock: boolean = false
 ): void {
@@ -16,7 +16,10 @@ export function effectClock(
   if (target.lv > 3) target.lv = 3;
   if (target.lv < 1) target.lv = 1;
 
-  if (target.owner.hand.find(card => card.id === target.id)) {
+  if (
+    target.owner.hand.find(card => card.id === target.id) ||
+    target.owner.trigger.find(card => card.id === target.id)
+  ) {
     if (target.lv !== before) {
       if (value > 0) stack.core.room.soundEffect('clock-up');
       if (value < 0) stack.core.room.soundEffect('trash');
@@ -24,7 +27,7 @@ export function effectClock(
     return;
   }
 
-  if (target.lv !== before) {
+  if (target.lv !== before && target instanceof Unit) {
     if (value > 0) {
       target.delta = target.delta.filter(delta => delta.effect.type !== 'damage');
       stack.core.room.soundEffect('clock-up');

--- a/src/game-data/effects/engine/effect/types.ts
+++ b/src/game-data/effects/engine/effect/types.ts
@@ -1,6 +1,5 @@
-import type { Delta, DeltaSource } from '@/package/core/class/delta';
+import type { Delta, DeltaCondition, DeltaSource } from '@/package/core/class/delta';
 import type { GameEvent } from '../../schema/events';
-import type { Unit } from '@/package/core/class/card';
 
 export interface KeywordOptionParams {
   event?: GameEvent;
@@ -14,7 +13,7 @@ export interface KeywordOptionParams {
    * @param blocker ブロッカーの候補
    * @returns falseでブロック可能、trueでブロック不可能
    */
-  condition?: (self?: Unit, blocker?: Unit) => boolean | unknown;
+  condition?: DeltaCondition;
 }
 
 export type ModifyBPOption =

--- a/src/game-data/effects/engine/effect/types.ts
+++ b/src/game-data/effects/engine/effect/types.ts
@@ -1,5 +1,6 @@
 import type { Delta, DeltaSource } from '@/package/core/class/delta';
 import type { GameEvent } from '../../schema/events';
+import type { Unit } from '@/package/core/class/card';
 
 export interface KeywordOptionParams {
   event?: GameEvent;
@@ -7,6 +8,13 @@ export interface KeywordOptionParams {
   cost?: number;
   onlyForOwnersTurn?: boolean;
   source?: DeltaSource;
+  /**
+   * 次元干渉の特殊条件関数
+   * @param self アタッカー
+   * @param blocker ブロッカーの候補
+   * @returns falseでブロック可能、trueでブロック不可能
+   */
+  condition?: (self?: Unit, blocker?: Unit) => boolean | unknown;
 }
 
 export type ModifyBPOption =

--- a/src/package/core/class/delta.ts
+++ b/src/package/core/class/delta.ts
@@ -1,6 +1,6 @@
 import type { DeltaEffect, IDelta, IUnit } from '@/submodule/suit/types';
 import type { StackWithCard } from '@/game-data/effects/schema/types';
-import type { Card } from './card';
+import type { Card, Unit } from './card';
 import type { GameEvent } from '@/game-data/effects/schema/events';
 
 export interface DeltaSource {
@@ -14,12 +14,14 @@ export interface DeltaEvent {
 }
 
 export type DeltaCalculator = (self: Card) => number;
+export type DeltaCondition = (self?: Unit, blocker?: Unit) => boolean | unknown;
 
 export type DeltaConstructorOptionParams = {
   onlyForOwnersTurn?: boolean;
   source?: DeltaSource;
   permanent?: boolean;
   calculator?: DeltaCalculator;
+  condition?: DeltaCondition;
 } & (DeltaEvent | {});
 
 export class Delta implements IDelta {
@@ -30,7 +32,8 @@ export class Delta implements IDelta {
   source?: DeltaSource;
   onlyForOwnersTurn: boolean; // このパラメータが true のとき、eventに合致するイベントが発生しても自分のターン中でない場合はcountを減算しない
   permanent: boolean; // このパラメータが true のとき、unit.reset() しても残す (効果が永続するという意味ではない。その場合はeventにundefiendを設定する。)
-  calculator?: (self: Card) => number; // 数値の変動を動的に計算する
+  calculator?: DeltaCalculator; // 数値の変動を動的に計算する
+  condition?: DeltaCondition; // 特殊条件次元干渉用
 
   constructor(effect: DeltaEffect, options: DeltaConstructorOptionParams | undefined = {}) {
     this.id = crypto.randomUUID();
@@ -45,6 +48,7 @@ export class Delta implements IDelta {
     this.source = options.source;
     this.permanent = options.permanent ?? false;
     this.calculator = options.calculator;
+    this.condition = options.condition;
   }
 
   /**

--- a/src/package/core/class/delta.ts
+++ b/src/package/core/class/delta.ts
@@ -14,7 +14,7 @@ export interface DeltaEvent {
 }
 
 export type DeltaCalculator = (self: Card) => number;
-export type DeltaCondition = (self?: Unit, blocker?: Unit) => boolean | unknown;
+export type DeltaCondition = (self?: Unit, blocker?: Unit) => boolean;
 
 export type DeltaConstructorOptionParams = {
   onlyForOwnersTurn?: boolean;

--- a/src/package/core/operations/battle.ts
+++ b/src/package/core/operations/battle.ts
@@ -161,8 +161,6 @@ export async function block(core: Core, attacker: Unit): Promise<Unit | undefine
   if (!blockerOwner || !attackerOwner)
     throw new Error('存在しないプレイヤーまたはユニットが指定されました');
 
-  console.log('block');
-
   // ブロック側ユニットのブロック可能ユニットを列挙
   const blockable = blockerOwner.field.filter((unit: Unit) => {
     // 次元干渉／コストN を発動している場合、指定コスト以上のユニットはブロックできない

--- a/src/package/core/operations/battle.ts
+++ b/src/package/core/operations/battle.ts
@@ -161,27 +161,27 @@ export async function block(core: Core, attacker: Unit): Promise<Unit | undefine
   if (!blockerOwner || !attackerOwner)
     throw new Error('存在しないプレイヤーまたはユニットが指定されました');
 
+  console.log('block');
+
   // ブロック側ユニットのブロック可能ユニットを列挙
   const blockable = blockerOwner.field.filter((unit: Unit) => {
-    // 次元干渉を発動している場合、指定コスト以上のユニットはブロックできない
-    const blockableCost = attacker.hasKeyword('次元干渉')
-      ? Math.min(
-          ...attacker.delta
-            .map(delta =>
-              delta.effect.type === 'keyword' && delta.effect.name === '次元干渉'
-                ? delta.effect.cost
-                : undefined
-            )
-            .filter(v => v !== undefined)
-        )
-      : undefined;
-    const isNumber = blockableCost !== undefined && Number.isInteger(blockableCost);
+    // 次元干渉／コストN を発動している場合、指定コスト以上のユニットはブロックできない
+    // Delta内の少なくとも1つがブロック不可能と判定すれば対象のunitにはブロックされない
+    const isUnblockable = attacker.hasKeyword('次元干渉')
+      ? attacker.delta
+          .filter(delta => delta.effect.type === 'keyword' && delta.effect.name === '次元干渉')
+          .some(delta => {
+            if (delta.effect.type === 'keyword' && delta.effect.name === '次元干渉') {
+              if (delta.condition) {
+                return delta.condition(attacker, unit);
+              } else {
+                return delta.effect.cost <= unit.catalog.cost;
+              }
+            }
+          })
+      : false;
 
-    return (
-      unit.active &&
-      !unit.hasKeyword('防御禁止') &&
-      (isNumber ? unit.catalog.cost < blockableCost : true)
-    );
+    return unit.active && !unit.hasKeyword('防御禁止') && !isUnblockable;
   });
 
   const forceBlock = blockable.filter((unit: Unit) => {

--- a/src/package/core/operations/battle.ts
+++ b/src/package/core/operations/battle.ts
@@ -176,6 +176,8 @@ export async function block(core: Core, attacker: Unit): Promise<Unit | undefine
                 return delta.effect.cost <= unit.catalog.cost;
               }
             }
+
+            return false;
           })
       : false;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 多数の新カード効果を追加（ドライブ／ブレイク／ターン開始／攻撃等の選択、召喚・破壊・生成・ダメージ・特殊キーワード付与を含む）。

* **改善**
  * カード禁止（ban）やクロック操作、永続効果の適用をエンジン経由で統一し、条件付き効果の柔軟性を向上。
  * ブロック判定をデルタ（条件）駆動の「解除不可」判定へ移行し、対戦挙動の一貫性を強化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->