### PR TITLE
Fix/card fix 20260319

### DIFF
--- a/src/game-data/effects/cards/2-0-135.ts
+++ b/src/game-data/effects/cards/2-0-135.ts
@@ -11,7 +11,17 @@ export const effects: CardEffects = {
     }
 
     // 自分のユニットがフィールドに出た時のみ発動
-    return stack.target.owner.id === stack.processing.owner.id;
+    if (stack.target.owner.id !== stack.processing.owner.id) return false;
+
+    // 【神獣】ユニットがフィールドに出た時は、存在チェックを行う
+    if (
+      stack.target.catalog.species?.includes('神獣') &&
+      !stack.target.owner.field.some(unit => unit.id === stack.target?.id)
+    ) {
+      return false;
+    }
+
+    return true;
   },
 
   // トリガー効果

--- a/src/game-data/effects/cards/2-0-310.ts
+++ b/src/game-data/effects/cards/2-0-310.ts
@@ -67,7 +67,13 @@ export const effects: CardEffects = {
   // アタック時の効果
   onAttackSelf: spiritAttackEffect,
   onAttack: async (stack: StackWithCard<Unit>) => {
-    if (stack.target instanceof Unit && stack.target.id === stack.processing.id) return;
-    await spiritAttackEffect(stack);
+    if (stack.target instanceof Unit) {
+      if (
+        stack.target.id === stack.processing.id ||
+        stack.target.owner.id === stack.processing.owner.opponent.id
+      )
+        return;
+      await spiritAttackEffect(stack);
+    }
   },
 };

--- a/src/game-data/effects/cards/2-0-311.ts
+++ b/src/game-data/effects/cards/2-0-311.ts
@@ -38,9 +38,10 @@ export const effects: CardEffects = {
     Effect.activate(stack, stack.processing, target, false);
   },
 
-  // ターン終了時に相手の捨札から3枚をランダムで消滅
+  // 自分のターン終了時に相手の捨札から3枚をランダムで消滅
   onTurnEnd: async (stack: StackWithCard<Unit>) => {
     const opponent = stack.processing.owner.opponent;
+    if (stack.source.id === opponent.id) return;
     if (opponent.trash.length === 0) return;
 
     await System.show(stack, '食欲旺盛', '捨札から3枚消滅');

--- a/src/game-data/effects/cards/2-0-313.ts
+++ b/src/game-data/effects/cards/2-0-313.ts
@@ -1,10 +1,14 @@
-import type { Unit } from '@/package/core/class/card';
+import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
   // 自身が召喚された時に発動する効果を記述
   onDriveSelf: async (stack: StackWithCard): Promise<void> => {
+    if (!EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)) {
+      return;
+    }
+
     await System.show(stack, '黙滅の烏羽', '【沈黙】を与える');
     const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id;
     const [target] = await EffectHelper.pickUnit(
@@ -17,6 +21,11 @@ export const effects: CardEffects = {
   },
 
   onBreakSelf: async (stack: StackWithCard): Promise<void> => {
+    const targets = stack.processing.owner.trash.filter(
+      card => card instanceof Unit && card.catalog.species?.includes('盗賊')
+    );
+    if (targets.length === 0) return;
+
     await System.show(stack, '蒼き渡り鴉', '捨札から【盗賊】を1枚回収');
     EffectHelper.random(
       stack.processing.owner.trash.filter(card => card.catalog.species?.includes('盗賊')),

--- a/src/game-data/effects/cards/2-0-324.ts
+++ b/src/game-data/effects/cards/2-0-324.ts
@@ -10,6 +10,7 @@ export const effects: CardEffects = {
     );
 
     if (candidate.length > 0 && stack.processing.owner.field.length <= 4) {
+      await System.show(stack, '私の救世主さま', 'コスト7以下を【特殊召喚】');
       const [target] = await EffectHelper.selectCard<Unit>(
         stack,
         stack.processing.owner,
@@ -34,7 +35,7 @@ export const effects: CardEffects = {
       target instanceof Unit &&
       stack.processing.owner.field.length <= 4
     ) {
-      await System.show(stack, '私の救世主さま', 'コスト3以下を【特殊召喚】');
+      await System.show(stack, '星は巡る', 'コスト3以下を【特殊召喚】');
       await Effect.summon(stack, stack.processing, target);
     }
   },

--- a/src/game-data/effects/cards/2-0-333.ts
+++ b/src/game-data/effects/cards/2-0-333.ts
@@ -69,9 +69,6 @@ export const effects: CardEffects = {
   onIntercept: async (stack: StackWithCard<Unit>): Promise<void> => {
     const owner = stack.processing.owner;
 
-    // 自分のインターセプトカードが発動した場合のみ処理
-    if (stack.source.id !== owner.id) return;
-
     // ユニットを選べるか確認
     if (!EffectHelper.isUnitSelectable(stack.core, 'all', owner)) return;
 

--- a/src/game-data/effects/cards/2-0-338.ts
+++ b/src/game-data/effects/cards/2-0-338.ts
@@ -6,29 +6,31 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // トリガー: あなたがプレイヤーアタックを受けた時
   checkPlayerAttack: (stack: StackWithCard<Card>): boolean => {
-    return stack.target?.id === stack.processing.owner.id;
+    return (
+      stack.target?.id === stack.processing.owner.id &&
+      stack.processing.owner.hand.length > 0 &&
+      stack.processing.owner.opponent.field.length > 0
+    );
   },
 
   onPlayerAttack: async (stack: StackWithCard<Card>): Promise<void> => {
-    if (stack.processing.owner.hand.length > 0) {
-      // ランダムに手札を1枚捨てる
-      const cards = EffectHelper.random(stack.processing.owner.hand, 1);
-      const card = cards[0];
-      if (card) {
-        Effect.break(stack, stack.processing, card);
+    // ランダムに手札を1枚捨てる
+    const cards = EffectHelper.random(stack.processing.owner.hand, 1);
+    const card = cards[0];
+    if (card) {
+      await System.show(
+        stack,
+        'パラライズ・フォグ',
+        '全てのユニットの行動権を消費\n【呪縛】を付与'
+      );
 
-        await System.show(
-          stack,
-          'パラライズ・フォグ',
-          '全てのユニットの行動権を消費\n【呪縛】を付与'
-        );
+      Effect.break(stack, stack.processing, card);
 
-        // 全てのユニットの行動権を消費し、呪縛を与える
-        const allUnits = stack.core.players.flatMap(p => p.field);
-        for (const unit of allUnits) {
-          Effect.activate(stack, stack.processing, unit, false);
-          Effect.keyword(stack, stack.processing, unit, '呪縛');
-        }
+      // 全てのユニットの行動権を消費し、呪縛を与える
+      const allUnits = stack.core.players.flatMap(p => p.field);
+      for (const unit of allUnits) {
+        Effect.activate(stack, stack.processing, unit, false);
+        Effect.keyword(stack, stack.processing, unit, '呪縛');
       }
     }
   },

--- a/src/game-data/effects/cards/2-0-338.ts
+++ b/src/game-data/effects/cards/2-0-338.ts
@@ -6,10 +6,13 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // トリガー: あなたがプレイヤーアタックを受けた時
   checkPlayerAttack: (stack: StackWithCard<Card>): boolean => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
     return (
       stack.target?.id === stack.processing.owner.id &&
-      stack.processing.owner.hand.length > 0 &&
-      stack.processing.owner.opponent.field.length > 0
+      owner.hand.length > 0 &&
+      owner.field.length + opponent.field.length > 0
     );
   },
 

--- a/src/game-data/effects/cards/2-0-343.ts
+++ b/src/game-data/effects/cards/2-0-343.ts
@@ -7,9 +7,14 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // インターセプト: 対戦相手のターン終了時、あなたのフィールドのユニットが4体以下の場合
   checkTurnEnd: (stack: StackWithCard<Card>): boolean => {
+    const filter = (unit: Unit) =>
+      unit.owner.id === stack.processing.owner.id &&
+      (unit.catalog.species?.includes('武身') ?? false);
+
     return (
       stack.source.id === stack.processing.owner.opponent.id &&
-      stack.processing.owner.field.length <= 4
+      stack.processing.owner.field.length <= 4 &&
+      EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)
     );
   },
 
@@ -18,40 +23,38 @@ export const effects: CardEffects = {
       unit.owner.id === stack.processing.owner.id &&
       (unit.catalog.species?.includes('武身') ?? false);
 
-    if (EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) {
-      await System.show(
-        stack,
-        '鍛冶神の業物',
-        '【武身】をデッキに戻す\nコスト[戻したユニットのコスト+1]のユニットを【特殊召喚】'
-      );
+    await System.show(
+      stack,
+      '鍛冶神の業物',
+      '【武身】をデッキに戻す\nコスト[戻したユニットのコスト+1]のユニットを【特殊召喚】'
+    );
 
-      // 武身ユニットを選択
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        filter,
-        'デッキに戻すユニットを選択'
-      );
+    // 武身ユニットを選択
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      filter,
+      'デッキに戻すユニットを選択'
+    );
 
-      const targetCost = target.catalog.cost;
+    const targetCost = target.catalog.cost;
 
-      // デッキに戻す
-      Effect.bounce(stack, stack.processing, target, 'deck');
+    // デッキに戻す
+    Effect.bounce(stack, stack.processing, target, 'deck');
 
-      // コスト+1の武身ユニットをデッキから探す
-      const upperBushi = stack.processing.owner.deck.filter(
-        card =>
-          card instanceof Unit &&
-          card.catalog.species?.includes('武身') &&
-          card.catalog.cost === targetCost + 1 &&
-          !card.catalog.isEvolution
-      );
+    // コスト+1の武身ユニットをデッキから探す
+    const upperBushi = stack.processing.owner.deck.filter(
+      card =>
+        card instanceof Unit &&
+        card.catalog.species?.includes('武身') &&
+        card.catalog.cost === targetCost + 1 &&
+        !card.catalog.isEvolution
+    );
 
-      if (upperBushi.length > 0) {
-        const [summonTarget] = EffectHelper.random(upperBushi);
-        if (summonTarget instanceof Unit) {
-          await Effect.summon(stack, stack.processing, summonTarget);
-        }
+    if (upperBushi.length > 0) {
+      const [summonTarget] = EffectHelper.random(upperBushi);
+      if (summonTarget instanceof Unit) {
+        await Effect.summon(stack, stack.processing, summonTarget);
       }
     }
   },

--- a/src/game-data/effects/cards/2-0-360.ts
+++ b/src/game-data/effects/cards/2-0-360.ts
@@ -5,8 +5,16 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   // ■不可侵光壁
   // あなたのユニットが戦闘した時
-  checkBattle: (_stack: StackWithCard) => {
-    return true;
+  checkBattle: (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    const fields = [...owner.field, ...opponent.field];
+
+    // 戦闘中のユニットがフィールドにまだいる場合のみ発動
+    return (
+      fields.some(unit => unit.id === stack.source?.id) &&
+      fields.some(unit => unit.id === stack.target?.id)
+    );
   },
 
   onBattle: async (stack: StackWithCard): Promise<void> => {

--- a/src/game-data/effects/cards/2-1-004.ts
+++ b/src/game-data/effects/cards/2-1-004.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to red units in hand

--- a/src/game-data/effects/cards/2-1-009.ts
+++ b/src/game-data/effects/cards/2-1-009.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to yellow units in hand

--- a/src/game-data/effects/cards/2-1-014.ts
+++ b/src/game-data/effects/cards/2-1-014.ts
@@ -15,7 +15,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to blue units in hand

--- a/src/game-data/effects/cards/2-1-019.ts
+++ b/src/game-data/effects/cards/2-1-019.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to green units in hand

--- a/src/game-data/effects/cards/2-1-025.ts
+++ b/src/game-data/effects/cards/2-1-025.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to purple units in hand

--- a/src/game-data/effects/cards/2-2-105.ts
+++ b/src/game-data/effects/cards/2-2-105.ts
@@ -1,6 +1,6 @@
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Unit } from '@/package/core/class/card';
+import { Intercept, Trigger, Unit } from '@/package/core/class/card';
 import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
@@ -11,12 +11,12 @@ export const effects: CardEffects = {
     const handCards = owner.hand;
     const fieldUnits = owner.field;
 
-    await System.show(stack, '推理とは爆発だァ！', '手札とフィールドのユニットのレベル+1');
+    await System.show(stack, '推理とは爆発だァ！', '手札のカードとフィールドのユニットのレベル+1');
 
     // 手札のカードのレベルを+1する
     for (const card of handCards) {
-      if (card instanceof Unit) {
-        card.lv = Math.min(card.lv + 1, 3);
+      if (card instanceof Unit || card instanceof Intercept || card instanceof Trigger) {
+        Effect.clock(stack, stack.processing, card, 1);
       }
     }
 

--- a/src/game-data/effects/cards/2-3-032.ts
+++ b/src/game-data/effects/cards/2-3-032.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@/package/core/class/card';
 import { Delta } from '@/package/core/class/delta';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
@@ -39,7 +40,11 @@ export const effects: CardEffects = {
 
   checkDrive: (stack: StackWithCard) => {
     return (
+      stack.target instanceof Unit &&
       stack.source.id === stack.processing.owner.id &&
+      (stack.target.catalog.name === '織女星ベガ' ||
+        stack.target.catalog.name === '牽牛星アルタイル' ||
+        stack.target.catalog.name === '天川星デネブ') &&
       stack.processing.owner.hand.filter(
         unit =>
           unit.catalog.name === '織女星ベガ' ||

--- a/src/game-data/effects/cards/2-3-156.ts
+++ b/src/game-data/effects/cards/2-3-156.ts
@@ -17,20 +17,20 @@ export const effects: CardEffects = {
     const deck = stack.processing.owner.deck.filter(card => card.catalog.type === 'unit');
     switch (stack.processing.lv) {
       case 1: {
-        await System.show(stack, '花いろ日記', 'デッキからコスト2以下を【特殊召喚】');
-        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost <= 2));
+        await System.show(stack, '花いろ日記', 'デッキからコスト2を【特殊召喚】');
+        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost === 2));
         if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
         break;
       }
       case 2: {
-        await System.show(stack, '花いろ日記', 'デッキからコスト3以下を【特殊召喚】');
-        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost <= 3));
+        await System.show(stack, '花いろ日記', 'デッキからコスト3を【特殊召喚】');
+        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost === 3));
         if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
         break;
       }
       case 3: {
-        await System.show(stack, '花いろ日記', 'デッキからコスト5以下を【特殊召喚】');
-        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost <= 5));
+        await System.show(stack, '花いろ日記', 'デッキからコスト5を【特殊召喚】');
+        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost === 5));
         if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
         break;
       }

--- a/src/game-data/effects/cards/2-3-233.ts
+++ b/src/game-data/effects/cards/2-3-233.ts
@@ -1,4 +1,4 @@
-import { Effect, System } from '..';
+import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
@@ -16,7 +16,26 @@ export const effects: CardEffects = {
   // 実際の効果本体
   // 関数名に self は付かない
   onTurnStart: async (stack: StackWithCard): Promise<void> => {
-    await System.show(stack, 'トリニティ・アステリズム', '3ライフダメージ');
+    const opponent = stack.processing.owner.opponent;
+    // 対戦相手のフィールド、トリガーゾーン、手札のカードをリストアップ
+    const targetCards = [...opponent.field, ...opponent.trigger, ...opponent.hand];
+    if (targetCards.length > 0) {
+      await System.show(
+        stack,
+        'トリニティ・アステリズム',
+        'フィールド/トリガーゾーン/手札から3枚消滅\n3ライフダメージ'
+      );
+
+      // 消滅させる枚数（最大3枚まで）
+      const deleteCount = Math.min(3, targetCards.length);
+      const randomCards = EffectHelper.random(targetCards, deleteCount);
+      // 選択したカードを消滅させる
+      for (const card of randomCards) {
+        Effect.delete(stack, stack.processing, card);
+      }
+    } else {
+      await System.show(stack, 'トリニティ・アステリズム', '3ライフダメージ');
+    }
     Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -3);
   },
 };

--- a/src/game-data/effects/cards/2-3-233.ts
+++ b/src/game-data/effects/cards/2-3-233.ts
@@ -1,4 +1,4 @@
-import { Effect, EffectHelper, System } from '..';
+import { Effect, EffectHelper } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
@@ -19,23 +19,27 @@ export const effects: CardEffects = {
     const opponent = stack.processing.owner.opponent;
     // 対戦相手のフィールド、トリガーゾーン、手札のカードをリストアップ
     const targetCards = [...opponent.field, ...opponent.trigger, ...opponent.hand];
-    if (targetCards.length > 0) {
-      await System.show(
-        stack,
-        'トリニティ・アステリズム',
-        'フィールド/トリガーゾーン/手札から3枚消滅\n3ライフダメージ'
-      );
 
-      // 消滅させる枚数（最大3枚まで）
-      const deleteCount = Math.min(3, targetCards.length);
-      const randomCards = EffectHelper.random(targetCards, deleteCount);
-      // 選択したカードを消滅させる
-      for (const card of randomCards) {
-        Effect.delete(stack, stack.processing, card);
-      }
-    } else {
-      await System.show(stack, 'トリニティ・アステリズム', '3ライフダメージ');
-    }
-    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -3);
+    await EffectHelper.combine(stack, [
+      {
+        title: 'トリニティ・アステリズム',
+        description: 'フィールド/トリガーゾーン/手札から3枚消滅',
+        effect: () => {
+          // 消滅させる枚数（最大3枚まで）
+          const randomCards = EffectHelper.random(targetCards, 3);
+          // 選択したカードを消滅させる
+          for (const card of randomCards) {
+            Effect.delete(stack, stack.processing, card);
+          }
+        },
+        condition: targetCards.length > 0,
+      },
+      {
+        title: 'トリニティ・アステリズム',
+        description: '3ライフダメージ',
+        effect: () =>
+          Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -3),
+      },
+    ]);
   },
 };

--- a/src/game-data/effects/cards/PR-234.ts
+++ b/src/game-data/effects/cards/PR-234.ts
@@ -17,6 +17,8 @@ export const effects: CardEffects = {
       stack.source.owner.id === stack.processing.owner.id &&
       stack.target instanceof Unit &&
       stack.target.owner.id !== stack.processing.owner.id &&
+      stack.option?.type === 'damage' &&
+      stack.option?.cause === 'effect' &&
       // 効果発動の条件を確認
       (EffectHelper.isUnitSelectable(stack.core, 'opponents', owner) ||
         owner.trigger.length < stack.core.room.rule.player.max.trigger)


### PR DESCRIPTION
[2-0-135] 神獣の住む秘境
・召喚した神獣が破壊済みの場合に空打ちしないように修正

[2-0-310] ジンニーヤ
・対戦相手の【精霊】ユニットがアタックした時に効果が発動しないように修正

[2-0-311] ハーピー
・相手ターン終了時に捨て札消滅効果が発動しないように修正

[2-0-313] レイヴンテング
・相手ユニットが選択不可の場合にCIPのメッセージが表示されないように修正
・捨て札に盗賊ユニットが無い場合に破壊時のメッセージが表示されないように修正

[2-0-324] 星天女アンドロメダ
・メッセージが正しく表示されるように修正

[2-0-333] ヘカトンケイル
・相手のインターセプト使用時に基本BP上昇効果が発動するように修正

[2-0-338] パラライズ・フォグ
・効果対象が無い場合に空打ちしないように修正
・効果メッセージ表示後に手札を捨てる処理を行うように修正

[2-0-343] 鍛冶神の業物
・自分の場に武身がいない場合に空打ちしないように修正

[2-0-360] 不可侵光壁
・戦闘中のユニットが破壊されていた場合に空打ちしないように修正

[2-2-105] 未来探偵ホームズ
・CIP効果で手札のトリガーとインターセプトのレベルが上がるように修正

[2-1-004] ストロベリーガール
[2-1-009] レモンガール
[2-1-014] ブルーベリーガール
[2-1-019] メロンガール
[2-1-025] グレープガール
・トリガーカード、インターセプトカードを使用した時にコスト軽減効果が終了しないように修正

[2-3-032] トライフォース
・ベガ・デネブ・アルタイルが出た時のみ発動できるように修正

[2-3-156] 花いろ日記
・特殊召喚対象のコスト指定が正しくなるように修正

[2-3-233] トリニティ・アステリズム
・消滅効果を実装

[PR-234] 神慌意乱
・戦闘によるダメージで効果が発動しないように修正

Fixes #511 
Fixes #512  
Fixes #535 
Fixes #536 
Fixes #537 
Fixes #538 
Fixes #539  
Fixes #540 
Fixes #541 
Fixes #542 
Fixes #543 
Fixes #544 
Fixes #545 
Fixes #546 
Fixes #547 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 複数のカードのトリガー条件と効果の発動タイミングを調整しました
  * カードの対象指定ルールを改善し、より正確な動作を実現しました
  * 特定のカードの能力が適切な状況でのみ発動するよう修正しました
  * ターン終了時やドライブ時の効果判定を精密化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->