### PR TITLE
カード効果修正

### DIFF
--- a/src/game-data/effects/cards/2-0-006.ts
+++ b/src/game-data/effects/cards/2-0-006.ts
@@ -5,7 +5,7 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   // 自身が召喚された時に発動する効果を記述
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, '胎動＆固着', '手札に戻らない\nコスト3以下に【狂戦士】を与える');
+    await System.show(stack, '胎動＆固着', 'コスト3以下に【狂戦士】を与える\n手札に戻らない');
     Effect.keyword(stack, stack.processing, stack.processing, '固着');
   },
 

--- a/src/game-data/effects/cards/2-0-014.ts
+++ b/src/game-data/effects/cards/2-0-014.ts
@@ -4,6 +4,7 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
 
 const onBattle = async (stack: StackWithCard) => {
+  if (stack.processing.owner.trash.length === 0) return;
   await System.show(stack, 'ミーナ頑張る！', '捨札を1枚消滅');
   EffectHelper.random(stack.processing.owner.trash).forEach(card =>
     Effect.move(stack, stack.processing, card, 'delete')
@@ -18,7 +19,8 @@ export const effects: CardEffects = {
     const isOpponentTurn = stack.processing.owner.id !== stack.core.getTurnPlayer().id;
     const isAtLeast15BlueCardsInTrash =
       stack.processing.owner.trash.filter(card => card.catalog.color === Color.BLUE).length >= 15;
-    const hasFieldSpace = stack.processing.owner.field.length <= 4;
+    const hasFieldSpace =
+      stack.processing.owner.field.length < stack.core.room.rule.player.max.field;
 
     if (isOpponentTurn && isAtLeast15BlueCardsInTrash && hasFieldSpace) {
       // oxlint-disable-next-line no-floating-promises

--- a/src/game-data/effects/cards/2-0-016.ts
+++ b/src/game-data/effects/cards/2-0-016.ts
@@ -4,10 +4,29 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
 
 const onBattle = async (stack: StackWithCard) => {
+  if (stack.processing.owner.trash.length === 0) return;
   await System.show(stack, '永久凍土', '捨札を3枚消滅');
   EffectHelper.random(stack.processing.owner.trash, 3).forEach(card =>
     Effect.move(stack, stack.processing, card, 'delete')
   );
+};
+
+const clockupEffect = async (stack: StackWithCard): Promise<void> => {
+  if (!(stack.target instanceof Unit)) return;
+  const isClockUpToLv3 =
+    stack.target.owner.id === stack.processing.owner.id && stack.target.lv === 3;
+  const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id && unit.lv >= 2;
+
+  if (isClockUpToLv3 && EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) {
+    await System.show(stack, '絶対零度の息吹', 'レベル2以上のユニットを1体破壊');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      filter,
+      '破壊するユニットを選択してください'
+    );
+    Effect.break(stack, stack.processing, target, 'effect');
+  }
 };
 
 export const effects: CardEffects = {
@@ -18,7 +37,8 @@ export const effects: CardEffects = {
     const isOpponentTurn = stack.processing.owner.id !== stack.core.getTurnPlayer().id;
     const isAtLeast25BlueCardsInTrash =
       stack.processing.owner.trash.filter(card => card.catalog.color === Color.BLUE).length >= 25;
-    const hasFieldSpace = stack.processing.owner.field.length <= 4;
+    const hasFieldSpace =
+      stack.processing.owner.field.length < stack.core.room.rule.player.max.field;
 
     if (isOpponentTurn && isAtLeast25BlueCardsInTrash && hasFieldSpace) {
       // oxlint-disable-next-line no-floating-promises
@@ -31,22 +51,11 @@ export const effects: CardEffects = {
   onBlockSelf: async (stack: StackWithCard): Promise<void> => await onBattle(stack),
   onBreakSelf: async (stack: StackWithCard): Promise<void> => await onBattle(stack),
 
-  onClockupSelf: async (stack: StackWithCard): Promise<void> => {
-    const isClockUpToLv3 = stack.processing.lv === 3;
-    const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id && unit.lv >= 2;
-
-    if (
-      isClockUpToLv3 &&
-      EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)
-    ) {
-      await System.show(stack, '絶対零度の息吹', 'レベル2以上のユニットを1体破壊');
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        filter,
-        '破壊するユニットを選択してください'
-      );
-      Effect.break(stack, stack.processing, target, 'effect');
+  onClockupSelf: clockupEffect,
+  onClockup: async (stack: StackWithCard): Promise<void> => {
+    if (!(stack.target instanceof Unit)) return;
+    if (stack.processing.id !== stack.target.id) {
+      await clockupEffect(stack);
     }
   },
 };

--- a/src/game-data/effects/cards/2-0-017.ts
+++ b/src/game-data/effects/cards/2-0-017.ts
@@ -4,6 +4,7 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
 
 const onBattle = async (stack: StackWithCard) => {
+  if (stack.processing.owner.trash.length === 0) return;
   await System.show(stack, 'オーシャンヒロイン', '捨札を2枚消滅');
   EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
     Effect.move(stack, stack.processing, card, 'delete')
@@ -18,7 +19,8 @@ export const effects: CardEffects = {
     const isOpponentTurn = stack.processing.owner.id !== stack.core.getTurnPlayer().id;
     const isAtLeast20BlueCardsInTrash =
       stack.processing.owner.trash.filter(card => card.catalog.color === Color.BLUE).length >= 20;
-    const hasFieldSpace = stack.processing.owner.field.length <= 4;
+    const hasFieldSpace =
+      stack.processing.owner.field.length < stack.core.room.rule.player.max.field;
 
     if (isOpponentTurn && isAtLeast20BlueCardsInTrash && hasFieldSpace) {
       // oxlint-disable-next-line no-floating-promises

--- a/src/game-data/effects/cards/2-0-024.ts
+++ b/src/game-data/effects/cards/2-0-024.ts
@@ -11,16 +11,17 @@ export const effects: CardEffects = {
       '自分の手札を選んで捨てる\nコスト3のユニットを1枚引く\n【秩序の盾】を得る'
     );
 
-    // 手札を選んで捨てる
     const owner = stack.processing.owner;
-    const [target] = await EffectHelper.selectCard(
-      stack,
-      owner,
-      owner.hand,
-      '捨てるカードを選択してください'
-    );
-    Effect.break(stack, stack.processing, target);
-
+    if (owner.hand.length > 0) {
+      // 手札を選んで捨てる
+      const [target] = await EffectHelper.selectCard(
+        stack,
+        owner,
+        owner.hand,
+        '捨てるカードを選択してください'
+      );
+      Effect.break(stack, stack.processing, target);
+    }
     // コスト3のユニットを引く
     const [card] = EffectHelper.random(
       owner.deck.filter(card => card.catalog.cost === 3 && card instanceof Unit),

--- a/src/game-data/effects/cards/2-0-026.ts
+++ b/src/game-data/effects/cards/2-0-026.ts
@@ -1,11 +1,15 @@
 import { Unit } from '@/package/core/class/card';
 import { EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { Color } from '@/submodule/suit/constant/color';
 
 export const effects: CardEffects = {
-  // このユニットがフィールドに出た時、あなたはインターセプトカードを1枚引く。
+  // このユニットがフィールドに出た時、あなたは紫属性のインターセプトカードを1枚引く。
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, 'インターセプトドロー', 'インターセプトカードを1枚引く');
-    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['intercept'] });
+    await System.show(stack, 'インターセプトドロー', '紫属性のインターセプトカードを1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, {
+      type: ['intercept'],
+      color: Color.PURPLE,
+    });
   },
 };

--- a/src/game-data/effects/cards/2-0-027.ts
+++ b/src/game-data/effects/cards/2-0-027.ts
@@ -3,11 +3,16 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
   onBreakSelf: async (stack: StackWithCard) => {
-    await System.show(stack, '幼竜の叫び', 'インターセプトカードを捨札から1枚回収\n紫ゲージ+1');
-    EffectHelper.random(
+    const targets = EffectHelper.random(
       stack.processing.owner.trash.filter(card => card.catalog.type === 'intercept'),
       1
-    ).forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+    );
+    if (targets.length > 0) {
+      await System.show(stack, '幼竜の叫び', 'インターセプトカードを捨札から1枚回収\n紫ゲージ+1');
+      targets.forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+    } else {
+      await System.show(stack, '幼竜の叫び', '紫ゲージ+1');
+    }
     await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
   },
 };

--- a/src/game-data/effects/cards/2-0-028.ts
+++ b/src/game-data/effects/cards/2-0-028.ts
@@ -28,14 +28,24 @@ export const effects: CardEffects = {
     );
 
     // 2000ダメージを与える
-    const destroyed = Effect.damage(stack, stack.processing, target, 2000, 'effect');
+    Effect.damage(stack, stack.processing, target, 2000, 'effect');
 
     // 紫ゲージ+1
     await Effect.modifyPurple(stack, stack.processing, owner, 1);
+  },
+
+  onBreak: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分の効果で破壊されたかチェック
+    if (
+      stack.source.id !== stack.processing.id ||
+      stack.option?.type !== 'break' ||
+      stack.option.cause !== 'damage'
+    )
+      return;
 
     // この効果でユニットを破壊した場合、追加で紫ゲージ+1
-    if (destroyed) {
-      await Effect.modifyPurple(stack, stack.processing, owner, 1);
-    }
+    const owner = stack.processing.owner;
+    await System.show(stack, '熱々のキスはいかが？', '紫ゲージ+1');
+    await Effect.modifyPurple(stack, stack.processing, owner, 1);
   },
 };

--- a/src/game-data/effects/cards/2-0-041.ts
+++ b/src/game-data/effects/cards/2-0-041.ts
@@ -3,6 +3,11 @@ import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
+  // 召喚時効果
+  onDriveSelf: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '聖なる悪意', 'レベル2の時【加護】を得る');
+  },
+
   // ターン開始時効果
   onTurnStart: async (stack: StackWithCard<Unit>) => {
     if (!EffectHelper.isUnitSelectable(stack.core, 'all', stack.processing.owner)) return;

--- a/src/game-data/effects/cards/2-0-044.ts
+++ b/src/game-data/effects/cards/2-0-044.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
     // 紫ゲージが4以上の場合、捨札からコスト3以下の紫属性ユニットを2体特殊召喚
     if (
       purpleGauge >= 4 &&
-      trashCards.length > 0 &&
+      trashCards.length >= 2 &&
       stack.core.room.rule.player.max.field - stack.processing.owner.field.length >= 2
     ) {
       await System.show(
@@ -58,10 +58,7 @@ export const effects: CardEffects = {
     // 紫属性ユニットに【貫通】を付与
     owner.field.forEach(unit => {
       if (unit.catalog.color === Color.PURPLE) {
-        Effect.keyword(stack, stack.processing, unit, '貫通', {
-          event: 'turnEnd',
-          count: 1,
-        });
+        Effect.keyword(stack, stack.processing, unit, '貫通');
       }
     });
 

--- a/src/game-data/effects/cards/2-0-045.ts
+++ b/src/game-data/effects/cards/2-0-045.ts
@@ -11,6 +11,8 @@ export const effects: CardEffects = {
   // 関数名に self は付かない
   onDrive: async (stack: StackWithCard): Promise<void> => {
     await System.show(stack, '愛しき来訪者', 'ユニットカードを1枚引く');
-    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['unit'] });
+    EffectTemplate.reinforcements(stack, stack.processing.owner, {
+      type: ['unit', 'advanced_unit'],
+    });
   },
 };

--- a/src/game-data/effects/cards/2-0-054.ts
+++ b/src/game-data/effects/cards/2-0-054.ts
@@ -11,12 +11,13 @@ export const effects: CardEffects = {
 
     const attacker = stack.target;
     const owner = stack.processing.owner;
-
-    // 相手が攻撃した場合は常に発動可能
-    if (attacker.owner.id !== owner.id) return true;
-
-    // 自分が攻撃した場合は、対戦相手に行動済ユニットが存在する時のみ発動可能
     const opponent = owner.opponent;
+
+    // 相手が攻撃した場合は、攻撃ユニットが存在している時のみ発動可能
+    if (attacker.owner.id === opponent.id) {
+      return opponent.field.some(unit => unit.id === attacker.id);
+    }
+    // 自分が攻撃した場合は、対戦相手に行動済ユニットが存在する時のみ発動可能
     return opponent.field.some(u => !u.active);
   },
 

--- a/src/game-data/effects/cards/2-0-055.ts
+++ b/src/game-data/effects/cards/2-0-055.ts
@@ -6,28 +6,30 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // あなたのターン開始時
   checkTurnStart: (stack: StackWithCard<Card>): boolean => {
-    // あなたのフィールドにユニットが1体以上いる場合に発動可能
-    return stack.source.id === stack.processing.owner.id && stack.processing.owner.field.length > 0;
+    const owner = stack.processing.owner;
+    // あなたのフィールドのユニットが選択できる場合に発動可能
+    return (
+      stack.source.id === stack.processing.owner.id &&
+      EffectHelper.isUnitSelectable(stack.core, 'owns', owner)
+    );
   },
 
   onTurnStart: async (stack: StackWithCard<Card>): Promise<void> => {
     const owner = stack.processing.owner;
 
+    await System.show(stack, 'チョークスリーパー', '選んだ以外の全ユニットの行動権を消費');
+
     // あなたのユニットを1体選ぶ
-    if (EffectHelper.isUnitSelectable(stack.core, 'owns', owner)) {
-      await System.show(stack, 'チョークスリーパー', '選んだ以外の全ユニットの行動権を消費');
+    const [keepUnit] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'owns',
+      '行動権を残すユニットを選択'
+    );
 
-      const [keepUnit] = await EffectHelper.pickUnit(
-        stack,
-        owner,
-        'owns',
-        '行動権を残すユニットを選択'
-      );
-
-      // それ以外の全てのユニットの行動権を消費
-      EffectHelper.exceptSelf(stack.core, keepUnit, unit =>
-        Effect.activate(stack, stack.processing, unit, false)
-      );
-    }
+    // それ以外の全てのユニットの行動権を消費
+    EffectHelper.exceptSelf(stack.core, keepUnit, unit =>
+      Effect.activate(stack, stack.processing, unit, false)
+    );
   },
 };


### PR DESCRIPTION
[2-0-006] 創世竜ティアマト
・効果説明文の順番を修正

[2-0-014] 天然魔道士ミーナ
・フィールド上限まで特殊召喚されるように修正
・捨て札が0枚の場合は捨て札消滅効果のメッセージが表示されないように修正

[2-0-016] ドラゴンブリザード
・フィールド上限まで特殊召喚されるように修正
・捨て札が0枚の場合は捨て札消滅効果のメッセージが表示されないように修正

[2-0-017] レヴィアタン
・フィールド上限まで特殊召喚されるように修正
・捨て札が0枚の場合は捨て札消滅効果のメッセージが表示されないように修正

[2-0-024] 聖少女ブリギッド
・手札が0枚の場合にはカードを捨てる処理をスキップするように修正

[2-0-026] なすカウ
・CIPで紫属性のインターセプトを引くように修正

[2-0-027] タイニードラコ
・捨て札に回収対象が無い場合に回収のメッセージが表示されないように修正

[2-0-028] パープルバニー
・破壊時の追加効果をonBreakで処理するように修正

[2-0-041] マスティマ
CIP時にフィールド効果のメッセージが表示されるように修正

[2-0-044] 魔天ルシファー
・特殊召喚対象が2体に満たない場合は効果が発動しないように修正
・アタック時に付与した【貫通】が、ターンエンドで消えないように修正

[2-0-045] 愛しき来訪者
・進化ユニットを引けるように修正

[2-0-054] 美しき彫像
・相手ユニットが破壊済みの場合に空打ちできないように修正

[2-0-055] チョークスリーパー
・自ユニットが加護で選択できない場合に、空打ちできないように修正

Fixes #518 
Fixes #521 
Fixes #522 
Fixes #523 
Fixes #524 
Fixes #525 
Fixes #526 
Fixes #527 
Fixes #528 
Fixes #529 
Fixes #530 
Fixes #531 
Fixes #532 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 空の墓地・手札に対する防御条件を追加し、不正な効果発動を防止
  * カード効果の条件判定ロジックを改善

* **新機能**
  * 複数のカードに新規効果を追加
  * カード増援の対象タイプを拡張

* **ゲームバランス調整**
  * 特定の効果発動条件を厳格化
  * ゲームルールに基づいた動的な値の参照を導入し、より一貫性のあるゲームプレイを実現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->