### PR TITLE
2026-04-28-01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: bunx oxfmt --check src
 
       - name: Lint (oxlint)
-        run: bunx oxlint --type-aware
+        run: bunx oxlint
 
       - name: Lint (ESLint)
         run: bunx eslint

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 CODE OF JOKERのシミュレーションシステムを提供するWebSocketサーバ
 
+> [!Tip]
+> 個人のサーバを建てたくてここに訪れている場合は、[the-highpriestess](https://github.com/sweshelo/the-highpriestess) を利用するとより簡単です  
+> サーバ構築や開発で疑問点があれば、お気軽にIssueまたはDiscordなどでご連絡下さい  
+
 ## ドキュメント
 
 開発を始める前に、以下のドキュメントを参照してください：

--- a/bun.lock
+++ b/bun.lock
@@ -33,15 +33,15 @@
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
 
-    "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
 
     "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
 
     "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
 
-    "@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
@@ -71,31 +71,33 @@
 
     "@oxfmt/win32-x64": ["@oxfmt/win32-x64@0.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fkJqHbJaoOMRmrjHSljyb4/7BgXO3xPLBsJSFGtm3mpfW0HHFbAKvd4/6njhqJz9KY+b3RWP1WssjFshcqQQ4w=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.10.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mhBF/pjey0UdLL1ocU46Fqta+uJuRfqrLfDpcViRg17BtDiUNd8JY9iN2FOoS2HGSCAgCUjZ0AZkwkHwFs/VTw=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.10.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-KGC4++BeEqrIcmDHiJt/e6/860PWJmUJjjp0mE+smpBmRXMjmOFFjrPmN+ZyCyVgf1WdmhPkQXsRSPeTR+2omw=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.10.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-roLi34mw/i1z+NS7luboix55SXyhVv38dNUTcRDkk+0lNPzI9ngrM+1y1N2oBSUmz5o9OZGnfJJ7BSGCw/fFEQ=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.10.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-tvmrDgj3Q0tdc+zMWfCVLVq8EQDEUqasm1zaWgSMYIszpID6qdgqbT+OpWWXV9fLZgtvrkoXGwxkHAUJzdVZXQ=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-HL9NThPH1V2F6l9XhwNmhQZUknN4m4yQYEvQFFGfZTYN6cvEEBIiqfF4KvBUg8c0xadMbQlW+Ug7/ybA9Nn+CA=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-7kD28z6/ykGx8WetKTPRZt30pd+ziassxg/8cM24lhjUI+hNXyRHVtHes73dh9D6glJKno+1ut+3amUdZBZcpQ=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Tw8QNq8ab+4+qE5krvJyMA66v6XE3GoiISRD5WmJ7YOxUnu//jSw/bBm7OYf/TNEZyeV0BTR7zXzhT5R+VFWlQ=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-NmJmiqdzYUTHIxteSTyX6IFFgnIsOAjRWXfrS6Jbo5xlB3g39WHniSF3asB/khLJNtwSg4InUS34NprYM7zrEw=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.10.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-LTogmTRwpwQqVaH1Ama8Wd5/VVZWBSF8v5qTbeT628+1F5Kt1V5eHBvyFh4oN18UCZlgqrh7DqkDhsieXUaC8Q=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.10.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-3KrT80vl3nXUkjuJI/z8dF6xWsKx0t9Tz4ZQHgQw3fYw+CoihBRWGklrdlmCz+EGfMyVaQLqBV9PZckhSqLe2A=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ygqxx8EmNWy9/wCQS5uXq9k/o2EyYNwNxY1ZHNzlmZC/kV06Aemx5OBDafefawBNqH7xTZPfccUrjdiy+QlTrw=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-hW1fSJZVxG51sLdGq1sQjOzb1tsQ23z/BquJfUwL7CqBobxr7TJvGmoINL+9KryOJt0jCoaiMfWe4yoYw5XfIA=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.93.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-JdnkHZPKexVGSNONtu89RHU4bxz3X9kxx+f5ZnR5osoCIX+vs/MckwWRPZEybAEvlJXt5xjomDb3IB876QCxWQ=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.104.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.93.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-qWO0gHNDm/5jRjROv/nv9L6sYabCWS1kzorOLUv3kqCwRvEJLYZga93ppJPrZwOgoZfXmJzvpjY8fODA4HQfBw=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.104.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-JjAH4JN9rZzxh4plQnILPrQZXAG6ccoRS6z9hQAGmXpRSwJA+7CWbsDV2R82I8MROlGDsjqj1Ot/cWpTfdf6xg=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.93.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-+iJ96g94skO2e4clsRSmEXg22NUOjh9BziapsJSAvnB1grOBf/BA8vGtCHjNOA+Z6lvKXL1jwBqcL9+fS1W/Lg=="],
+    "@supabase/phoenix": ["@supabase/phoenix@0.4.0", "", {}, "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.93.3", "", { "dependencies": { "@types/phoenix": "^1.6.6", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-gnYpcFzwy8IkezRP4CDbT5I8jOsiOjrWrqTY1B+7jIriXsnpifmlM6RRjLBm9oD7OwPG0/WksniGPdKW67sXOA=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.104.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-RqlLpvgXsjcc27fLyHNGm3zN0KDWXbkdTdaFtaEdX83RsTEqH7BAmshH7zoUMml5lL04naUeRjS3B81O6jZcJw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.93.3", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-cw4qXiLrx3apglDM02Tx/w/stvFlrkKocC6vCvuFAz3JtVEl1zH8MUfDQDTH59kJAQVaVdbewrMWSoBob7REnA=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.104.1", "", { "dependencies": { "@supabase/phoenix": "^0.4.0", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-dVJHhFB2ErBd0/2qE9G8CedCrGoAtBfL9Q4zbSMXO7b1Cpld916ljSiX21mURUqijPf1WoPQG4Bp/averUzk/g=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.93.3", "", { "dependencies": { "@supabase/auth-js": "2.93.3", "@supabase/functions-js": "2.93.3", "@supabase/postgrest-js": "2.93.3", "@supabase/realtime-js": "2.93.3", "@supabase/storage-js": "2.93.3" } }, "sha512-paUqEqdBI9ztr/4bbMoCgeJ6M8ZTm2fpfjSOlzarPuzYveKFM20ZfDZqUpi9CFfYagYj5Iv3m3ztUjaI9/tM1w=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.104.1", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-2bQaLbkRshctkUVuqamwYZDEd+0cGSc9DY9sjh92DcA5hu1F/1AP8p6gxGr76sgdK9Ngi0rh+2Kdh+uC4hcnGA=="],
 
-    "@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.104.1", "", { "dependencies": { "@supabase/auth-js": "2.104.1", "@supabase/functions-js": "2.104.1", "@supabase/postgrest-js": "2.104.1", "@supabase/realtime-js": "2.104.1", "@supabase/storage-js": "2.104.1" } }, "sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -105,37 +107,35 @@
 
     "@types/node": ["@types/node@22.13.10", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw=="],
 
-    "@types/phoenix": ["@types/phoenix@1.6.7", "", {}, "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="],
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/type-utils": "8.59.0", "@typescript-eslint/utils": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.52.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.52.0", "@typescript-eslint/type-utils": "8.52.0", "@typescript-eslint/utils": "8.52.0", "@typescript-eslint/visitor-keys": "8.52.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.52.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.52.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.52.0", "@typescript-eslint/types": "8.52.0", "@typescript-eslint/typescript-estree": "8.52.0", "@typescript-eslint/visitor-keys": "8.52.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.0", "@typescript-eslint/types": "^8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.52.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.52.0", "@typescript-eslint/types": "^8.52.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0" } }, "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.52.0", "", { "dependencies": { "@typescript-eslint/types": "8.52.0", "@typescript-eslint/visitor-keys": "8.52.0" } }, "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.52.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.52.0", "", { "dependencies": { "@typescript-eslint/types": "8.52.0", "@typescript-eslint/typescript-estree": "8.52.0", "@typescript-eslint/utils": "8.52.0", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.0", "", {}, "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.52.0", "", {}, "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.0", "@typescript-eslint/tsconfig-utils": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.52.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.52.0", "@typescript-eslint/tsconfig-utils": "8.52.0", "@typescript-eslint/types": "8.52.0", "@typescript-eslint/visitor-keys": "8.52.0", "debug": "^4.4.3", "minimatch": "^9.0.5", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.52.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.52.0", "@typescript-eslint/types": "8.52.0", "@typescript-eslint/typescript-estree": "8.52.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.52.0", "", { "dependencies": { "@typescript-eslint/types": "8.52.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ=="],
-
-    "acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "acorn-jsx-walk": ["acorn-jsx-walk@2.0.0", "", {}, "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA=="],
 
-    "acorn-loose": ["acorn-loose@8.4.0", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-M0EUka6rb+QC4l9Z3T0nJEzNOO7JcoJlYMrBlyBCiFSXRyxjLKayd4TbQs2FDRWQU1h9FR7QVNHt+PEaoNL5rQ=="],
+    "acorn-loose": ["acorn-loose@8.5.2", "", { "dependencies": { "acorn": "^8.15.0" } }, "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A=="],
 
     "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
 
@@ -149,7 +149,7 @@
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
-    "bun-types": ["bun-types@1.2.5", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-3oO6LVGGRRKI4kHINx5PIdIgnLRb7l/SprhzqXapmoYkFl5m4j6EvALvbDVuuBFaamB46Ap6HCUxIXNLCGy+tg=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -169,13 +169,13 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
-    "dependency-cruiser": ["dependency-cruiser@16.10.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-jsx": "^5.3.2", "acorn-jsx-walk": "^2.0.0", "acorn-loose": "^8.4.0", "acorn-walk": "^8.3.4", "ajv": "^8.17.1", "commander": "^13.1.0", "enhanced-resolve": "^5.18.1", "ignore": "^7.0.3", "interpret": "^3.1.1", "is-installed-globally": "^1.0.0", "json5": "^2.2.3", "memoize": "^10.0.0", "picocolors": "^1.1.1", "picomatch": "^4.0.2", "prompts": "^2.4.2", "rechoir": "^0.8.0", "safe-regex": "^2.1.1", "semver": "^7.7.1", "teamcity-service-messages": "^0.1.14", "tsconfig-paths-webpack-plugin": "^4.2.0", "watskeburt": "^4.2.3" }, "bin": { "dependency-cruiser": "bin/dependency-cruise.mjs", "dependency-cruise": "bin/dependency-cruise.mjs", "depcruise": "bin/dependency-cruise.mjs", "depcruise-baseline": "bin/depcruise-baseline.mjs", "depcruise-fmt": "bin/depcruise-fmt.mjs", "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs" } }, "sha512-o6pEB8X/XS0AjpQBhPJW3pSY7HIviRM7+G601T9ruV63NVJC4DxLMA+a1VzZlKOzO2fO6JKRHjRmGjzZZHEFYA=="],
+    "dependency-cruiser": ["dependency-cruiser@16.10.4", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "acorn-jsx-walk": "^2.0.0", "acorn-loose": "^8.5.2", "acorn-walk": "^8.3.4", "ajv": "^8.17.1", "commander": "^13.1.0", "enhanced-resolve": "^5.18.2", "ignore": "^7.0.5", "interpret": "^3.1.1", "is-installed-globally": "^1.0.0", "json5": "^2.2.3", "memoize": "^10.1.0", "picocolors": "^1.1.1", "picomatch": "^4.0.2", "prompts": "^2.4.2", "rechoir": "^0.8.0", "safe-regex": "^2.1.1", "semver": "^7.7.2", "teamcity-service-messages": "^0.1.14", "tsconfig-paths-webpack-plugin": "^4.2.0", "watskeburt": "^4.2.3" }, "bin": { "depcruise": "bin/dependency-cruise.mjs", "depcruise-fmt": "bin/depcruise-fmt.mjs", "dependency-cruise": "bin/dependency-cruise.mjs", "depcruise-baseline": "bin/depcruise-baseline.mjs", "dependency-cruiser": "bin/dependency-cruise.mjs", "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs" } }, "sha512-hrxVOjIm8idZ9ZVDGSyyG3SHiNcEUPhL6RTEmO/3wfQWLepH5pA3nuDMMrcJ1DkZztFA7xg3tk8OVO+MmwwH9w=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
+    "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -215,7 +215,7 @@
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
-    "globals": ["globals@16.0.0", "", {}, "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A=="],
+    "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -247,9 +247,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "jiti": ["jiti@2.4.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
-
-    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -263,27 +261,27 @@
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "lefthook": ["lefthook@2.0.13", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.0.13", "lefthook-darwin-x64": "2.0.13", "lefthook-freebsd-arm64": "2.0.13", "lefthook-freebsd-x64": "2.0.13", "lefthook-linux-arm64": "2.0.13", "lefthook-linux-x64": "2.0.13", "lefthook-openbsd-arm64": "2.0.13", "lefthook-openbsd-x64": "2.0.13", "lefthook-windows-arm64": "2.0.13", "lefthook-windows-x64": "2.0.13" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-D39rCVl7/GpqakvhQvqz07SBpzUWTvWjXKnBZyIy8O6D+Lf9xD6tnbHtG5nWXd9iPvv1AKGQwL9R/e5rNtV6SQ=="],
+    "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
 
-    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.0.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-KbQqpNSNTugjtPzt97CNcy/XZy5asJ0+uSLoHc4ML8UCJdsXKYJGozJHNwAd0Xfci/rQlj82A7rPOuTdh0jY0Q=="],
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ=="],
 
-    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.0.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-s/vI6sEE8/+rE6CONZzs59LxyuSc/KdU+/3adkNx+Q13R1+p/AvQNeszg3LAHzXmF3NqlxYf8jbj/z5vBzEpRw=="],
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ=="],
 
-    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.0.13", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-iQeJTU7Zl8EJlCMQxNZQpJFAQ9xl40pydUIv5SYnbJ4nqIr9ONuvrioNv6N2LtKP5aBl1nIWQQ9vMjgVyb3k+A=="],
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA=="],
 
-    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.0.13", "", { "os": "freebsd", "cpu": "x64" }, "sha512-99cAXKRIzpq/u3obUXbOQJCHP+0ZkJbN3TF+1ZQZlRo3Y6+mPSCg9fh/oi6dgbtu4gTI5Ifz3o5p2KZzAIF9ZQ=="],
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg=="],
 
-    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.0.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-RWarenY3kLy/DT4/8dY2bwDlYwlELRq9MIFq+FiMYmoBHES3ckWcLX2JMMlM49Y672paQc7MbneSrNUn/FQWhg=="],
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g=="],
 
-    "lefthook-linux-x64": ["lefthook-linux-x64@2.0.13", "", { "os": "linux", "cpu": "x64" }, "sha512-QZRcxXGf8Uj/75ITBqoBh0zWhJE7+uFoRxEHwBq0Qjv55Q4KcFm7FBN/IFQCSd14reY5pmY3kDaWVVy60cAGJA=="],
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw=="],
 
-    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.0.13", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-LAuOWwnNmOlRE0RxKMOhIz5Kr9tXi0rCjzXtDARW9lvfAV6Br2wP+47q0rqQ8m/nVwBYoxfJ/RDunLbb86O1nA=="],
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A=="],
 
-    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.0.13", "", { "os": "openbsd", "cpu": "x64" }, "sha512-n9TIN3QLncyxOHomiKKwzDFHKOCm5H28CVNAZFouKqDwEaUGCs5TJI88V85j4/CgmLVUU8uUn4ClVCxIWYG59w=="],
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg=="],
 
-    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.0.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-sdSC4F9Di7y0t43Of9MOA5g/0CmvkM4juQ3sKfUhRcoygetLJn4PR2/pvuDOIaGf4mNMXBP5IrcKaeDON9HrcA=="],
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
 
-    "lefthook-windows-x64": ["lefthook-windows-x64@2.0.13", "", { "os": "win32", "cpu": "x64" }, "sha512-ccl1v7Fl10qYoghEtjXN+JC1x/y/zLM/NSHf3NFGeKEGBNd1P5d/j6w8zVmhfzi+ekS8whXrcNbRAkLdAqUrSw=="],
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -295,13 +293,13 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
+    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -309,7 +307,7 @@
 
     "oxfmt": ["oxfmt@0.20.0", "", { "dependencies": { "tinypool": "2.0.0" }, "optionalDependencies": { "@oxfmt/darwin-arm64": "0.20.0", "@oxfmt/darwin-x64": "0.20.0", "@oxfmt/linux-arm64-gnu": "0.20.0", "@oxfmt/linux-arm64-musl": "0.20.0", "@oxfmt/linux-x64-gnu": "0.20.0", "@oxfmt/linux-x64-musl": "0.20.0", "@oxfmt/win32-arm64": "0.20.0", "@oxfmt/win32-x64": "0.20.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-+7f8eV8iaK3tENN/FUVxZM1g78HjPehybN8/+/dvEA1O893Dcvk6O7/Q1wTQOHMD7wvdwWdujKl+Uo8QMiKDrQ=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.10.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.10.0", "@oxlint-tsgolint/darwin-x64": "0.10.0", "@oxlint-tsgolint/linux-arm64": "0.10.0", "@oxlint-tsgolint/linux-x64": "0.10.0", "@oxlint-tsgolint/win32-arm64": "0.10.0", "@oxlint-tsgolint/win32-x64": "0.10.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-LDDSIu5J/4D4gFUuQQIEQpAC6maNEbMg4nC8JL/+Pe0cUDR86dtVZ09E2x5MwCh8f9yfktoaxt5x6UIVyzrajg=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@0.10.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.10.1", "@oxlint-tsgolint/darwin-x64": "0.10.1", "@oxlint-tsgolint/linux-arm64": "0.10.1", "@oxlint-tsgolint/linux-x64": "0.10.1", "@oxlint-tsgolint/win32-arm64": "0.10.1", "@oxlint-tsgolint/win32-x64": "0.10.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-EEHNdo5cW2w1xwYdBQ7d3IXDqWAtMkfVFrh+9gQ4kYbYJwygY4QXSh1eH80/xVipZdVKujAwBgg/nNNHk56kxQ=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -325,7 +323,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -345,7 +343,7 @@
 
     "safe-regex": ["safe-regex@2.1.1", "", { "dependencies": { "regexp-tree": "~0.1.1" } }, "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A=="],
 
-    "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -361,7 +359,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tapable": ["tapable@2.2.1", "", {}, "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="],
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "teamcity-service-messages": ["teamcity-service-messages@0.1.14", "", {}, "sha512-29aQwaHqm8RMX74u2o/h1KbMLP89FjNiMxD9wbF2BbWOnbM+q+d1sCEC+MqCc4QW3NJykn77OMpTFw/xTHIc0w=="],
 
@@ -369,7 +367,7 @@
 
     "tinypool": ["tinypool@2.0.0", "", {}, "sha512-/RX9RzeH2xU5ADE7n2Ykvmi9ED3FBGPAjw9u3zucrNNaEBIO0HPSYgL0NT7+3p147ojeSdaVu08F6hjpv31HJg=="],
 
-    "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
@@ -381,7 +379,7 @@
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
-    "typescript-eslint": ["typescript-eslint@8.52.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.52.0", "@typescript-eslint/parser": "8.52.0", "@typescript-eslint/typescript-estree": "8.52.0", "@typescript-eslint/utils": "8.52.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA=="],
+    "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
@@ -393,42 +391,38 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/eslintrc/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "@eslint/eslintrc/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "@supabase/realtime-js/@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "@supabase/realtime-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "acorn-walk/acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "dependency-cruiser/ignore": ["ignore@7.0.3", "", {}, "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA=="],
-
-    "eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "espree/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+    "tsconfig-paths-webpack-plugin/enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "tsconfig-paths-webpack-plugin/tapable": ["tapable@2.2.1", "", {}, "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="],
 
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,7 @@
 pre-commit:
   jobs:
     - name: lint
-      run: bunx oxlint {staged_files} --type-aware
+      run: bunx oxlint {staged_files}
 
     - name: ban as
       run: bunx eslint

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preinstall": "git submodule update --init --recursive",
     "dev": "bun --hot run src/index.ts",
     "prepare": "lefthook install",
-    "lint": "bunx oxlint --type-aware && bunx eslint --fix"
+    "lint": "bunx oxlint && bunx eslint --fix"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.10",

--- a/src/game-data/effects/cards/1-0-008.ts
+++ b/src/game-data/effects/cards/1-0-008.ts
@@ -6,6 +6,8 @@ import type { Unit } from '@/package/core/class/card';
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
     await System.show(stack, '聖女の加護', 'ブロックされない');
-    Effect.keyword(stack, stack.processing, stack.processing, '次元干渉', { cost: 0 });
+    Effect.keyword(stack, stack.processing, stack.processing, '次元干渉', {
+      condition: () => true,
+    });
   },
 };

--- a/src/game-data/effects/cards/1-0-012.ts
+++ b/src/game-data/effects/cards/1-0-012.ts
@@ -37,7 +37,7 @@ export const effects: CardEffects = {
 
     // ランダムで1枚選択して破壊
     EffectHelper.random(opponent.trigger, 1).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
   },
 };

--- a/src/game-data/effects/cards/1-0-052.ts
+++ b/src/game-data/effects/cards/1-0-052.ts
@@ -1,0 +1,24 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(
+      stack,
+      '貫通＆不屈',
+      'ブロックを貫通してプレイヤーにダメージを与える\nターン終了時に行動権を回復'
+    );
+    Effect.keyword(stack, stack.processing, stack.processing, '不屈');
+    Effect.keyword(stack, stack.processing, stack.processing, '貫通');
+  },
+
+  onOverclockSelf: async (stack: StackWithCard<Unit>) => {
+    if (stack.processing.owner.opponent.field.length === 0) return;
+    await System.show(stack, 'オーラブレード', '敵全体の基本BP-3000');
+    stack.processing.owner.opponent.field.forEach(unit =>
+      Effect.modifyBP(stack, stack.processing, unit, -3000, { isBaseBP: true })
+    );
+  },
+};

--- a/src/game-data/effects/cards/1-0-056.ts
+++ b/src/game-data/effects/cards/1-0-056.ts
@@ -1,0 +1,13 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBreak: (stack: StackWithCard) =>
+    stack.target instanceof Unit && stack.target.owner.id === stack.processing.owner.id,
+  onBreak: async (stack: StackWithCard) => {
+    await System.show(stack, '不穏な霧', 'CP+2');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, 2);
+  },
+};

--- a/src/game-data/effects/cards/1-0-136.ts
+++ b/src/game-data/effects/cards/1-0-136.ts
@@ -1,0 +1,16 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.processing.owner.id === stack.source.id &&
+    stack.processing.owner.opponent.hand.length > 0,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '迷子', '手札を1枚破壊');
+    EffectHelper.random(stack.processing.owner.opponent.hand).forEach(card =>
+      Effect.break(stack, stack.processing, card)
+    );
+  },
+};

--- a/src/game-data/effects/cards/1-0-136.ts
+++ b/src/game-data/effects/cards/1-0-136.ts
@@ -9,8 +9,8 @@ export const effects: CardEffects = {
     stack.processing.owner.opponent.hand.length > 0,
   onDrive: async (stack: StackWithCard) => {
     await System.show(stack, '迷子', '手札を1枚破壊');
-    EffectHelper.random(stack.processing.owner.opponent.hand).forEach(card =>
-      Effect.break(stack, stack.processing, card)
-    );
+    EffectHelper.random(stack.processing.owner.opponent.hand).forEach(card => {
+      Effect.break(stack, stack.processing, card);
+    });
   },
 };

--- a/src/game-data/effects/cards/1-1-017.ts
+++ b/src/game-data/effects/cards/1-1-017.ts
@@ -35,22 +35,32 @@ export const effects: CardEffects = {
 
   onBreakSelf: async (stack: StackWithCard<Unit>) => {
     const isOwnTurn = stack.processing.owner.id === stack.core.getTurnPlayer().id;
-    if (EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)) {
-      await System.show(
-        stack,
-        '選ばれし殉葬',
-        isOwnTurn ? 'BP+2000\nユニットを1体破壊' : 'BP+2000\nCP+1\nユニットを1体破壊'
-      );
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        'opponents',
-        '破壊するユニットを選択して下さい'
-      );
-      Effect.break(stack, stack.processing, target, 'effect');
-    } else {
-      await System.show(stack, '禍々しき厄災', isOwnTurn ? 'BP+2000' : 'BP+2000\nCP+1');
-    }
-    await effect(stack);
+    await EffectHelper.combine(stack, [
+      {
+        title: '選ばれし殉葬',
+        description: 'ユニットを1体破壊',
+        effect: async () => {
+          const [target] = await EffectHelper.pickUnit(
+            stack,
+            stack.processing.owner,
+            'opponents',
+            '破壊するユニットを選択して下さい'
+          );
+          Effect.break(stack, stack.processing, target, 'effect');
+        },
+        condition: EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
+      },
+      {
+        title: '禍々しき厄災',
+        description: 'BP+2000',
+        effect: async () => effect(stack),
+      },
+      {
+        title: '禍々しき厄災',
+        description: 'CP+1',
+        effect: () => {},
+        condition: !isOwnTurn,
+      },
+    ]);
   },
 };

--- a/src/game-data/effects/cards/1-1-022.ts
+++ b/src/game-data/effects/cards/1-1-022.ts
@@ -1,3 +1,4 @@
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { Effect, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
@@ -27,17 +28,13 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard) => {
-    const owner = stack.processing.owner;
-    owner.field.forEach(unit => {
-      if (
-        unit.catalog.species?.includes('侍') &&
-        !unit.delta.some(delta => delta.source?.unit === stack.processing.id)
-      ) {
-        // 【不屈】を付与
-        Effect.keyword(stack, stack.processing, unit, '不屈', {
-          source: { unit: stack.processing.id },
-        });
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => {
+        if (card instanceof Unit) Effect.keyword(stack, stack.processing, card, '不屈', { source });
+      },
+      effectCode: '心眼の撫子',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('侍'),
     });
   },
 

--- a/src/game-data/effects/cards/1-1-063.ts
+++ b/src/game-data/effects/cards/1-1-063.ts
@@ -16,7 +16,7 @@ export const effects: CardEffects = {
   onDrive: async (stack: StackWithCard): Promise<void> => {
     await System.show(stack, 'ダークマター', 'トリガーゾーンを全て破壊');
     [...stack.processing.owner.trigger, ...stack.processing.owner.opponent.trigger].forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
   },
 };

--- a/src/game-data/effects/cards/1-1-072.ts
+++ b/src/game-data/effects/cards/1-1-072.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   // このユニットのBPは+［あなたのライフ×1000］される。
@@ -9,25 +10,19 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    const self = stack.processing;
-    const owner = self.owner;
-
-    // 現在のライフに基づくBP増加量
-    const bpIncrease = owner.life.current * 1000;
-
-    // 既にこのユニットが発行したDeltaが存在するか確認
-    const delta = self.delta.find(
-      delta => delta.source?.unit === self.id && delta.source?.effectCode === '正統なる血統'
-    );
-
-    if (delta && delta.effect.type === 'bp') {
-      // 既存のDeltaを更新
-      delta.effect.diff = bpIncrease;
-    } else {
-      // 新しいDeltaを発行
-      Effect.modifyBP(stack, self, self, bpIncrease, {
-        source: { unit: self.id, effectCode: '正統なる血統' },
-      });
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.dynamicBP(
+            stack,
+            stack.processing,
+            target,
+            target => target.owner.life.current * 1000,
+            { source }
+          );
+      },
+      effectCode: '正当なる血統',
+      targets: ['self'],
+    });
   },
 };

--- a/src/game-data/effects/cards/1-1-086.ts
+++ b/src/game-data/effects/cards/1-1-086.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(stack, '不屈', 'ターン終了時に行動権を回復');
+    Effect.keyword(stack, stack.processing, stack.processing, '不屈');
+  },
+
+  onTurnStart: async (stack: StackWithCard<Unit>) => {
+    if (stack.processing.owner.id !== stack.source.id) return;
+    await System.show(stack, 'グロウアップ', '基本BP+1000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, 1000, { isBaseBP: true });
+  },
+
+  onBlockSelf: async (stack: StackWithCard) => {
+    await System.show(stack, 'オーバーフロー', 'CP-3');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner.opponent, -3);
+  },
+};

--- a/src/game-data/effects/cards/1-1-087.ts
+++ b/src/game-data/effects/cards/1-1-087.ts
@@ -1,6 +1,8 @@
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { Effect } from '../engine/effect';
 import { System } from '../engine/system';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { Unit } from '@/package/core/class/card';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard) => {
@@ -17,68 +19,32 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard) => {
-    // BPアップ効果
-    stack.processing.owner.field.forEach(unit => {
-      if (
-        !unit.delta.some(
-          delta =>
-            delta.source?.unit === stack.processing.id && delta.source.effectCode === '五輪書_BP'
-        )
-      ) {
-        Effect.modifyBP(stack, stack.processing, unit, 1000, {
-          source: { unit: stack.processing.id, effectCode: '五輪書_BP' },
-        });
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.modifyBP(stack, stack.processing, target, 1000, { source });
+      },
+      effectCode: '五輪書_BP',
+      targets: ['owns'],
     });
 
-    // 自フィールドの侍をカウント
-    const ownSamurai = stack.processing.owner.field.filter(unit =>
-      unit.catalog.species?.includes('侍')
-    );
-    const hasMoreThanTwoSamurai = ownSamurai.length >= 2;
-
-    if (hasMoreThanTwoSamurai) {
-      // キーワード能力を付与
-      ownSamurai.forEach(unit => {
-        if (
-          !unit.delta.some(
-            delta =>
-              delta.source?.unit === stack.processing.id && delta.source.effectCode === '五輪書'
-          )
-        ) {
-          Effect.keyword(stack, stack.processing, unit, '不屈', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-          Effect.keyword(stack, stack.processing, unit, '貫通', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-          Effect.keyword(stack, stack.processing, unit, '無我の境地', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-          Effect.keyword(stack, stack.processing, unit, '固着', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-          Effect.speedMove(stack, unit);
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit) {
+          Effect.keyword(stack, stack.processing, target, '不屈', { source });
+          Effect.keyword(stack, stack.processing, target, '貫通', { source });
+          Effect.keyword(stack, stack.processing, target, '無我の境地', { source });
+          Effect.keyword(stack, stack.processing, target, '固着', { source });
+          Effect.speedMove(stack, target);
         }
-      });
-    } else {
-      // キーワード能力を剥奪
-      ownSamurai.forEach(unit => {
-        if (unit.delta.some(delta => delta.source?.unit === stack.processing.id)) {
-          Effect.removeKeyword(stack, unit, '不屈', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-          Effect.removeKeyword(stack, unit, '貫通', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-          Effect.removeKeyword(stack, unit, '無我の境地', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-          Effect.removeKeyword(stack, unit, '固着', {
-            source: { unit: stack.processing.id, effectCode: '五輪書' },
-          });
-        }
-      });
-    }
+      },
+      effectCode: '五輪書_侍',
+      targets: ['owns'],
+      condition: target =>
+        target instanceof Unit &&
+        target.catalog.species?.includes('侍') &&
+        stack.processing.owner.field.filter(unit => unit.catalog.species?.includes('侍')).length >=
+          2,
+    });
   },
 };

--- a/src/game-data/effects/cards/1-1-098.ts
+++ b/src/game-data/effects/cards/1-1-098.ts
@@ -1,0 +1,21 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkAttack: (stack: StackWithCard) =>
+    stack.target instanceof Unit &&
+    stack.target.owner.id === stack.processing.owner.id &&
+    stack.target.owner.field.some(unit => unit.id === stack.target?.id),
+  onAttack: async (stack: StackWithCard) => {
+    await System.show(stack, '浮遊術', 'ブロックされない');
+    if (stack.target instanceof Unit) {
+      Effect.keyword(stack, stack.processing, stack.target, '次元干渉', {
+        condition: () => true,
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-2-005.ts
+++ b/src/game-data/effects/cards/1-2-005.ts
@@ -2,33 +2,27 @@ import { Unit } from '@/package/core/class/card';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { System } from '../engine/system';
 import { Effect } from '../engine/effect';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   // ■増殖
   // このユニットのBPはあなたのフィールドの【昆虫】ユニット1体につき+2000される。
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    // プレイヤーのフィールド上の昆虫ユニット数を数える
-    const insectCount = stack.processing.owner.field.filter(unit =>
-      unit.catalog.species?.includes('昆虫')
-    ).length;
-
-    // BP増加量を計算（昆虫1体につき+2000）
-    const bpBoost = insectCount * 2000;
-
-    // 既にこのユニットが発行したDeltaが存在するか確認
-    const delta = stack.processing.delta.find(
-      d => d.source?.unit === stack.processing.id && d.source?.effectCode === '増殖'
-    );
-
-    if (delta && delta.effect.type === 'bp') {
-      // Deltaを編集する
-      delta.effect.diff = bpBoost;
-    } else {
-      // 新しいDeltaを追加
-      Effect.modifyBP(stack, stack.processing, stack.processing, bpBoost, {
-        source: { unit: stack.processing.id, effectCode: '増殖' },
-      });
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => {
+        if (card instanceof Unit)
+          Effect.dynamicBP(
+            stack,
+            stack.processing,
+            card,
+            self =>
+              self.owner.field.filter(unit => unit.catalog.species?.includes('昆虫')).length * 2000,
+            { source }
+          );
+      },
+      effectCode: '増殖',
+      targets: ['self'],
+    });
   },
 
   onDriveSelf: async (stack: StackWithCard<Unit>) => {

--- a/src/game-data/effects/cards/1-2-014.ts
+++ b/src/game-data/effects/cards/1-2-014.ts
@@ -48,31 +48,20 @@ export const effects: CardEffects = {
     // 自分のレベル2以上のユニット
     const ownTargets = owner.field.filter(unit => unit.lv >= 2);
 
-    // 両方のターゲットがいない場合は何もしない
-    if (opponentTargets.length === 0 && ownTargets.length === 0) {
-      return;
-    }
-
-    // メッセージを条件に応じて構築
-    let message = '';
-    if (opponentTargets.length > 0 && ownTargets.length > 0) {
-      message = '敵のレベル2以上に6000ダメージ\n味方のレベル2以上に【スピードムーブ】を付与';
-    } else if (opponentTargets.length > 0) {
-      message = '敵のレベル2以上に6000ダメージ';
-    } else {
-      message = '味方のレベル2以上に【スピードムーブ】を付与';
-    }
-
-    await System.show(stack, '堕天使の鎮魂歌', message);
-
-    // 対戦相手のレベル2以上のユニットに6000ダメージ
-    if (opponentTargets.length > 0) {
-      opponentTargets.forEach(unit => Effect.damage(stack, stack.processing, unit, 6000));
-    }
-
-    // 自分のレベル2以上のユニットに【スピードムーブ】
-    if (ownTargets.length > 0) {
-      ownTargets.forEach(unit => Effect.speedMove(stack, unit));
-    }
+    await EffectHelper.combine(stack, [
+      {
+        title: '堕天使の鎮魂歌',
+        description: '敵のレベル2以上に6000ダメージ',
+        effect: () =>
+          opponentTargets.forEach(unit => Effect.damage(stack, stack.processing, unit, 6000)),
+        condition: opponentTargets.length > 0,
+      },
+      {
+        title: '堕天使の鎮魂歌',
+        description: '味方のレベル2以上に【スピードムーブ】',
+        effect: () => ownTargets.forEach(unit => Effect.speedMove(stack, unit)),
+        condition: ownTargets.length > 0,
+      },
+    ]);
   },
 };

--- a/src/game-data/effects/cards/1-2-014.ts
+++ b/src/game-data/effects/cards/1-2-014.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
         opponent.trigger,
         Math.min(2, opponent.trigger.length)
       );
-      cardsToDestroy.forEach(card => Effect.move(stack, stack.processing, card, 'trash'));
+      cardsToDestroy.forEach(card => Effect.break(stack, stack.processing, card));
     } else {
       // 対戦相手のトリガーゾーンにカードがない場合、デッキからインターセプトカードをセット
       const interceptCards = owner.deck.filter(card => card.catalog.type === 'intercept');

--- a/src/game-data/effects/cards/1-2-020.ts
+++ b/src/game-data/effects/cards/1-2-020.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   // ■女神の慈愛
@@ -13,29 +14,14 @@ export const effects: CardEffects = {
 
   // フィールド効果：レベル1ユニットに加護を与える
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    const owner = stack.processing.owner;
-
-    // 自分のフィールドにあるレベル1のユニットを対象にする
-    owner.field.forEach(unit => {
-      // レベル1のユニットか確認
-      if (unit.lv === 1) {
-        // 既にこのユニットが発行したDeltaが存在するか確認
-        const delta = unit.delta.find(
-          d => d.source?.unit === stack.processing.id && d.source?.effectCode === '女神の慈愛'
-        );
-
-        // 既にDeltaが存在しない場合のみ加護を付与
-        if (!delta) {
-          Effect.keyword(stack, stack.processing, unit, '加護', {
-            source: { unit: stack.processing.id, effectCode: '女神の慈愛' },
-          });
-        }
-      } else {
-        // レベル1でなくなった場合、このユニットが付与した加護を削除
-        unit.delta = unit.delta.filter(
-          d => !(d.source?.unit === stack.processing.id && d.source?.effectCode === '女神の慈愛')
-        );
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '加護', { source });
+      },
+      effectCode: '女神の慈愛',
+      targets: ['owns'],
+      condition: target => target.lv === 1,
     });
   },
 };

--- a/src/game-data/effects/cards/1-2-024.ts
+++ b/src/game-data/effects/cards/1-2-024.ts
@@ -1,33 +1,20 @@
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
 
 export const effects: CardEffects = {
   // ■八咫鏡
-  // 様々なレベルに応じた効果を持つカード
-
   // フィールド効果: レベル1の時に【加護】を与える
   fieldEffect(stack: StackWithCard<Unit>) {
-    const self = stack.processing;
-
-    // 自身が与えた加護の効果があるか確認
-    const delta = self.delta.find(
-      delta => delta.source?.unit === self.id && delta.source?.effectCode === 'level1_protection'
-    );
-
-    if (self.lv === 1) {
-      // レベル1の時に【加護】を与える
-      if (!delta) {
-        Effect.keyword(stack, self, self, '加護', {
-          source: { unit: self.id, effectCode: 'level1_protection' },
-        });
-      }
-    } else if (delta) {
-      // レベル1以外では自身が与えた【加護】を除外
-      self.delta = self.delta.filter(
-        d => d.source?.unit !== self.id || d.source?.effectCode !== 'level1_protection'
-      );
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '加護', { source });
+      },
+      targets: ['self'],
+      effectCode: '八咫鏡',
+    });
   },
 
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
@@ -37,20 +24,28 @@ export const effects: CardEffects = {
   // プレイヤーアタックを受けた時の効果
   async onPlayerAttack(stack: StackWithCard<Unit>) {
     const owner = stack.processing.owner;
+    const source = stack.source;
 
     // 自分がプレイヤーアタックを受けた時のみ発動
     if (
-      stack.source instanceof Unit &&
-      stack.source.owner.id === owner.opponent.id && // 相手のユニットがアタックしている
+      source instanceof Unit &&
+      source.owner.id === owner.opponent.id && // 相手のユニットがアタックしている
       stack.target?.id === owner.id // 自分がプレイヤーアタックを受けている
     ) {
-      await System.show(stack, '八咫鏡', 'ユニットを消滅\nレベル+1');
-
-      // アタックしてきたユニットを消滅させる
-      Effect.delete(stack, stack.processing, stack.source);
-
-      // 自身のレベルを+1する
-      Effect.clock(stack, stack.processing, stack.processing, 1);
+      await EffectHelper.combine(stack, [
+        {
+          title: '八咫鏡',
+          description: 'ユニットを消滅',
+          effect: () => Effect.delete(stack, stack.processing, source),
+          condition: source.owner.field.some(unit => unit.id === source.id),
+        },
+        {
+          title: '八咫鏡',
+          description: 'レベル+1',
+          effect: () => Effect.clock(stack, stack.processing, stack.processing, 1),
+          condition: stack.processing.lv < 3,
+        },
+      ]);
     }
   },
 

--- a/src/game-data/effects/cards/1-2-024.ts
+++ b/src/game-data/effects/cards/1-2-024.ts
@@ -106,7 +106,7 @@ export const effects: CardEffects = {
       }
 
       // ライフを+2する
-      owner.life.current = Math.min(owner.life.current + 2, owner.life.max);
+      Effect.modifyLife(stack, stack.processing, stack.processing.owner, +2);
     }
   },
 };

--- a/src/game-data/effects/cards/1-2-034.ts
+++ b/src/game-data/effects/cards/1-2-034.ts
@@ -33,7 +33,7 @@ export const effects: CardEffects = {
       await System.show(stack, '死への誘い', 'トリガーゾーンのカードを1枚破壊');
       const [target] = EffectHelper.random(triggerZone, 1);
       if (target) {
-        Effect.move(stack, stack.processing, target, 'trash');
+        Effect.break(stack, stack.processing, target);
       }
     }
   },

--- a/src/game-data/effects/cards/1-2-037.ts
+++ b/src/game-data/effects/cards/1-2-037.ts
@@ -39,7 +39,7 @@ export const effects: CardEffects = {
         // トリガーゾーンからランダムで1枚選択して破壊
         const randomTriggers = EffectHelper.random(triggerCards, 1);
         randomTriggers.forEach(trigger => {
-          Effect.move(stack, stack.processing, trigger, 'trash');
+          Effect.break(stack, stack.processing, trigger);
         });
 
         // アタックしたユニットを破壊

--- a/src/game-data/effects/cards/1-2-038.ts
+++ b/src/game-data/effects/cards/1-2-038.ts
@@ -13,29 +13,30 @@ export const effects: CardEffects = {
 
   onOverclockSelf: async (stack: StackWithCard): Promise<void> => {
     if (!(stack.processing instanceof Unit)) return;
-
     const owner = stack.processing.owner;
 
-    const hasTargets = EffectHelper.isUnitSelectable(
-      stack.core,
-      'opponents',
-      stack.processing.owner
-    );
-
-    await System.show(stack, '爆発する寄生魚', `${hasTargets ? 'レベル+1\n' : ''}自身を破壊`);
-    if (hasTargets) {
-      // ユニットの選択を実施する
-      const selection: Unit[] = await EffectHelper.pickUnit(
-        stack,
-        owner,
-        'opponents',
-        'レベルを+1するユニットを選択',
-        2
-      );
-
-      selection.forEach(unit => Effect.clock(stack, stack.processing, unit, 1));
-    }
-
-    Effect.break(stack, stack.processing, stack.processing, 'effect');
+    await EffectHelper.combine(stack, [
+      {
+        title: '爆発する寄生魚',
+        description: 'レベル+1',
+        effect: async () => {
+          (
+            await EffectHelper.pickUnit(
+              stack,
+              owner,
+              'opponents',
+              'レベルを+1するユニットを選択',
+              2
+            )
+          ).forEach(unit => Effect.clock(stack, stack.processing, unit, 1));
+        },
+        condition: EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
+      },
+      {
+        title: '爆発する寄生魚',
+        description: '自身を破壊',
+        effect: () => Effect.break(stack, stack.processing, stack.processing, 'effect'),
+      },
+    ]);
   },
 };

--- a/src/game-data/effects/cards/1-2-039.ts
+++ b/src/game-data/effects/cards/1-2-039.ts
@@ -34,27 +34,29 @@ export const effects: CardEffects = {
       stack.processing.owner
     );
 
-    const messages = [
-      reviveCard ? '捨札から1枚回収' : undefined,
-      isUnitSelectable ? 'ユニットを1体破壊' : undefined,
-    ].filter(message => !!message);
-
-    if (messages.length > 0) {
-      await System.show(stack, '極楽浄土', messages.join('\n'));
-
-      if (isUnitSelectable) {
-        const [target] = await EffectHelper.pickUnit(
-          stack,
-          stack.processing.owner,
-          'owns',
-          '破壊するユニットを選択'
-        );
-        Effect.break(stack, stack.processing, target);
-      }
-
-      if (reviveCard) {
-        Effect.move(stack, stack.processing, reviveCard, 'hand');
-      }
-    }
+    await EffectHelper.combine(stack, [
+      {
+        title: '極楽浄土',
+        description: '捨札から1枚回収',
+        effect: () => {
+          if (reviveCard) Effect.move(stack, stack.processing, reviveCard, 'hand');
+        },
+        condition: reviveCard ? true : false,
+      },
+      {
+        title: '極楽浄土',
+        description: 'ユニットを1体破壊',
+        effect: async () => {
+          const [target] = await EffectHelper.pickUnit(
+            stack,
+            stack.processing.owner,
+            'owns',
+            '破壊するユニットを選択'
+          );
+          Effect.break(stack, stack.processing, target);
+        },
+        condition: isUnitSelectable,
+      },
+    ]);
   },
 };

--- a/src/game-data/effects/cards/1-2-047.ts
+++ b/src/game-data/effects/cards/1-2-047.ts
@@ -27,23 +27,8 @@ export const effects: CardEffects = {
     await System.show(stack, '繁殖', '【昆虫】ユニットの基本BP+1000');
 
     // プレイヤーのフィールド上の昆虫ユニットすべてにBP+1000
-    const insectUnits = stack.processing.owner.field.filter(unit =>
-      unit.catalog.species?.includes('昆虫')
-    );
-
-    for (const unit of insectUnits) {
-      // 既にこのユニットが発行したDeltaが存在するか確認
-      const delta = unit.delta.find(
-        d => d.source?.unit === stack.processing.id && d.source?.effectCode === '繁殖'
-      );
-
-      if (delta && delta.effect.type === 'bp') {
-        // Deltaを編集する
-        delta.effect.diff = 1000;
-      } else {
-        // 新しいDeltaを追加
-        Effect.modifyBP(stack, stack.processing, unit, 1000, { isBaseBP: true });
-      }
-    }
+    stack.processing.owner.field
+      .filter(unit => unit.catalog.species?.includes('昆虫'))
+      .forEach(unit => Effect.modifyBP(stack, stack.processing, unit, 1000, { isBaseBP: true }));
   },
 };

--- a/src/game-data/effects/cards/1-2-053.ts
+++ b/src/game-data/effects/cards/1-2-053.ts
@@ -1,8 +1,9 @@
-import type { Unit } from '@/package/core/class/card';
+import { Unit } from '@/package/core/class/card';
 import { Effect } from '../engine/effect';
 import { System } from '../engine/system';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { EffectHelper } from '../engine/helper';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard) => {
@@ -32,16 +33,20 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard<Unit>) => {
-    const delta = stack.processing.delta.find(delta => delta.source?.unit === stack.processing.id);
-    const value =
-      stack.processing.owner.field.filter(unit => unit.catalog.species?.includes('忍者')).length *
-      1000;
-    if (delta && delta.effect.type === 'bp') {
-      delta.effect.diff = value;
-    } else {
-      Effect.modifyBP(stack, stack.processing, stack.processing, value, {
-        source: { unit: stack.processing.id },
-      });
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.dynamicBP(
+            stack,
+            stack.processing,
+            target,
+            self =>
+              self.owner.field.filter(unit => unit.catalog.species?.includes('忍者')).length * 1000,
+            { source }
+          );
+      },
+      effectCode: '闘士／忍者',
+      targets: ['self'],
+    });
   },
 };

--- a/src/game-data/effects/cards/1-2-073.ts
+++ b/src/game-data/effects/cards/1-2-073.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
   onTurnStart: async (stack: StackWithCard) => {
     await System.show(stack, '換金所', 'トリガーゾーンのカードを1枚破壊\nCP+2');
     const [target] = EffectHelper.random(stack.processing.owner.trigger);
-    if (target) Effect.move(stack, stack.processing, target, 'trash');
+    if (target) Effect.break(stack, stack.processing, target);
     Effect.modifyCP(stack, stack.processing, stack.processing.owner, 2);
   },
 };

--- a/src/game-data/effects/cards/1-2-086.ts
+++ b/src/game-data/effects/cards/1-2-086.ts
@@ -1,0 +1,30 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit, type Card } from '@/package/core/class/card';
+import { Color } from '@/submodule/suit/constant';
+
+const getYellowFilter = (self: Card) => (unit: Unit) =>
+  unit.catalog.color === Color.YELLOW && unit.owner.id === self.owner.id;
+
+export const effect: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    EffectHelper.isUnitSelectable(
+      stack.core,
+      getYellowFilter(stack.processing),
+      stack.processing.owner
+    ) && stack.processing.owner.opponent.field.some(unit => unit.id === stack.target?.id),
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '熾天使の片翼', '手札に戻す');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      getYellowFilter(stack.processing),
+      '手札に戻すユニットを選択'
+    );
+    [stack.target, target].forEach(unit => {
+      if (unit instanceof Unit) Effect.bounce(stack, stack.processing, unit, 'hand');
+    });
+  },
+};

--- a/src/game-data/effects/cards/1-2-086.ts
+++ b/src/game-data/effects/cards/1-2-086.ts
@@ -8,7 +8,7 @@ import { Color } from '@/submodule/suit/constant';
 const getYellowFilter = (self: Card) => (unit: Unit) =>
   unit.catalog.color === Color.YELLOW && unit.owner.id === self.owner.id;
 
-export const effect: CardEffects = {
+export const effects: CardEffects = {
   checkDrive: (stack: StackWithCard) =>
     EffectHelper.isUnitSelectable(
       stack.core,

--- a/src/game-data/effects/cards/1-2-098.ts
+++ b/src/game-data/effects/cards/1-2-098.ts
@@ -1,0 +1,12 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (_stack: StackWithCard) => true,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '大いなる世界', 'CP-12');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, -12);
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner.opponent, -12);
+  },
+};

--- a/src/game-data/effects/cards/1-2-104.ts
+++ b/src/game-data/effects/cards/1-2-104.ts
@@ -18,7 +18,7 @@ export const effects: CardEffects = {
 
         // ランダムで1枚選択して破壊
         EffectHelper.random(opponent.trigger, 1).forEach(card =>
-          Effect.move(stack, stack.processing, card, 'trash')
+          Effect.break(stack, stack.processing, card)
         );
       }
     }

--- a/src/game-data/effects/cards/1-2-109.ts
+++ b/src/game-data/effects/cards/1-2-109.ts
@@ -1,3 +1,4 @@
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
@@ -10,31 +11,17 @@ export const effects: CardEffects = {
 
   fieldEffect: (stack: StackWithCard<Unit>) => {
     // 【神獣】ユニットのBPを+3000し、【不滅】を付与
-    stack.processing.owner.field
-      .filter(unit => unit.catalog.species?.includes('神獣'))
-      .forEach(unit => {
-        // 既にこのユニットが発行したDeltaが存在するか確認
-        const delta = unit.delta.find(
-          delta =>
-            delta.source?.unit === stack.processing.id &&
-            delta.source?.effectCode === '黄金蝶の鱗粉'
-        );
-
-        if (delta) {
-          // Deltaを編集する
-          if (delta.effect.type === 'bp') {
-            delta.effect.diff = 3000;
-          }
-        } else {
-          // 新しいDeltaを発行
-          Effect.modifyBP(stack, stack.processing, unit, 3000, {
-            source: { unit: stack.processing.id, effectCode: '黄金蝶の鱗粉' },
-          });
-          Effect.keyword(stack, stack.processing, unit, '不滅', {
-            source: { unit: stack.processing.id, effectCode: '黄金蝶の鱗粉' },
-          });
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit) {
+          Effect.modifyBP(stack, stack.processing, target, 3000, { source });
+          Effect.keyword(stack, stack.processing, target, '不滅', { source });
         }
-      });
+      },
+      effectCode: '黄金蝶の鱗粉',
+      condition: target => target instanceof Unit && target.catalog.species?.includes('神獣'),
+      targets: ['owns'],
+    });
   },
 
   onTurnEnd: async (stack: StackWithCard<Unit>) => {

--- a/src/game-data/effects/cards/1-2-110.ts
+++ b/src/game-data/effects/cards/1-2-110.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   // ■煌めく筋肉
@@ -15,29 +16,14 @@ export const effects: CardEffects = {
 
   // フィールド効果：巨人ユニットに加護を与える
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    const owner = stack.processing.owner;
-
-    // 自分のフィールドの巨人ユニットを対象にする
-    owner.field.forEach(unit => {
-      // 巨人ユニットか確認
-      if (unit.catalog.species?.includes('巨人')) {
-        // 既にこのユニットが発行したDeltaが存在するか確認
-        const delta = unit.delta.find(
-          d => d.source?.unit === stack.processing.id && d.source?.effectCode === '煌めく筋肉'
-        );
-
-        // 既にDeltaが存在しない場合のみ加護を付与
-        if (!delta) {
-          Effect.keyword(stack, stack.processing, unit, '加護', {
-            source: { unit: stack.processing.id, effectCode: '煌めく筋肉' },
-          });
-        }
-      } else {
-        // 巨人でなくなった場合、このユニットが付与した加護を削除
-        unit.delta = unit.delta.filter(
-          d => !(d.source?.unit === stack.processing.id && d.source?.effectCode === '煌めく筋肉')
-        );
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '加護', { source });
+      },
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('巨人'),
+      effectCode: '煌めく筋肉',
     });
   },
 

--- a/src/game-data/effects/cards/1-2-112.ts
+++ b/src/game-data/effects/cards/1-2-112.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard): Promise<void> => {
@@ -35,26 +36,14 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard) => {
-    if (
-      stack.processing.delta.some(
-        delta =>
-          delta.source?.unit === stack.processing.id && delta.source.effectCode === '神速の一閃'
-      )
-    ) {
-      if (stack.processing.lv !== 1)
-        stack.processing.delta = stack.processing.delta.filter(
-          delta =>
-            !(
-              delta.source?.unit === stack.processing.id && delta.source.effectCode === '神速の一閃'
-            )
-        );
-    } else {
-      if (stack.processing.lv === 1 && stack.processing instanceof Unit) {
-        Effect.keyword(stack, stack.processing, stack.processing, '次元干渉', {
-          cost: 0,
-          source: { unit: stack.processing.id, effectCode: '神速の一閃' },
-        });
-      }
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '次元干渉', { source });
+      },
+      effectCode: '神速の一閃',
+      targets: ['self'],
+      condition: target => target.lv === 1,
+    });
   },
 };

--- a/src/game-data/effects/cards/1-2-112.ts
+++ b/src/game-data/effects/cards/1-2-112.ts
@@ -39,7 +39,10 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (target, source) => {
         if (target instanceof Unit)
-          Effect.keyword(stack, stack.processing, target, '次元干渉', { source });
+          Effect.keyword(stack, stack.processing, target, '次元干渉', {
+            source,
+            condition: () => true,
+          });
       },
       effectCode: '神速の一閃',
       targets: ['self'],

--- a/src/game-data/effects/cards/1-2-117.ts
+++ b/src/game-data/effects/cards/1-2-117.ts
@@ -10,12 +10,14 @@ export const effects: CardEffects = {
     // 対戦相手のフィールドにユニットがいる場合
     if (opponent.field.length > 0) {
       await System.show(stack, '破滅谷の神獣', '【加護】\nユニットを破壊');
-      Effect.keyword(stack, stack.processing, stack.processing, '加護');
 
       // 対戦相手のBPが最も高いユニットからランダムで1体破壊する
       const max = Math.max(...opponent.field.map(unit => unit.currentBP));
       const candidate = opponent.field.filter(unit => unit.currentBP === max);
       EffectHelper.random(candidate).forEach(unit => Effect.break(stack, stack.processing, unit));
+    } else {
+      await System.show(stack, '加護', '効果に選ばれない');
     }
+    Effect.keyword(stack, stack.processing, stack.processing, '加護');
   },
 };

--- a/src/game-data/effects/cards/1-2-119.ts
+++ b/src/game-data/effects/cards/1-2-119.ts
@@ -1,7 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   // 【貫通】
@@ -18,31 +18,14 @@ export const effects: CardEffects = {
   // フィールド効果：昆虫ユニットのBPを+1000する
   fieldEffect: (stack: StackWithCard<Unit>): void => {
     // 自身も含む、自分のフィールド上の昆虫ユニットを対象にする
-    stack.processing.owner.field.forEach(unit => {
-      if (unit.catalog.species?.includes('昆虫')) {
-        // 既にこのユニットが発行したDeltaが存在するか確認
-        const delta = unit.delta.find(
-          d => d.source?.unit === stack.processing.id && d.source?.effectCode === 'サポーター／昆虫'
-        );
-
-        if (delta && delta.effect.type === 'bp') {
-          // Deltaを編集する
-          delta.effect.diff = 1000;
-        } else {
-          // 新しいDeltaを追加
-          unit.delta.push(
-            new Delta(
-              { type: 'bp', diff: 1000 },
-              {
-                source: {
-                  unit: stack.processing.id,
-                  effectCode: 'サポーター／昆虫',
-                },
-              }
-            )
-          );
-        }
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.modifyBP(stack, stack.processing, target, 1000, { source });
+      },
+      effectCode: 'サポーター／昆虫',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('昆虫'),
     });
   },
 };

--- a/src/game-data/effects/cards/1-2-128.ts
+++ b/src/game-data/effects/cards/1-2-128.ts
@@ -21,7 +21,7 @@ export const effects = {
       '消滅させるカードを選択して下さい',
       3
     );
-    targets.forEach(card => Effect.move(stack, stack.processing, card, 'delete'));
+    targets.forEach(card => Effect.delete(stack, stack.processing, card));
 
     EffectTemplate.draw(stack.processing.owner, stack.core);
   },

--- a/src/game-data/effects/cards/1-2-132.ts
+++ b/src/game-data/effects/cards/1-2-132.ts
@@ -29,7 +29,7 @@ export const effects: CardEffects = {
         );
 
         // 選択したカードを消滅させる
-        Effect.move(stack, stack.processing, selectedCard, 'delete');
+        Effect.delete(stack, stack.processing, selectedCard);
 
         // 捨札からトリガーカードを2枚までランダムで手札に加える
         const triggerCards = stack.processing.owner.trash.filter(

--- a/src/game-data/effects/cards/1-3-004.ts
+++ b/src/game-data/effects/cards/1-3-004.ts
@@ -26,7 +26,7 @@ export const effects: CardEffects = {
     const [target] = EffectHelper.random(stack.processing.owner.opponent.trigger);
     if (target) {
       await System.show(stack, '罪と罰', 'トリガーゾーンを1枚破壊');
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
     }
   },
 };

--- a/src/game-data/effects/cards/1-3-028.ts
+++ b/src/game-data/effects/cards/1-3-028.ts
@@ -2,6 +2,7 @@ import { Unit } from '@/package/core/class/card';
 import { Effect, EffectTemplate } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { System } from '../engine/system';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   // ■援軍／獣
@@ -13,30 +14,15 @@ export const effects: CardEffects = {
   // ■リトルキャットソウル
   // あなたのフィールドに【獣】ユニットが3体以上いる時、このユニットのBPを+4000する
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    const beastCount = stack.processing.owner.field.filter(unit =>
-      unit.catalog.species?.includes('獣')
-    ).length;
-
-    // 既にこのユニットが発行したDeltaが存在するか確認する
-    const delta = stack.processing.delta.find(
-      delta => delta.source?.unit === stack.processing.id && delta.effect.type === 'bp'
-    );
-
-    if (beastCount >= 3) {
-      if (delta && delta.effect.type === 'bp') {
-        // Deltaを編集する
-        delta.effect.diff = 4000;
-      } else {
-        // 新規Deltaを生成
-        Effect.modifyBP(stack, stack.processing, stack.processing, 4000, {
-          source: { unit: stack.processing.id },
-        });
-      }
-    } else {
-      // 条件を満たしていない場合は既存のDeltaを削除
-      if (delta) {
-        stack.processing.delta = stack.processing.delta.filter(d => d !== delta);
-      }
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.modifyBP(stack, stack.processing, target, 3000, { source });
+      },
+      targets: ['self'],
+      condition: target =>
+        target.owner.field.filter(unit => unit.catalog.species?.includes('獣')).length >= 3,
+      effectCode: 'リトルキャットソウル',
+    });
   },
 };

--- a/src/game-data/effects/cards/1-3-028.ts
+++ b/src/game-data/effects/cards/1-3-028.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (target, source) => {
         if (target instanceof Unit)
-          Effect.modifyBP(stack, stack.processing, target, 3000, { source });
+          Effect.modifyBP(stack, stack.processing, target, 4000, { source });
       },
       targets: ['self'],
       condition: target =>

--- a/src/game-data/effects/cards/1-3-036.ts
+++ b/src/game-data/effects/cards/1-3-036.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
@@ -13,42 +14,25 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    const owner = stack.processing.owner;
-
     // 全てのユニットのBPを+2000
-    owner.field.forEach(unit => {
-      // 既にこのユニットが発行したDeltaが存在するか確認
-      const delta = unit.delta.find(
-        d =>
-          d.source?.unit === stack.processing.id &&
-          d.source?.effectCode === 'インフィニット・フォース'
-      );
-
-      if (!delta) {
-        // 新しいDeltaを発行
-        Effect.modifyBP(stack, stack.processing, unit, 2000, {
-          source: { unit: stack.processing.id, effectCode: 'インフィニット・フォース' },
-        });
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.modifyBP(stack, stack.processing, target, 2000, { source });
+      },
+      effectCode: 'インフィニット・フォース',
+      targets: ['owns'],
     });
 
     // 【英雄】ユニットに【不屈】を与える
-    owner.field.forEach(unit => {
-      if (unit.catalog.species?.includes('英雄')) {
-        // 既にこのユニットが発行したDeltaが存在するか確認
-        const delta = unit.delta.find(
-          d =>
-            d.source?.unit === stack.processing.id &&
-            d.source?.effectCode === 'インフィニット・フォース_不屈'
-        );
-
-        // Deltaが存在しない場合のみ不屈を付与
-        if (!delta) {
-          Effect.keyword(stack, stack.processing, unit, '不屈', {
-            source: { unit: stack.processing.id, effectCode: 'インフィニット・フォース_不屈' },
-          });
-        }
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '不屈', { source });
+      },
+      effectCode: 'インフィニット・フォース・英雄',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('英雄'),
     });
   },
 

--- a/src/game-data/effects/cards/1-3-050.ts
+++ b/src/game-data/effects/cards/1-3-050.ts
@@ -20,6 +20,6 @@ export const effects: CardEffects = {
       stack.processing.owner.opponent.trigger,
       '破壊するカードを選択して下さい'
     );
-    Effect.move(stack, stack.processing, target, 'trash');
+    Effect.break(stack, stack.processing, target);
   },
 };

--- a/src/game-data/effects/cards/1-3-057.ts
+++ b/src/game-data/effects/cards/1-3-057.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id && stack.processing.owner.delete.length > 0,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '神札再生', '消滅から1枚回収');
+    const [target] = await EffectHelper.selectCard(
+      stack,
+      stack.processing.owner,
+      stack.processing.owner.delete,
+      '手札に加えるカードを選択'
+    );
+    // 手札が上限に達している場合、消滅から捨札に送られる
+    Effect.move(stack, stack.processing, target, 'hand');
+  },
+};

--- a/src/game-data/effects/cards/1-3-063.ts
+++ b/src/game-data/effects/cards/1-3-063.ts
@@ -20,7 +20,7 @@ export const effects: CardEffects = {
       stack.processing.owner.hand,
       '消滅させるカードを選択して下さい'
     );
-    Effect.move(stack, stack.processing, target, 'delete');
+    Effect.delete(stack, stack.processing, target);
     EffectHelper.repeat(2, () =>
       EffectTemplate.reinforcements(stack, stack.processing.owner, {
         type: ['intercept'],

--- a/src/game-data/effects/cards/1-3-104.ts
+++ b/src/game-data/effects/cards/1-3-104.ts
@@ -24,7 +24,7 @@ export const effects: CardEffects = {
     ) {
       await System.show(stack, '口伝・真如剣', 'トリガーゾーンにあるカードを1枚破壊');
       const [target] = EffectHelper.random(stack.processing.owner.opponent.trigger);
-      if (target) Effect.move(stack, stack.processing, target, 'trash');
+      if (target) Effect.break(stack, stack.processing, target);
     }
   },
   onAttackSelf: effect,

--- a/src/game-data/effects/cards/1-3-107.ts
+++ b/src/game-data/effects/cards/1-3-107.ts
@@ -24,7 +24,7 @@ export const effects: CardEffects = {
       if (opponent.trash.length > 0) {
         await System.show(stack, '恩寵の牙', '捨札を3枚消滅');
         EffectHelper.random(opponent.trash, Math.min(3, opponent.trash.length)).forEach(card =>
-          Effect.move(stack, stack.processing, card, 'delete')
+          Effect.delete(stack, stack.processing, card)
         );
       }
     }

--- a/src/game-data/effects/cards/1-3-119.ts
+++ b/src/game-data/effects/cards/1-3-119.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, EffectTemplate } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 // カードがフィールドにあるかをカタログの name で判断するヘルパー関数
 const hasFourGodCard = (stack: StackWithCard<Unit>, name: string): boolean => {
@@ -60,28 +61,14 @@ export const effects: CardEffects = {
 
   // あなたの【四聖獣】ユニットに【不屈】を与える。（フィールド効果）
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    // 自分の四聖獣ユニットを取得
-    const fourGodUnits = stack.processing.owner.field.filter(unit =>
-      unit.catalog.species?.includes('四聖獣')
-    );
-
-    // 各四聖獣ユニットに【不屈】を付与（自身が付与したもののみを管理）
-    for (const unit of fourGodUnits) {
-      // このカードから既に付与された【不屈】があるか確認
-      const fortitudeDelta = unit.delta.find(
-        delta =>
-          delta.source?.unit === stack.processing.id &&
-          delta.source.effectCode === '不屈' &&
-          delta.effect.type === 'keyword' &&
-          delta.effect.name === '不屈'
-      );
-
-      // まだ付与されていない場合は付与する
-      if (!fortitudeDelta) {
-        Effect.keyword(stack, stack.processing, unit, '不屈', {
-          source: { unit: stack.processing.id, effectCode: '不屈' },
-        });
-      }
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '不屈', { source });
+      },
+      effectCode: '翠檄叡智',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('四聖獣'),
+    });
   },
 };

--- a/src/game-data/effects/cards/1-3-125.ts
+++ b/src/game-data/effects/cards/1-3-125.ts
@@ -1,0 +1,14 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.processing.owner.field.length + stack.processing.owner.opponent.field.length > 0,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '皆既日食', '全ユニットの行動権を回復');
+    [...stack.processing.owner.field, ...stack.processing.owner.opponent.field].forEach(unit =>
+      Effect.activate(stack, stack.processing, unit, true)
+    );
+  },
+};

--- a/src/game-data/effects/cards/1-3-125.ts
+++ b/src/game-data/effects/cards/1-3-125.ts
@@ -4,6 +4,7 @@ import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/type
 
 export const effects: CardEffects = {
   checkDrive: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
     stack.processing.owner.field.length + stack.processing.owner.opponent.field.length > 0,
   onDrive: async (stack: StackWithCard) => {
     await System.show(stack, '皆既日食', '全ユニットの行動権を回復');

--- a/src/game-data/effects/cards/1-3-215.ts
+++ b/src/game-data/effects/cards/1-3-215.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 // カードがフィールドにあるかをカタログの name で判断するヘルパー関数
 const hasFourGodCard = (stack: StackWithCard<Unit>, name: string): boolean => {
@@ -48,44 +49,24 @@ export const effects: CardEffects = {
 
   // あなたの【四聖獣】ユニットに【加護】と【貫通】を与える（フィールド効果）
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    // 自分の四聖獣ユニットを取得
-    const fourGodUnits = stack.processing.owner.field.filter(unit =>
-      unit.catalog.species?.includes('四聖獣')
-    );
-
-    // 各四聖獣ユニットに【加護】と【貫通】を付与
-    for (const unit of fourGodUnits) {
-      // このカードから既に付与された【加護】があるか確認
-      const protectDelta = unit.delta.find(
-        delta =>
-          delta.source?.unit === stack.processing.id &&
-          delta.source.effectCode === '加護' &&
-          delta.effect.type === 'keyword' &&
-          delta.effect.name === '加護'
-      );
-
-      // このカードから既に付与された【貫通】があるか確認
-      const penetrateDelta = unit.delta.find(
-        delta =>
-          delta.source?.unit === stack.processing.id &&
-          delta.source.effectCode === '貫通' &&
-          delta.effect.type === 'keyword' &&
-          delta.effect.name === '貫通'
-      );
-
-      // まだ付与されていない場合は付与する
-      if (!protectDelta) {
-        Effect.keyword(stack, stack.processing, unit, '加護', {
-          source: { unit: stack.processing.id, effectCode: '加護' },
-        });
-      }
-
-      if (!penetrateDelta) {
-        Effect.keyword(stack, stack.processing, unit, '貫通', {
-          source: { unit: stack.processing.id, effectCode: '貫通' },
-        });
-      }
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '加護', { source });
+      },
+      effectCode: '四聖を統べる少女_加護',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('四聖獣'),
+    });
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '貫通', { source });
+      },
+      effectCode: '四聖を統べる少女_貫通',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('四聖獣'),
+    });
   },
 
   // あなたのターン開始時、あなたのフィールドに［青龍］［朱雀］［白虎］［玄武］がいる場合、対戦相手に4ライフダメージを与える。

--- a/src/game-data/effects/cards/1-3-222.ts
+++ b/src/game-data/effects/cards/1-3-222.ts
@@ -60,7 +60,7 @@ export const effects: CardEffects = {
             if (card.id === selected.id) {
               Effect.move(stack, stack.processing, card, 'hand');
             } else {
-              Effect.move(stack, stack.processing, card, 'trash');
+              Effect.break(stack, stack.processing, card);
             }
           }
         },

--- a/src/game-data/effects/cards/1-3-236.ts
+++ b/src/game-data/effects/cards/1-3-236.ts
@@ -80,7 +80,7 @@ export const effects: CardEffects = {
     // 残りのカードを捨札に送る
     const remainingCard = randomCards.find(c => c.id !== selectedCard.id);
     if (remainingCard) {
-      Effect.move(stack, stack.processing, remainingCard, 'trash');
+      Effect.break(stack, stack.processing, remainingCard);
     }
   },
 };

--- a/src/game-data/effects/cards/1-3-255.ts
+++ b/src/game-data/effects/cards/1-3-255.ts
@@ -12,7 +12,7 @@ export const effects: CardEffects = {
     if (stack.target instanceof Unit) {
       Effect.keyword(stack, stack.processing, stack.target, '次元干渉', {
         condition: (self, blocker) => (self?.currentBP ?? 0) < (blocker?.currentBP ?? 0),
-        event: 'turnEnd',
+        event: '_postBattle',
         count: 1,
       });
     }

--- a/src/game-data/effects/cards/1-3-255.ts
+++ b/src/game-data/effects/cards/1-3-255.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkAttack: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    stack.processing.owner.field.some(unit => unit.id === stack.target?.id),
+  onAttack: async (stack: StackWithCard) => {
+    await System.show(stack, 'タルンカッペ', 'BP以下のユニットにしかブロックされない');
+    if (stack.target instanceof Unit) {
+      Effect.keyword(stack, stack.processing, stack.target, '次元干渉', {
+        condition: (self, blocker) => (self?.currentBP ?? 0) < (blocker?.currentBP ?? 0),
+        event: 'turnEnd',
+        count: 1,
+      });
+    }
+  },
+};

--- a/src/game-data/effects/cards/1-3-256.ts
+++ b/src/game-data/effects/cards/1-3-256.ts
@@ -1,0 +1,14 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) => stack.source.id !== stack.processing.owner.id,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '聖光による庇護', '味方全体のBP+5000\n対戦相手のライフ+1');
+    stack.processing.owner.field.forEach(unit =>
+      Effect.modifyBP(stack, stack.processing, unit, 5000, { event: 'turnEnd', count: 1 })
+    );
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, 1);
+  },
+};

--- a/src/game-data/effects/cards/1-3-264.ts
+++ b/src/game-data/effects/cards/1-3-264.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
         '捨てるカードを選んで下さい',
         3
       )
-    ).forEach(card => Effect.move(stack, stack.processing, card, 'trash'));
+    ).forEach(card => Effect.break(stack, stack.processing, card));
     EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['intercept'] });
   },
 };

--- a/src/game-data/effects/cards/1-4-008.ts
+++ b/src/game-data/effects/cards/1-4-008.ts
@@ -2,7 +2,7 @@ import type { Unit } from '@/package/core/class/card';
 import { EffectHelper, System, Effect } from '..';
 import type { StackWithCard } from '../schema/types';
 import { Color } from '@/submodule/suit/constant/color';
-import { Delta } from '@/package/core/class/delta';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects = {
   // 自身が召喚された時に発動する効果を記述
@@ -48,12 +48,11 @@ export const effects = {
 
   // 手札効果：自分の赤のユニットが場にいる場合、このユニットのコスト-1
   handEffect: (core: unknown, self: Unit) => {
-    if (!self.delta.some(delta => delta.source?.unit === self.id)) {
-      if (self.owner.field.some(unit => unit.catalog.color === Color.RED))
-        self.delta.push(new Delta({ type: 'cost', value: -1 }, { source: { unit: self.id } }));
-    } else {
-      if (!self.owner.field.some(unit => unit.catalog.color === Color.RED))
-        self.delta = self.delta.filter(delta => delta.source?.unit !== self.id);
-    }
+    PermanentEffect.mount(self, {
+      effect: (target, source) => Effect.modifyCost(target, -1, { source }),
+      effectCode: '破界炎舞・絶華繚乱',
+      targets: ['self'],
+      condition: target => target.owner.field.some(unit => unit.catalog.color === Color.RED),
+    });
   },
 };

--- a/src/game-data/effects/cards/1-4-101.ts
+++ b/src/game-data/effects/cards/1-4-101.ts
@@ -6,7 +6,7 @@ export const effects = {
     if (stack.processing.owner.opponent.trigger.length > 0) {
       await System.show(stack, 'ペローネ・ブラスト', 'トリガーゾーンを2枚破壊');
       EffectHelper.random(stack.processing.owner.opponent.trigger, 2).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
     }
   },

--- a/src/game-data/effects/cards/1-4-105.ts
+++ b/src/game-data/effects/cards/1-4-105.ts
@@ -15,7 +15,7 @@ export const effects: CardEffects = {
       );
       const [target] = EffectHelper.random(opponentTrigger, 1);
       if (target) {
-        Effect.move(stack, stack.processing, target, 'trash');
+        Effect.break(stack, stack.processing, target);
       }
     } else {
       await System.show(stack, '消滅効果耐性', '対戦相手の効果によって消滅しない');

--- a/src/game-data/effects/cards/1-4-120.ts
+++ b/src/game-data/effects/cards/1-4-120.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 async function unitAttackEffect(stack: StackWithCard<Unit>): Promise<void> {
   // どのユニットがアタックしてもこの効果は発動する
@@ -36,33 +37,14 @@ export const effects: CardEffects = {
 
   // フィールド効果：天使ユニットに貫通を与える
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    const owner = stack.processing.owner;
-
-    // 自分のフィールドの天使ユニットを対象にする
-    owner.field.forEach(unit => {
-      // 天使ユニットか確認
-      if (unit.catalog.species?.includes('天使')) {
-        // 既にこのユニットが発行したDeltaが存在するか確認
-        const delta = unit.delta.find(
-          d =>
-            d.source?.unit === stack.processing.id && d.source?.effectCode === 'フェイタル☆アロー'
-        );
-
-        // 既にDeltaが存在しない場合のみ貫通を付与
-        if (!delta) {
-          Effect.keyword(stack, stack.processing, unit, '貫通', {
-            source: { unit: stack.processing.id, effectCode: 'フェイタル☆アロー' },
-          });
-        }
-      } else {
-        // 天使でなくなった場合、このユニットが付与した貫通を削除
-        unit.delta = unit.delta.filter(
-          d =>
-            !(
-              d.source?.unit === stack.processing.id && d.source?.effectCode === 'フェイタル☆アロー'
-            )
-        );
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '貫通', { source });
+      },
+      effectCode: 'フェイタル☆アロー',
+      condition: target => target instanceof Unit && target.catalog.species?.includes('天使'),
+      targets: ['owns'],
     });
   },
 };

--- a/src/game-data/effects/cards/1-4-125.ts
+++ b/src/game-data/effects/cards/1-4-125.ts
@@ -43,7 +43,7 @@ export const effects: CardEffects = {
 
     // トリガーカードがある場合、全て破壊
     triggerCards.forEach(card => {
-      Effect.move(stack, stack.processing, card, 'trash');
+      Effect.break(stack, stack.processing, card);
     });
   },
 };

--- a/src/game-data/effects/cards/1-4-216.ts
+++ b/src/game-data/effects/cards/1-4-216.ts
@@ -1,7 +1,7 @@
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
-import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
   // 自身が召喚された時に発動する効果を記述
@@ -56,15 +56,11 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: async (stack: StackWithCard): Promise<void> => {
-    stack.processing.owner.opponent.hand.forEach(card => {
-      if (
-        !card.delta.some(
-          delta => delta.effect.type === 'banned' && delta.source?.unit === stack.processing.id
-        ) &&
-        card.catalog.cost >= 7
-      ) {
-        card.delta.push(new Delta({ type: 'banned' }, { source: { unit: stack.processing.id } }));
-      }
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
+      targets: ['opponents', 'hand'],
+      condition: card => card.catalog.cost >= 7,
+      effectCode: '神制の耀矢',
     });
   },
 };

--- a/src/game-data/effects/cards/1-4-216.ts
+++ b/src/game-data/effects/cards/1-4-216.ts
@@ -39,7 +39,7 @@ export const effects: CardEffects = {
 
     await System.show(stack, '醒命の光矢', '捨札を消滅させる');
     const [target] = EffectHelper.random(stack.processing.owner.trash);
-    if (target) Effect.move(stack, stack.processing, target, 'delete');
+    if (target) Effect.delete(stack, stack.processing, target);
   },
 
   onBreakSelf: async (stack: StackWithCard): Promise<void> => {

--- a/src/game-data/effects/cards/1-4-216.ts
+++ b/src/game-data/effects/cards/1-4-216.ts
@@ -59,7 +59,7 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost >= 7,
+      condition: card => card.catalog.cost >= 7 && card instanceof Unit,
       effectCode: '神制の耀矢',
     });
   },

--- a/src/game-data/effects/cards/1-4-221.ts
+++ b/src/game-data/effects/cards/1-4-221.ts
@@ -1,6 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
@@ -47,54 +48,30 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard<Unit>) => {
-    const owner = stack.processing.owner;
-    // Count Samurai units on the field
-    const samuraiUnitsOnField = owner.field.filter(unit => unit.catalog.species?.includes('侍'));
-    const samuraiCount = samuraiUnitsOnField.length;
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '不屈', { source });
+      },
+      effectCode: '白拍子の鼓舞_不屈',
+      targets: ['owns'],
+      condition: target =>
+        target instanceof Unit &&
+        target.owner.field.filter(unit => unit.catalog.species?.includes('侍')).length <= 2 &&
+        target.catalog.species?.includes('侍'),
+    });
 
-    // Check if the condition is met (2 or fewer Samurai units)
-    if (samuraiCount <= 2) {
-      // For each Samurai unit, give Fortitude and Order Shield
-      samuraiUnitsOnField.forEach(unit => {
-        // Check for existing delta from this unit
-        const fortitudeDelta = unit.delta.find(
-          delta =>
-            delta.source?.unit === stack.processing.id &&
-            delta.source?.effectCode === '白拍子の鼓舞_不屈'
-        );
-
-        const orderShieldDelta = unit.delta.find(
-          delta =>
-            delta.source?.unit === stack.processing.id &&
-            delta.source?.effectCode === '白拍子の鼓舞_秩序の盾'
-        );
-
-        // Apply Fortitude if not already applied
-        if (!fortitudeDelta) {
-          Effect.keyword(stack, stack.processing, unit, '不屈', {
-            source: { unit: stack.processing.id, effectCode: '白拍子の鼓舞_不屈' },
-          });
-        }
-
-        // Apply Order Shield if not already applied
-        if (!orderShieldDelta) {
-          Effect.keyword(stack, stack.processing, unit, '秩序の盾', {
-            source: { unit: stack.processing.id, effectCode: '白拍子の鼓舞_秩序の盾' },
-          });
-        }
-      });
-    } else {
-      // Remove the keywords if condition is no longer met
-      samuraiUnitsOnField.forEach(unit => {
-        unit.delta = unit.delta.filter(
-          delta =>
-            !(
-              delta.source?.unit === stack.processing.id &&
-              (delta.source?.effectCode === '白拍子の鼓舞_不屈' ||
-                delta.source?.effectCode === '白拍子の鼓舞_秩序の盾')
-            )
-        );
-      });
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '秩序の盾', { source });
+      },
+      effectCode: '白拍子の鼓舞_秩序の盾',
+      targets: ['owns'],
+      condition: target =>
+        target instanceof Unit &&
+        target.owner.field.filter(unit => unit.catalog.species?.includes('侍')).length <= 2 &&
+        target.catalog.species?.includes('侍'),
+    });
   },
 };

--- a/src/game-data/effects/cards/1-4-231.ts
+++ b/src/game-data/effects/cards/1-4-231.ts
@@ -1,7 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import type { KeywordEffect } from '@/submodule/suit/types';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 const ability = async (stack: StackWithCard): Promise<void> => {
   await System.show(
@@ -39,18 +39,23 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard) => {
-    stack.processing.owner.field
-      .filter(unit => unit.catalog.species?.includes('武身'))
-      .forEach(unit => {
-        if (!unit.delta.some(delta => delta.source?.unit === stack.processing.id)) {
-          (['不屈', '貫通'] satisfies KeywordEffect[]).forEach(keyword =>
-            Effect.keyword(stack, stack.processing, unit, keyword, {
-              source: {
-                unit: stack.processing.id,
-              },
-            })
-          );
-        }
-      });
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '不屈', { source });
+      },
+      effectCode: '護剣の戦舞_不屈',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('武身'),
+    });
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '貫通', { source });
+      },
+      effectCode: '護剣の戦舞_貫通',
+      targets: ['owns'],
+      condition: target => target instanceof Unit && target.catalog.species?.includes('武身'),
+    });
   },
 };

--- a/src/game-data/effects/cards/1-4-243.ts
+++ b/src/game-data/effects/cards/1-4-243.ts
@@ -24,11 +24,9 @@ export const effects: CardEffects = {
       );
       const ownUnit =
         stack.source.owner.id === stack.processing.owner.id ? stack.source : stack.target;
-      stack.processing.owner.trash.forEach(card =>
-        Effect.move(stack, stack.processing, card, 'delete')
-      );
+      stack.processing.owner.trash.forEach(card => Effect.delete(stack, stack.processing, card));
       EffectHelper.random(stack.processing.owner.deck, 5).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
       Effect.modifyBP(
         stack,

--- a/src/game-data/effects/cards/1-4-258.ts
+++ b/src/game-data/effects/cards/1-4-258.ts
@@ -1,0 +1,29 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Card, Unit } from '@/package/core/class/card';
+
+const getSelfUnderCost3Filter = (self: Card) => (unit: Unit) =>
+  self.owner.id === unit.owner.id && unit.catalog.cost <= 3;
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    stack.processing.owner.field.length <= 4 &&
+    EffectHelper.isUnitSelectable(
+      stack.core,
+      getSelfUnderCost3Filter(stack.processing),
+      stack.processing.owner
+    ),
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '大天使の息吹', 'コスト3以下を【複製】');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      getSelfUnderCost3Filter(stack.processing),
+      '【複製】するユニットを選択'
+    );
+    await Effect.clone(stack, stack.processing, target, stack.processing.owner);
+  },
+};

--- a/src/game-data/effects/cards/1-4-261.ts
+++ b/src/game-data/effects/cards/1-4-261.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    EffectHelper.isUnitSelectable(stack.core, 'owns', stack.processing.owner),
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, 'ペイン・シャドウ', 'ユニットを破壊する');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'owns',
+      '破壊するユニットを選択'
+    );
+    Effect.break(stack, stack.processing, target);
+  },
+};

--- a/src/game-data/effects/cards/1-4-303.ts
+++ b/src/game-data/effects/cards/1-4-303.ts
@@ -12,7 +12,7 @@ const triggerDestroy = async (stack: StackWithCard<Unit>): Promise<void> => {
 
   // トリガーゾーンからランダムで1枚選ぶ
   const [targetCard] = EffectHelper.random(opponent.trigger, 1);
-  if (targetCard) Effect.move(stack, stack.processing, targetCard, 'trash');
+  if (targetCard) Effect.break(stack, stack.processing, targetCard);
 };
 
 export const effects: CardEffects = {

--- a/src/game-data/effects/cards/1-4-310.ts
+++ b/src/game-data/effects/cards/1-4-310.ts
@@ -21,7 +21,7 @@ export const effects: CardEffects = {
       const triggerCards = [...opponent.trigger];
 
       for (const card of triggerCards) {
-        Effect.move(stack, stack.processing, card, 'hand');
+        Effect.bounce(stack, stack.processing, card, 'hand');
       }
     }
   },

--- a/src/game-data/effects/cards/1-4-315.ts
+++ b/src/game-data/effects/cards/1-4-315.ts
@@ -34,6 +34,6 @@ export const effects: CardEffects = {
     if (!target) return;
 
     await System.show(stack, 'えんじぇりっく・ろすと', 'トリガーゾーンを1枚破壊');
-    Effect.move(stack, stack.processing, target, 'trash');
+    Effect.break(stack, stack.processing, target);
   },
 };

--- a/src/game-data/effects/cards/1-4-326.ts
+++ b/src/game-data/effects/cards/1-4-326.ts
@@ -13,7 +13,7 @@ export const effects: CardEffects = {
     await System.show(stack, '文明崩壊', 'お互いのデッキと捨札を消滅させる\nカードを1枚引く');
     stack.core.players.forEach(player => {
       [...player.deck, ...player.trash].forEach(card =>
-        Effect.move(stack, stack.processing, card, 'delete')
+        Effect.delete(stack, stack.processing, card)
       );
       EffectTemplate.draw(player, stack.core);
     });

--- a/src/game-data/effects/cards/1-4-327.ts
+++ b/src/game-data/effects/cards/1-4-327.ts
@@ -12,7 +12,7 @@ export const effects: CardEffects = {
   onDrive: async (stack: StackWithCard): Promise<void> => {
     await System.show(stack, '紅蓮の命', 'トリガーゾーンを全て破壊\n1ライフダメージ');
     [...stack.processing.owner.trigger, ...stack.processing.owner.opponent.trigger].forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
     Effect.modifyLife(stack, stack.processing, stack.processing.owner, -1);
   },

--- a/src/game-data/effects/cards/2-0-006.ts
+++ b/src/game-data/effects/cards/2-0-006.ts
@@ -5,7 +5,7 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   // 自身が召喚された時に発動する効果を記述
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, '胎動＆固着', '手札に戻らない\nコスト3以下に【狂戦士】を与える');
+    await System.show(stack, '胎動＆固着', 'コスト3以下に【狂戦士】を与える\n手札に戻らない');
     Effect.keyword(stack, stack.processing, stack.processing, '固着');
   },
 

--- a/src/game-data/effects/cards/2-0-011.ts
+++ b/src/game-data/effects/cards/2-0-011.ts
@@ -9,21 +9,19 @@ export const effects: CardEffects = {
   },
 
   onTurnStart: async (stack: StackWithCard<Unit>) => {
-    // 自分のターン開始時のみ発動
-    if (stack.processing.owner.id !== stack.core.getTurnPlayer().id) {
-      return;
-    }
-
-    // 【神託】を持っているか確認
-    if (!stack.processing.hasKeyword('神託')) {
-      return;
-    }
-
-    // デッキからカードを1枚選ぶ
     const deck = stack.processing.owner.deck;
-    if (deck.length === 0) {
+
+    if (
+      // 自分のターン開始時のみ発動
+      stack.processing.owner.id !== stack.core.getTurnPlayer().id ||
+      // 神託チェック
+      !stack.processing.hasKeyword('神託') ||
+      // デッキ選択可能か
+      deck.length === 0 ||
+      // ドロー可能か
+      stack.processing.owner.hand.length >= stack.core.room.rule.player.max.hand
+    )
       return;
-    }
 
     await System.show(stack, '奇跡・出会いは必然', 'デッキから1枚引く');
     const [selectedCard] = await EffectHelper.selectCard(
@@ -55,6 +53,6 @@ export const effects: CardEffects = {
       return;
     }
 
-    Effect.move(stack, stack.processing, selectedCard, 'hand');
+    Effect.bounce(stack, stack.processing, selectedCard, 'hand');
   },
 };

--- a/src/game-data/effects/cards/2-0-012.ts
+++ b/src/game-data/effects/cards/2-0-012.ts
@@ -1,7 +1,7 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
@@ -33,22 +33,12 @@ export const effects: CardEffects = {
     Effect.keyword(stack, stack.processing, stack.processing, '進化禁止');
   },
 
-  fieldEffect: (stack: StackWithCard) => {
-    stack.processing.owner.opponent.hand
-      .filter(
-        card =>
-          card.catalog.cost >= 6 &&
-          !card.delta.find(delta => delta.source?.unit === stack.processing.id)
-      )
-      .forEach(card =>
-        card.delta.push(
-          new Delta(
-            { type: 'banned' },
-            {
-              source: { unit: stack.processing.id },
-            }
-          )
-        )
-      );
+  fieldEffect: async (stack: StackWithCard): Promise<void> => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
+      targets: ['opponents', 'hand'],
+      condition: card => card.catalog.cost >= 7,
+      effectCode: '神制の耀矢',
+    });
   },
 };

--- a/src/game-data/effects/cards/2-0-012.ts
+++ b/src/game-data/effects/cards/2-0-012.ts
@@ -50,7 +50,7 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost >= 6,
+      condition: card => card.catalog.cost >= 6 && card instanceof Unit,
       effectCode: '神征の楔',
     });
   },

--- a/src/game-data/effects/cards/2-0-012.ts
+++ b/src/game-data/effects/cards/2-0-012.ts
@@ -1,5 +1,5 @@
 import { Unit } from '@/package/core/class/card';
-import { Effect, EffectHelper, System } from '..';
+import { Effect, EffectHelper } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
@@ -11,34 +11,47 @@ export const effects: CardEffects = {
     const opponentTargets = stack.processing.owner.opponent.field;
     const targets = [...ownerTargets, ...opponentTargets];
 
-    if (targets.length > 0) {
-      if (ownerTargets.length >= 2) {
-        await System.show(
-          stack,
-          '神怒の豪雷＆進化禁止',
-          '進化することができない\n自身以外を消滅\n基本BP+2000\n【加護】を得る'
-        );
-        Effect.modifyBP(stack, stack.processing, stack.processing, 2000, { isBaseBP: true });
-        Effect.keyword(stack, stack.processing, stack.processing, '加護');
-      } else {
-        await System.show(stack, '神怒の豪雷＆進化禁止', '進化することができない\n自身以外を消滅');
-      }
-      EffectHelper.exceptSelf(stack.core, stack.processing, unit =>
-        Effect.delete(stack, stack.processing, unit)
-      );
-    } else {
-      await System.show(stack, '進化禁止', '進化することができない');
-    }
-
-    Effect.keyword(stack, stack.processing, stack.processing, '進化禁止');
+    await EffectHelper.combine(stack, [
+      {
+        title: '神怒の豪雷',
+        description: '自身以外を消滅',
+        effect: () => {
+          EffectHelper.exceptSelf(stack.core, stack.processing, unit =>
+            Effect.delete(stack, stack.processing, unit)
+          );
+        },
+        condition: targets.length > 0,
+      },
+      {
+        title: '神怒の豪雷',
+        description: '基本BP+2000\n【加護】を得る',
+        effect: () => {
+          Effect.modifyBP(stack, stack.processing, stack.processing, 2000, { isBaseBP: true });
+          Effect.keyword(stack, stack.processing, stack.processing, '加護');
+        },
+        condition: ownerTargets.length >= 2,
+      },
+      {
+        title: '進化禁止',
+        description: '進化することができない',
+        effect: () => {
+          Effect.keyword(stack, stack.processing, stack.processing, '進化禁止');
+        },
+      },
+      {
+        title: '神征の楔',
+        description: 'コスト6以上をフィールドに出せない',
+        effect: () => {},
+      },
+    ]);
   },
 
   fieldEffect: async (stack: StackWithCard): Promise<void> => {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost >= 7,
-      effectCode: '神制の耀矢',
+      condition: card => card.catalog.cost >= 6,
+      effectCode: '神征の楔',
     });
   },
 };

--- a/src/game-data/effects/cards/2-0-014.ts
+++ b/src/game-data/effects/cards/2-0-014.ts
@@ -6,7 +6,7 @@ import { Unit } from '@/package/core/class/card';
 const onBattle = async (stack: StackWithCard) => {
   await System.show(stack, 'ミーナ頑張る！', '捨札を1枚消滅');
   EffectHelper.random(stack.processing.owner.trash).forEach(card =>
-    Effect.move(stack, stack.processing, card, 'delete')
+    Effect.delete(stack, stack.processing, card)
   );
 };
 

--- a/src/game-data/effects/cards/2-0-014.ts
+++ b/src/game-data/effects/cards/2-0-014.ts
@@ -4,6 +4,7 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
 
 const onBattle = async (stack: StackWithCard) => {
+  if (stack.processing.owner.trash.length === 0) return;
   await System.show(stack, 'ミーナ頑張る！', '捨札を1枚消滅');
   EffectHelper.random(stack.processing.owner.trash).forEach(card =>
     Effect.move(stack, stack.processing, card, 'delete')
@@ -18,7 +19,8 @@ export const effects: CardEffects = {
     const isOpponentTurn = stack.processing.owner.id !== stack.core.getTurnPlayer().id;
     const isAtLeast15BlueCardsInTrash =
       stack.processing.owner.trash.filter(card => card.catalog.color === Color.BLUE).length >= 15;
-    const hasFieldSpace = stack.processing.owner.field.length <= 4;
+    const hasFieldSpace =
+      stack.processing.owner.field.length < stack.core.room.rule.player.max.field;
 
     if (isOpponentTurn && isAtLeast15BlueCardsInTrash && hasFieldSpace) {
       // oxlint-disable-next-line no-floating-promises

--- a/src/game-data/effects/cards/2-0-016.ts
+++ b/src/game-data/effects/cards/2-0-016.ts
@@ -4,10 +4,29 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
 
 const onBattle = async (stack: StackWithCard) => {
+  if (stack.processing.owner.trash.length === 0) return;
   await System.show(stack, '永久凍土', '捨札を3枚消滅');
   EffectHelper.random(stack.processing.owner.trash, 3).forEach(card =>
     Effect.move(stack, stack.processing, card, 'delete')
   );
+};
+
+const clockupEffect = async (stack: StackWithCard): Promise<void> => {
+  if (!(stack.target instanceof Unit)) return;
+  const isClockUpToLv3 =
+    stack.target.owner.id === stack.processing.owner.id && stack.target.lv === 3;
+  const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id && unit.lv >= 2;
+
+  if (isClockUpToLv3 && EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) {
+    await System.show(stack, '絶対零度の息吹', 'レベル2以上のユニットを1体破壊');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      filter,
+      '破壊するユニットを選択してください'
+    );
+    Effect.break(stack, stack.processing, target, 'effect');
+  }
 };
 
 export const effects: CardEffects = {
@@ -18,7 +37,8 @@ export const effects: CardEffects = {
     const isOpponentTurn = stack.processing.owner.id !== stack.core.getTurnPlayer().id;
     const isAtLeast25BlueCardsInTrash =
       stack.processing.owner.trash.filter(card => card.catalog.color === Color.BLUE).length >= 25;
-    const hasFieldSpace = stack.processing.owner.field.length <= 4;
+    const hasFieldSpace =
+      stack.processing.owner.field.length < stack.core.room.rule.player.max.field;
 
     if (isOpponentTurn && isAtLeast25BlueCardsInTrash && hasFieldSpace) {
       // oxlint-disable-next-line no-floating-promises
@@ -31,22 +51,11 @@ export const effects: CardEffects = {
   onBlockSelf: async (stack: StackWithCard): Promise<void> => await onBattle(stack),
   onBreakSelf: async (stack: StackWithCard): Promise<void> => await onBattle(stack),
 
-  onClockupSelf: async (stack: StackWithCard): Promise<void> => {
-    const isClockUpToLv3 = stack.processing.lv === 3;
-    const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id && unit.lv >= 2;
-
-    if (
-      isClockUpToLv3 &&
-      EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)
-    ) {
-      await System.show(stack, '絶対零度の息吹', 'レベル2以上のユニットを1体破壊');
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        filter,
-        '破壊するユニットを選択してください'
-      );
-      Effect.break(stack, stack.processing, target, 'effect');
+  onClockupSelf: clockupEffect,
+  onClockup: async (stack: StackWithCard): Promise<void> => {
+    if (!(stack.target instanceof Unit)) return;
+    if (stack.processing.id !== stack.target.id) {
+      await clockupEffect(stack);
     }
   },
 };

--- a/src/game-data/effects/cards/2-0-016.ts
+++ b/src/game-data/effects/cards/2-0-016.ts
@@ -6,7 +6,7 @@ import { Unit } from '@/package/core/class/card';
 const onBattle = async (stack: StackWithCard) => {
   await System.show(stack, '永久凍土', '捨札を3枚消滅');
   EffectHelper.random(stack.processing.owner.trash, 3).forEach(card =>
-    Effect.move(stack, stack.processing, card, 'delete')
+    Effect.delete(stack, stack.processing, card)
   );
 };
 

--- a/src/game-data/effects/cards/2-0-017.ts
+++ b/src/game-data/effects/cards/2-0-017.ts
@@ -6,7 +6,7 @@ import { Unit } from '@/package/core/class/card';
 const onBattle = async (stack: StackWithCard) => {
   await System.show(stack, 'オーシャンヒロイン', '捨札を2枚消滅');
   EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
-    Effect.move(stack, stack.processing, card, 'delete')
+    Effect.delete(stack, stack.processing, card)
   );
 };
 

--- a/src/game-data/effects/cards/2-0-017.ts
+++ b/src/game-data/effects/cards/2-0-017.ts
@@ -4,6 +4,7 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
 
 const onBattle = async (stack: StackWithCard) => {
+  if (stack.processing.owner.trash.length === 0) return;
   await System.show(stack, 'オーシャンヒロイン', '捨札を2枚消滅');
   EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
     Effect.move(stack, stack.processing, card, 'delete')
@@ -18,7 +19,8 @@ export const effects: CardEffects = {
     const isOpponentTurn = stack.processing.owner.id !== stack.core.getTurnPlayer().id;
     const isAtLeast20BlueCardsInTrash =
       stack.processing.owner.trash.filter(card => card.catalog.color === Color.BLUE).length >= 20;
-    const hasFieldSpace = stack.processing.owner.field.length <= 4;
+    const hasFieldSpace =
+      stack.processing.owner.field.length < stack.core.room.rule.player.max.field;
 
     if (isOpponentTurn && isAtLeast20BlueCardsInTrash && hasFieldSpace) {
       // oxlint-disable-next-line no-floating-promises

--- a/src/game-data/effects/cards/2-0-018.ts
+++ b/src/game-data/effects/cards/2-0-018.ts
@@ -18,7 +18,7 @@ export const effects = {
         Effect.break(stack, stack.processing, unit, 'effect')
       );
       EffectHelper.random(stack.processing.owner.trigger, 2).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
     }
   },

--- a/src/game-data/effects/cards/2-0-024.ts
+++ b/src/game-data/effects/cards/2-0-024.ts
@@ -11,16 +11,17 @@ export const effects: CardEffects = {
       '自分の手札を選んで捨てる\nコスト3のユニットを1枚引く\n【秩序の盾】を得る'
     );
 
-    // 手札を選んで捨てる
     const owner = stack.processing.owner;
-    const [target] = await EffectHelper.selectCard(
-      stack,
-      owner,
-      owner.hand,
-      '捨てるカードを選択してください'
-    );
-    Effect.break(stack, stack.processing, target);
-
+    if (owner.hand.length > 0) {
+      // 手札を選んで捨てる
+      const [target] = await EffectHelper.selectCard(
+        stack,
+        owner,
+        owner.hand,
+        '捨てるカードを選択してください'
+      );
+      Effect.break(stack, stack.processing, target);
+    }
     // コスト3のユニットを引く
     const [card] = EffectHelper.random(
       owner.deck.filter(card => card.catalog.cost === 3 && card instanceof Unit),

--- a/src/game-data/effects/cards/2-0-026.ts
+++ b/src/game-data/effects/cards/2-0-026.ts
@@ -1,11 +1,15 @@
 import { Unit } from '@/package/core/class/card';
 import { EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { Color } from '@/submodule/suit/constant/color';
 
 export const effects: CardEffects = {
-  // このユニットがフィールドに出た時、あなたはインターセプトカードを1枚引く。
+  // このユニットがフィールドに出た時、あなたは紫属性のインターセプトカードを1枚引く。
   onDriveSelf: async (stack: StackWithCard<Unit>): Promise<void> => {
-    await System.show(stack, 'インターセプトドロー', 'インターセプトカードを1枚引く');
-    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['intercept'] });
+    await System.show(stack, 'インターセプトドロー', '紫属性のインターセプトカードを1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, {
+      type: ['intercept'],
+      color: Color.PURPLE,
+    });
   },
 };

--- a/src/game-data/effects/cards/2-0-027.ts
+++ b/src/game-data/effects/cards/2-0-027.ts
@@ -3,11 +3,16 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
   onBreakSelf: async (stack: StackWithCard) => {
-    await System.show(stack, '幼竜の叫び', 'インターセプトカードを捨札から1枚回収\n紫ゲージ+1');
-    EffectHelper.random(
+    const targets = EffectHelper.random(
       stack.processing.owner.trash.filter(card => card.catalog.type === 'intercept'),
       1
-    ).forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+    );
+    if (targets.length > 0) {
+      await System.show(stack, '幼竜の叫び', 'インターセプトカードを捨札から1枚回収\n紫ゲージ+1');
+      targets.forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+    } else {
+      await System.show(stack, '幼竜の叫び', '紫ゲージ+1');
+    }
     await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
   },
 };

--- a/src/game-data/effects/cards/2-0-028.ts
+++ b/src/game-data/effects/cards/2-0-028.ts
@@ -28,14 +28,24 @@ export const effects: CardEffects = {
     );
 
     // 2000ダメージを与える
-    const destroyed = Effect.damage(stack, stack.processing, target, 2000, 'effect');
+    Effect.damage(stack, stack.processing, target, 2000, 'effect');
 
     // 紫ゲージ+1
     await Effect.modifyPurple(stack, stack.processing, owner, 1);
+  },
+
+  onBreak: async (stack: StackWithCard<Unit>): Promise<void> => {
+    // 自分の効果で破壊されたかチェック
+    if (
+      stack.source.id !== stack.processing.id ||
+      stack.option?.type !== 'break' ||
+      stack.option.cause !== 'damage'
+    )
+      return;
 
     // この効果でユニットを破壊した場合、追加で紫ゲージ+1
-    if (destroyed) {
-      await Effect.modifyPurple(stack, stack.processing, owner, 1);
-    }
+    const owner = stack.processing.owner;
+    await System.show(stack, '熱々のキスはいかが？', '紫ゲージ+1');
+    await Effect.modifyPurple(stack, stack.processing, owner, 1);
   },
 };

--- a/src/game-data/effects/cards/2-0-041.ts
+++ b/src/game-data/effects/cards/2-0-041.ts
@@ -3,6 +3,11 @@ import { Effect, EffectHelper, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
+  // 召喚時効果
+  onDriveSelf: async (stack: StackWithCard): Promise<void> => {
+    await System.show(stack, '聖なる悪意', 'レベル2の時【加護】を得る');
+  },
+
   // ターン開始時効果
   onTurnStart: async (stack: StackWithCard<Unit>) => {
     if (!EffectHelper.isUnitSelectable(stack.core, 'all', stack.processing.owner)) return;

--- a/src/game-data/effects/cards/2-0-042.ts
+++ b/src/game-data/effects/cards/2-0-042.ts
@@ -1,0 +1,48 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit, type Card } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    await System.show(stack, '従順な眷属＆滾るステップ', 'BP+[紫ゲージ×500]\n【加護】を得る');
+  },
+  onAttackSelf: async (stack: StackWithCard) => {
+    if (
+      (stack.processing.owner.purple ?? 0) < 3 ||
+      stack.processing.owner.opponent.field.length === 0
+    )
+      return;
+    await System.show(stack, 'デッドリーダンス', '敵全体の基本BP-1000');
+    stack.processing.owner.opponent.field.forEach(unit =>
+      Effect.modifyBP(stack, stack.processing, unit, -1000, { isBaseBP: true })
+    );
+  },
+  fieldEffect: (stack: StackWithCard<Unit>) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.keyword(stack, stack.processing, target, '加護', { source });
+      },
+      effectCode: '滾るステップ',
+      targets: ['self'],
+      condition: (target: Card) => (target.owner.purple ?? 0) <= 4,
+    });
+
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.modifyBP(
+            stack,
+            stack.processing,
+            target,
+            (stack.processing.owner.purple ?? 0) * 500,
+            { source }
+          );
+      },
+      effectCode: '従順な眷属',
+      targets: ['owns'],
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-0-044.ts
+++ b/src/game-data/effects/cards/2-0-044.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
     // 紫ゲージが4以上の場合、捨札からコスト3以下の紫属性ユニットを2体特殊召喚
     if (
       purpleGauge >= 4 &&
-      trashCards.length > 0 &&
+      trashCards.length >= 2 &&
       stack.core.room.rule.player.max.field - stack.processing.owner.field.length >= 2
     ) {
       await System.show(
@@ -58,10 +58,7 @@ export const effects: CardEffects = {
     // 紫属性ユニットに【貫通】を付与
     owner.field.forEach(unit => {
       if (unit.catalog.color === Color.PURPLE) {
-        Effect.keyword(stack, stack.processing, unit, '貫通', {
-          event: 'turnEnd',
-          count: 1,
-        });
+        Effect.keyword(stack, stack.processing, unit, '貫通');
       }
     });
 

--- a/src/game-data/effects/cards/2-0-045.ts
+++ b/src/game-data/effects/cards/2-0-045.ts
@@ -11,6 +11,8 @@ export const effects: CardEffects = {
   // 関数名に self は付かない
   onDrive: async (stack: StackWithCard): Promise<void> => {
     await System.show(stack, '愛しき来訪者', 'ユニットカードを1枚引く');
-    EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['unit'] });
+    EffectTemplate.reinforcements(stack, stack.processing.owner, {
+      type: ['unit', 'advanced_unit'],
+    });
   },
 };

--- a/src/game-data/effects/cards/2-0-046.ts
+++ b/src/game-data/effects/cards/2-0-046.ts
@@ -1,0 +1,27 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) => {
+    const target = stack.target;
+    if (stack.source.id !== stack.processing.owner.id || !(target instanceof Unit)) return false;
+
+    return target.catalog.species?.includes('英雄')
+      ? stack.processing.owner.field.some(unit => unit.id === target.id)
+      : true;
+  },
+  onDrive: async (stack: StackWithCard) => {
+    if (!(stack.target instanceof Unit)) return;
+    if (stack.target.catalog.species?.includes('英雄')) {
+      await System.show(stack, '受け継がれし英雄譚', '基本BP+2000\n【不屈】を付与');
+      Effect.modifyBP(stack, stack.processing, stack.target, 2000, { isBaseBP: true });
+      Effect.keyword(stack, stack.processing, stack.target, '不屈');
+    } else {
+      await System.show(stack, '受け継がれし英雄譚', '【英雄】を1枚引く');
+      EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '英雄' });
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-0-054.ts
+++ b/src/game-data/effects/cards/2-0-054.ts
@@ -11,12 +11,13 @@ export const effects: CardEffects = {
 
     const attacker = stack.target;
     const owner = stack.processing.owner;
-
-    // 相手が攻撃した場合は常に発動可能
-    if (attacker.owner.id !== owner.id) return true;
-
-    // 自分が攻撃した場合は、対戦相手に行動済ユニットが存在する時のみ発動可能
     const opponent = owner.opponent;
+
+    // 相手が攻撃した場合は、攻撃ユニットが存在している時のみ発動可能
+    if (attacker.owner.id === opponent.id) {
+      return opponent.field.some(unit => unit.id === attacker.id);
+    }
+    // 自分が攻撃した場合は、対戦相手に行動済ユニットが存在する時のみ発動可能
     return opponent.field.some(u => !u.active);
   },
 

--- a/src/game-data/effects/cards/2-0-055.ts
+++ b/src/game-data/effects/cards/2-0-055.ts
@@ -6,28 +6,30 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // あなたのターン開始時
   checkTurnStart: (stack: StackWithCard<Card>): boolean => {
-    // あなたのフィールドにユニットが1体以上いる場合に発動可能
-    return stack.source.id === stack.processing.owner.id && stack.processing.owner.field.length > 0;
+    const owner = stack.processing.owner;
+    // あなたのフィールドのユニットが選択できる場合に発動可能
+    return (
+      stack.source.id === stack.processing.owner.id &&
+      EffectHelper.isUnitSelectable(stack.core, 'owns', owner)
+    );
   },
 
   onTurnStart: async (stack: StackWithCard<Card>): Promise<void> => {
     const owner = stack.processing.owner;
 
+    await System.show(stack, 'チョークスリーパー', '選んだ以外の全ユニットの行動権を消費');
+
     // あなたのユニットを1体選ぶ
-    if (EffectHelper.isUnitSelectable(stack.core, 'owns', owner)) {
-      await System.show(stack, 'チョークスリーパー', '選んだ以外の全ユニットの行動権を消費');
+    const [keepUnit] = await EffectHelper.pickUnit(
+      stack,
+      owner,
+      'owns',
+      '行動権を残すユニットを選択'
+    );
 
-      const [keepUnit] = await EffectHelper.pickUnit(
-        stack,
-        owner,
-        'owns',
-        '行動権を残すユニットを選択'
-      );
-
-      // それ以外の全てのユニットの行動権を消費
-      EffectHelper.exceptSelf(stack.core, keepUnit, unit =>
-        Effect.activate(stack, stack.processing, unit, false)
-      );
-    }
+    // それ以外の全てのユニットの行動権を消費
+    EffectHelper.exceptSelf(stack.core, keepUnit, unit =>
+      Effect.activate(stack, stack.processing, unit, false)
+    );
   },
 };

--- a/src/game-data/effects/cards/2-0-067.ts
+++ b/src/game-data/effects/cards/2-0-067.ts
@@ -23,11 +23,11 @@ export const effects: CardEffects = {
     if (purple >= 3) {
       const targets = EffectHelper.random(opponent.trigger, 2);
       await System.show(stack, 'ダークプリズン', 'トリガーゾーンのカードを2枚破壊');
-      targets.forEach(card => Effect.move(stack, stack.processing, card, 'trash'));
+      targets.forEach(card => Effect.break(stack, stack.processing, card));
     } else {
       await System.show(stack, 'ダークプリズン', 'トリガーゾーンのカードを1枚破壊');
       EffectHelper.random(opponent.trigger, 1).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
     }
   },

--- a/src/game-data/effects/cards/2-0-134.ts
+++ b/src/game-data/effects/cards/2-0-134.ts
@@ -1,0 +1,18 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) => stack.source.id === stack.processing.owner.id,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, 'グランドライブラリ', '同属性のインターセプトカードを1枚引く');
+    const target = stack.target instanceof Unit ? stack.target : undefined;
+    EffectHelper.random(
+      stack.processing.owner.deck.filter(
+        card => card.catalog.type === 'intercept' && card.catalog.color === target?.catalog.color
+      )
+    ).forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+  },
+};

--- a/src/game-data/effects/cards/2-0-135.ts
+++ b/src/game-data/effects/cards/2-0-135.ts
@@ -11,7 +11,17 @@ export const effects: CardEffects = {
     }
 
     // 自分のユニットがフィールドに出た時のみ発動
-    return stack.target.owner.id === stack.processing.owner.id;
+    if (stack.target.owner.id !== stack.processing.owner.id) return false;
+
+    // 【神獣】ユニットがフィールドに出た時は、存在チェックを行う
+    if (
+      stack.target.catalog.species?.includes('神獣') &&
+      !stack.target.owner.field.some(unit => unit.id === stack.target?.id)
+    ) {
+      return false;
+    }
+
+    return true;
   },
 
   // トリガー効果

--- a/src/game-data/effects/cards/2-0-204.ts
+++ b/src/game-data/effects/cards/2-0-204.ts
@@ -41,7 +41,7 @@ export const effects: CardEffects = {
       // ランダムで2枚選んで破壊
       const destroyTargets = EffectHelper.random(triggers, 2);
       for (const card of destroyTargets) {
-        Effect.move(stack, stack.processing, card, 'trash');
+        Effect.break(stack, stack.processing, card);
       }
 
       // このユニットを手札に戻す

--- a/src/game-data/effects/cards/2-0-220.ts
+++ b/src/game-data/effects/cards/2-0-220.ts
@@ -1,0 +1,20 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    if (
+      (stack.processing.owner.purple ?? 0) < 4 ||
+      stack.processing.owner.field.length + stack.processing.owner.opponent.field.length === 1
+    )
+      return;
+    await System.show(stack, 'せんじん再臨', '自身以外のユニットを破壊\n紫ゲージ-4');
+    EffectHelper.exceptSelf(stack.core, stack.processing, unit =>
+      Effect.break(stack, stack.processing, unit)
+    );
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -4);
+  },
+};

--- a/src/game-data/effects/cards/2-0-220.ts
+++ b/src/game-data/effects/cards/2-0-220.ts
@@ -8,7 +8,7 @@ export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
     if (
       (stack.processing.owner.purple ?? 0) < 4 ||
-      stack.processing.owner.field.length + stack.processing.owner.opponent.field.length === 1
+      stack.processing.owner.field.length + stack.processing.owner.opponent.field.length <= 1
     )
       return;
     await System.show(stack, 'せんじん再臨', '自身以外のユニットを破壊\n紫ゲージ-4');

--- a/src/game-data/effects/cards/2-0-302.ts
+++ b/src/game-data/effects/cards/2-0-302.ts
@@ -1,0 +1,23 @@
+import { Unit } from '@/package/core/class/card';
+import { System } from '../engine/system';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  onPlayerAttackSelf: async (stack: StackWithCard) => {
+    const targets = stack.processing.owner.opponent.field.filter(unit =>
+      unit.hasKeyword('防御禁止')
+    );
+    if (targets.length > 0) {
+      await System.show(stack, 'ご褒美よ！', '【防御禁止】に5000ダメージ');
+    }
+  },
+  onPlayerAttack: async (stack: StackWithCard) => {
+    if (
+      stack.source instanceof Unit &&
+      stack.source.owner.id !== stack.processing.owner.id &&
+      stack.source.owner.field.some(unit => unit.id === stack.source.id)
+    ) {
+      await System.show(stack, 'まってなさい！', '【防御禁止】を付与');
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-0-302.ts
+++ b/src/game-data/effects/cards/2-0-302.ts
@@ -1,6 +1,8 @@
 import { Unit } from '@/package/core/class/card';
 import { System } from '../engine/system';
 import type { CardEffects, StackWithCard } from '../schema/types';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { Effect } from '@/game-data/effects/engine/effect';
 
 export const effects: CardEffects = {
   onPlayerAttackSelf: async (stack: StackWithCard) => {
@@ -9,15 +11,24 @@ export const effects: CardEffects = {
     );
     if (targets.length > 0) {
       await System.show(stack, 'ご褒美よ！', '【防御禁止】に5000ダメージ');
+      targets.forEach(unit => Effect.damage(stack, stack.processing, unit, 5000));
     }
   },
   onPlayerAttack: async (stack: StackWithCard) => {
     if (
       stack.source instanceof Unit &&
       stack.source.owner.id !== stack.processing.owner.id &&
-      stack.source.owner.field.some(unit => unit.id === stack.source.id)
+      stack.source.owner.field.some(unit => unit.id === stack.source.id) &&
+      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
     ) {
       await System.show(stack, 'まってなさい！', '【防御禁止】を付与');
+      const [target] = await EffectHelper.pickUnit(
+        stack,
+        stack.processing.owner,
+        'opponents',
+        '【防御禁止】を与えるユニットを選択'
+      );
+      Effect.keyword(stack, stack.processing, target, '防御禁止');
     }
   },
 };

--- a/src/game-data/effects/cards/2-0-306.ts
+++ b/src/game-data/effects/cards/2-0-306.ts
@@ -34,10 +34,10 @@ export const effects: CardEffects = {
       );
 
       EffectHelper.random(stack.processing.owner.trigger, 1).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
       EffectHelper.random(stack.processing.owner.opponent.trigger, 1).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
 
       if (opponentsSelectable) {

--- a/src/game-data/effects/cards/2-0-310.ts
+++ b/src/game-data/effects/cards/2-0-310.ts
@@ -67,7 +67,13 @@ export const effects: CardEffects = {
   // アタック時の効果
   onAttackSelf: spiritAttackEffect,
   onAttack: async (stack: StackWithCard<Unit>) => {
-    if (stack.target instanceof Unit && stack.target.id === stack.processing.id) return;
-    await spiritAttackEffect(stack);
+    if (stack.target instanceof Unit) {
+      if (
+        stack.target.id === stack.processing.id ||
+        stack.target.owner.id === stack.processing.owner.opponent.id
+      )
+        return;
+      await spiritAttackEffect(stack);
+    }
   },
 };

--- a/src/game-data/effects/cards/2-0-311.ts
+++ b/src/game-data/effects/cards/2-0-311.ts
@@ -45,7 +45,7 @@ export const effects: CardEffects = {
 
     await System.show(stack, '食欲旺盛', '捨札から3枚消滅');
     EffectHelper.random(opponent.trash, 3).forEach(card => {
-      Effect.move(stack, stack.processing, card, 'delete');
+      Effect.delete(stack, stack.processing, card);
     });
   },
 };

--- a/src/game-data/effects/cards/2-0-311.ts
+++ b/src/game-data/effects/cards/2-0-311.ts
@@ -38,9 +38,10 @@ export const effects: CardEffects = {
     Effect.activate(stack, stack.processing, target, false);
   },
 
-  // ターン終了時に相手の捨札から3枚をランダムで消滅
+  // 自分のターン終了時に相手の捨札から3枚をランダムで消滅
   onTurnEnd: async (stack: StackWithCard<Unit>) => {
     const opponent = stack.processing.owner.opponent;
+    if (stack.source.id === opponent.id) return;
     if (opponent.trash.length === 0) return;
 
     await System.show(stack, '食欲旺盛', '捨札から3枚消滅');

--- a/src/game-data/effects/cards/2-0-313.ts
+++ b/src/game-data/effects/cards/2-0-313.ts
@@ -1,10 +1,14 @@
-import type { Unit } from '@/package/core/class/card';
+import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
   // 自身が召喚された時に発動する効果を記述
   onDriveSelf: async (stack: StackWithCard): Promise<void> => {
+    if (!EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)) {
+      return;
+    }
+
     await System.show(stack, '黙滅の烏羽', '【沈黙】を与える');
     const filter = (unit: Unit) => unit.owner.id !== stack.processing.owner.id;
     const [target] = await EffectHelper.pickUnit(
@@ -17,6 +21,11 @@ export const effects: CardEffects = {
   },
 
   onBreakSelf: async (stack: StackWithCard): Promise<void> => {
+    const targets = stack.processing.owner.trash.filter(
+      card => card instanceof Unit && card.catalog.species?.includes('盗賊')
+    );
+    if (targets.length === 0) return;
+
     await System.show(stack, '蒼き渡り鴉', '捨札から【盗賊】を1枚回収');
     EffectHelper.random(
       stack.processing.owner.trash.filter(card => card.catalog.species?.includes('盗賊')),

--- a/src/game-data/effects/cards/2-0-324.ts
+++ b/src/game-data/effects/cards/2-0-324.ts
@@ -10,6 +10,7 @@ export const effects: CardEffects = {
     );
 
     if (candidate.length > 0 && stack.processing.owner.field.length <= 4) {
+      await System.show(stack, '私の救世主さま', 'コスト7以下を【特殊召喚】');
       const [target] = await EffectHelper.selectCard<Unit>(
         stack,
         stack.processing.owner,
@@ -34,7 +35,7 @@ export const effects: CardEffects = {
       target instanceof Unit &&
       stack.processing.owner.field.length <= 4
     ) {
-      await System.show(stack, '私の救世主さま', 'コスト3以下を【特殊召喚】');
+      await System.show(stack, '星は巡る', 'コスト3以下を【特殊召喚】');
       await Effect.summon(stack, stack.processing, target);
     }
   },

--- a/src/game-data/effects/cards/2-0-333.ts
+++ b/src/game-data/effects/cards/2-0-333.ts
@@ -69,9 +69,6 @@ export const effects: CardEffects = {
   onIntercept: async (stack: StackWithCard<Unit>): Promise<void> => {
     const owner = stack.processing.owner;
 
-    // 自分のインターセプトカードが発動した場合のみ処理
-    if (stack.source.id !== owner.id) return;
-
     // ユニットを選べるか確認
     if (!EffectHelper.isUnitSelectable(stack.core, 'all', owner)) return;
 

--- a/src/game-data/effects/cards/2-0-338.ts
+++ b/src/game-data/effects/cards/2-0-338.ts
@@ -6,29 +6,31 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // トリガー: あなたがプレイヤーアタックを受けた時
   checkPlayerAttack: (stack: StackWithCard<Card>): boolean => {
-    return stack.target?.id === stack.processing.owner.id;
+    return (
+      stack.target?.id === stack.processing.owner.id &&
+      stack.processing.owner.hand.length > 0 &&
+      stack.processing.owner.opponent.field.length > 0
+    );
   },
 
   onPlayerAttack: async (stack: StackWithCard<Card>): Promise<void> => {
-    if (stack.processing.owner.hand.length > 0) {
-      // ランダムに手札を1枚捨てる
-      const cards = EffectHelper.random(stack.processing.owner.hand, 1);
-      const card = cards[0];
-      if (card) {
-        Effect.break(stack, stack.processing, card);
+    // ランダムに手札を1枚捨てる
+    const cards = EffectHelper.random(stack.processing.owner.hand, 1);
+    const card = cards[0];
+    if (card) {
+      await System.show(
+        stack,
+        'パラライズ・フォグ',
+        '全てのユニットの行動権を消費\n【呪縛】を付与'
+      );
 
-        await System.show(
-          stack,
-          'パラライズ・フォグ',
-          '全てのユニットの行動権を消費\n【呪縛】を付与'
-        );
+      Effect.break(stack, stack.processing, card);
 
-        // 全てのユニットの行動権を消費し、呪縛を与える
-        const allUnits = stack.core.players.flatMap(p => p.field);
-        for (const unit of allUnits) {
-          Effect.activate(stack, stack.processing, unit, false);
-          Effect.keyword(stack, stack.processing, unit, '呪縛');
-        }
+      // 全てのユニットの行動権を消費し、呪縛を与える
+      const allUnits = stack.core.players.flatMap(p => p.field);
+      for (const unit of allUnits) {
+        Effect.activate(stack, stack.processing, unit, false);
+        Effect.keyword(stack, stack.processing, unit, '呪縛');
       }
     }
   },

--- a/src/game-data/effects/cards/2-0-338.ts
+++ b/src/game-data/effects/cards/2-0-338.ts
@@ -6,10 +6,13 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // トリガー: あなたがプレイヤーアタックを受けた時
   checkPlayerAttack: (stack: StackWithCard<Card>): boolean => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+
     return (
       stack.target?.id === stack.processing.owner.id &&
-      stack.processing.owner.hand.length > 0 &&
-      stack.processing.owner.opponent.field.length > 0
+      owner.hand.length > 0 &&
+      owner.field.length + opponent.field.length > 0
     );
   },
 

--- a/src/game-data/effects/cards/2-0-343.ts
+++ b/src/game-data/effects/cards/2-0-343.ts
@@ -7,9 +7,14 @@ import { System } from '../engine/system';
 export const effects: CardEffects = {
   // インターセプト: 対戦相手のターン終了時、あなたのフィールドのユニットが4体以下の場合
   checkTurnEnd: (stack: StackWithCard<Card>): boolean => {
+    const filter = (unit: Unit) =>
+      unit.owner.id === stack.processing.owner.id &&
+      (unit.catalog.species?.includes('武身') ?? false);
+
     return (
       stack.source.id === stack.processing.owner.opponent.id &&
-      stack.processing.owner.field.length <= 4
+      stack.processing.owner.field.length <= 4 &&
+      EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)
     );
   },
 
@@ -18,40 +23,38 @@ export const effects: CardEffects = {
       unit.owner.id === stack.processing.owner.id &&
       (unit.catalog.species?.includes('武身') ?? false);
 
-    if (EffectHelper.isUnitSelectable(stack.core, filter, stack.processing.owner)) {
-      await System.show(
-        stack,
-        '鍛冶神の業物',
-        '【武身】をデッキに戻す\nコスト[戻したユニットのコスト+1]のユニットを【特殊召喚】'
-      );
+    await System.show(
+      stack,
+      '鍛冶神の業物',
+      '【武身】をデッキに戻す\nコスト[戻したユニットのコスト+1]のユニットを【特殊召喚】'
+    );
 
-      // 武身ユニットを選択
-      const [target] = await EffectHelper.pickUnit(
-        stack,
-        stack.processing.owner,
-        filter,
-        'デッキに戻すユニットを選択'
-      );
+    // 武身ユニットを選択
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      filter,
+      'デッキに戻すユニットを選択'
+    );
 
-      const targetCost = target.catalog.cost;
+    const targetCost = target.catalog.cost;
 
-      // デッキに戻す
-      Effect.bounce(stack, stack.processing, target, 'deck');
+    // デッキに戻す
+    Effect.bounce(stack, stack.processing, target, 'deck');
 
-      // コスト+1の武身ユニットをデッキから探す
-      const upperBushi = stack.processing.owner.deck.filter(
-        card =>
-          card instanceof Unit &&
-          card.catalog.species?.includes('武身') &&
-          card.catalog.cost === targetCost + 1 &&
-          !card.catalog.isEvolution
-      );
+    // コスト+1の武身ユニットをデッキから探す
+    const upperBushi = stack.processing.owner.deck.filter(
+      card =>
+        card instanceof Unit &&
+        card.catalog.species?.includes('武身') &&
+        card.catalog.cost === targetCost + 1 &&
+        !card.catalog.isEvolution
+    );
 
-      if (upperBushi.length > 0) {
-        const [summonTarget] = EffectHelper.random(upperBushi);
-        if (summonTarget instanceof Unit) {
-          await Effect.summon(stack, stack.processing, summonTarget);
-        }
+    if (upperBushi.length > 0) {
+      const [summonTarget] = EffectHelper.random(upperBushi);
+      if (summonTarget instanceof Unit) {
+        await Effect.summon(stack, stack.processing, summonTarget);
       }
     }
   },

--- a/src/game-data/effects/cards/2-0-360.ts
+++ b/src/game-data/effects/cards/2-0-360.ts
@@ -5,8 +5,16 @@ import type { CardEffects, StackWithCard } from '../schema/types';
 export const effects: CardEffects = {
   // ■不可侵光壁
   // あなたのユニットが戦闘した時
-  checkBattle: (_stack: StackWithCard) => {
-    return true;
+  checkBattle: (stack: StackWithCard) => {
+    const owner = stack.processing.owner;
+    const opponent = owner.opponent;
+    const fields = [...owner.field, ...opponent.field];
+
+    // 戦闘中のユニットがフィールドにまだいる場合のみ発動
+    return (
+      fields.some(unit => unit.id === stack.source?.id) &&
+      fields.some(unit => unit.id === stack.target?.id)
+    );
   },
 
   onBattle: async (stack: StackWithCard): Promise<void> => {

--- a/src/game-data/effects/cards/2-1-004.ts
+++ b/src/game-data/effects/cards/2-1-004.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to red units in hand

--- a/src/game-data/effects/cards/2-1-007.ts
+++ b/src/game-data/effects/cards/2-1-007.ts
@@ -11,7 +11,7 @@ export const effects = {
         stack.processing.owner.hand,
         '消滅させるカードを選択して下さい'
       );
-      Effect.move(stack, stack.processing, target, 'delete');
+      Effect.delete(stack, stack.processing, target);
       EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] });
     }
   },

--- a/src/game-data/effects/cards/2-1-009.ts
+++ b/src/game-data/effects/cards/2-1-009.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to yellow units in hand

--- a/src/game-data/effects/cards/2-1-014.ts
+++ b/src/game-data/effects/cards/2-1-014.ts
@@ -15,7 +15,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to blue units in hand

--- a/src/game-data/effects/cards/2-1-015.ts
+++ b/src/game-data/effects/cards/2-1-015.ts
@@ -22,7 +22,7 @@ export const effects: CardEffects = {
       const cardsToDiscard = owner.deck.slice(0, discardCount);
 
       for (const card of cardsToDiscard) {
-        Effect.move(stack, stack.processing, card, 'trash');
+        Effect.break(stack, stack.processing, card);
       }
 
       for (const unit of unitsToDestroy) {

--- a/src/game-data/effects/cards/2-1-019.ts
+++ b/src/game-data/effects/cards/2-1-019.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to green units in hand

--- a/src/game-data/effects/cards/2-1-025.ts
+++ b/src/game-data/effects/cards/2-1-025.ts
@@ -14,7 +14,10 @@ export const effects: CardEffects = {
 
     // Check if no units have been summoned this turn by checking histories
     const hasNotSummonedUnits = !stack.core.histories.some(
-      history => history.action === 'drive' && history.card.owner.id === owner.id
+      history =>
+        history.action === 'drive' &&
+        history.card.owner.id === owner.id &&
+        history.card instanceof Unit
     );
 
     // Apply or remove cost reduction to purple units in hand

--- a/src/game-data/effects/cards/2-1-056.ts
+++ b/src/game-data/effects/cards/2-1-056.ts
@@ -1,0 +1,41 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBattle: (stack: StackWithCard) =>
+    [stack.source, stack.target].some(object =>
+      stack.processing.owner.field.some(unit => unit.id === object?.id)
+    ),
+  onBattle: async (stack: StackWithCard) => {
+    await System.show(
+      stack,
+      'オーバードーズ',
+      'ターン終了時までBP+[紫ゲージ×4000]\n基本BP-[紫ゲージ×2000]'
+    );
+
+    // 戦闘中の自ユニットを特定
+    const ownUnit = [stack.source, stack.target].find(
+      (object): object is Unit =>
+        object instanceof Unit && object.owner.id === stack.processing.owner.id
+    );
+
+    if (ownUnit) {
+      Effect.modifyBP(
+        stack,
+        stack.processing,
+        ownUnit,
+        (stack.processing.owner.purple ?? 0) * 4000,
+        { event: 'turnEnd', count: 1 }
+      );
+      Effect.modifyBP(
+        stack,
+        stack.processing,
+        ownUnit,
+        (stack.processing.owner.purple ?? 0) * -2000,
+        { isBaseBP: true }
+      );
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-1-108.ts
+++ b/src/game-data/effects/cards/2-1-108.ts
@@ -1,7 +1,7 @@
-import { Unit } from '@/package/core/class/card';
+import { Trigger, Unit } from '@/package/core/class/card';
 import { Effect, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard) => {
@@ -9,22 +9,13 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard) => {
-    stack.processing.owner.opponent.trigger
-      .filter(
-        card =>
-          card.catalog.type === 'trigger' &&
-          !card.delta.find(delta => delta.source?.unit === stack.processing.id)
-      )
-      .forEach(card =>
-        card.delta.push(
-          new Delta(
-            { type: 'banned' },
-            {
-              source: { unit: stack.processing.id },
-            }
-          )
-        )
-      );
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Trigger) Effect.ban(stack, stack.processing, target, { source });
+      },
+      targets: ['opponents', 'trigger'],
+      effectCode: '王頂よりの威光',
+    });
   },
 
   onBlockSelf: async (stack: StackWithCard<Unit>) => {

--- a/src/game-data/effects/cards/2-1-109.ts
+++ b/src/game-data/effects/cards/2-1-109.ts
@@ -29,7 +29,7 @@ export const effects: CardEffects = {
       // 手札を1枚ランダムで消滅
       const [handCard] = EffectHelper.random(owner.hand, 1);
       if (handCard) {
-        Effect.move(stack, self, handCard, 'delete');
+        Effect.delete(stack, self, handCard);
       }
 
       // フィールドのユニットを1体ランダムで手札に戻す

--- a/src/game-data/effects/cards/2-1-114.ts
+++ b/src/game-data/effects/cards/2-1-114.ts
@@ -27,7 +27,7 @@ export const effects: CardEffects = {
 
         if (cardToMove) {
           // 捨札に送る
-          Effect.move(stack, stack.processing, cardToMove, 'trash');
+          Effect.break(stack, stack.processing, cardToMove);
         }
       }
     }

--- a/src/game-data/effects/cards/2-1-114.ts
+++ b/src/game-data/effects/cards/2-1-114.ts
@@ -27,7 +27,7 @@ export const effects: CardEffects = {
 
         if (cardToMove) {
           // 捨札に送る
-          Effect.break(stack, stack.processing, cardToMove);
+          Effect.move(stack, stack.processing, cardToMove, 'trash');
         }
       }
     }

--- a/src/game-data/effects/cards/2-2-018.ts
+++ b/src/game-data/effects/cards/2-2-018.ts
@@ -43,7 +43,7 @@ export const effects: CardEffects = {
     ) {
       await System.show(stack, '闇を蝕む混沌', '捨札に5枚送る');
       EffectHelper.random(stack.processing.owner.deck, 5).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
     }
   },

--- a/src/game-data/effects/cards/2-2-024.ts
+++ b/src/game-data/effects/cards/2-2-024.ts
@@ -42,37 +42,36 @@ export const effects: CardEffects = {
     const opponent = stack.processing.owner.opponent;
     const opponentUnits = opponent.field;
 
-    // 対戦相手のユニットがいるかチェック
-    const message: string[] = [];
+    await EffectHelper.combine(stack, [
+      {
+        title: 'ウィーゼル・ディソーダー',
+        description: '敵全体の基本BP-1000',
+        effect: () =>
+          opponentUnits.forEach(unit => {
+            Effect.modifyBP(stack, stack.processing, unit, -1000, { isBaseBP: true });
+          }),
+        condition: opponentUnits.length > 0,
+      },
+      {
+        title: 'ウィーゼル・ディソーダー',
+        description: 'コスト3ユニットを【特殊召喚】',
+        effect: async () => {
+          const summonTargets = stack.processing.owner.deck.filter(
+            card => card instanceof Unit && !(card instanceof Evolve) && card.catalog.cost === 3
+          );
 
-    if (opponentUnits.length > 0) message.push('敵全体の基本BP-1000');
-    if (stack.processing.owner.field.length <= 4) message.push('コスト3ユニットを【特殊召喚】');
+          if (summonTargets.length > 0) {
+            // ランダムで1体選択
+            const [target] = EffectHelper.random(summonTargets);
 
-    if (message.length === 0) return;
-
-    await System.show(stack, 'ウィーゼル・ディソーダー', message.join('\n'));
-
-    // 対戦相手の全てのユニットの基本BPを-1000する
-    opponentUnits.forEach(unit => {
-      Effect.modifyBP(stack, stack.processing, unit, -1000, { isBaseBP: true });
-    });
-
-    // あなたのフィールドのユニットが4体以下の場合、特殊召喚
-    if (stack.processing.owner.field.length <= 4) {
-      // デッキから進化ユニット以外のコスト3のユニットをフィルタリング
-      const summonTargets = stack.processing.owner.deck.filter(
-        card => card instanceof Unit && !(card instanceof Evolve) && card.catalog.cost === 3
-      );
-
-      if (summonTargets.length > 0) {
-        // ランダムで1体選択
-        const [target] = EffectHelper.random(summonTargets);
-
-        if (target instanceof Unit) {
-          // 特殊召喚
-          await Effect.summon(stack, stack.processing, target);
-        }
-      }
-    }
+            if (target instanceof Unit) {
+              // 特殊召喚
+              await Effect.summon(stack, stack.processing, target);
+            }
+          }
+        },
+        condition: stack.processing.owner.field.length <= 4,
+      },
+    ]);
   },
 };

--- a/src/game-data/effects/cards/2-2-031.ts
+++ b/src/game-data/effects/cards/2-2-031.ts
@@ -25,7 +25,7 @@ export const effects: CardEffects = {
     const filter = (unit: Unit) =>
       unit.owner.id === stack.processing.owner.id && unit.catalog.cost >= 3;
     EffectHelper.random(stack.processing.owner.trigger, 1).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
     const [target] = await EffectHelper.pickUnit(
       stack,

--- a/src/game-data/effects/cards/2-2-034.ts
+++ b/src/game-data/effects/cards/2-2-034.ts
@@ -6,9 +6,8 @@ export const effects: CardEffects = {
   checkDrive: (stack: StackWithCard): boolean => {
     return (
       stack.processing.owner.id === stack.source.id &&
-      Array.from(
-        new Set(stack.core.players.flatMap(player => player.field).map(card => card.catalog.color))
-      ).length === 5
+      new Set(stack.core.players.flatMap(player => player.field).map(card => card.catalog.color))
+        .size === 5
     );
   },
 

--- a/src/game-data/effects/cards/2-2-035.ts
+++ b/src/game-data/effects/cards/2-2-035.ts
@@ -7,7 +7,7 @@ export const effects: CardEffects = {
     const owner = stack.processing.owner;
     return (
       owner.id === stack.source.id &&
-      Array.from(new Set(owner.field.map(card => card.catalog.color))).length >= 3 &&
+      new Set(owner.field.map(card => card.catalog.color)).size >= 3 &&
       owner.hand.length >= 2 &&
       owner.deck.length >= 2
     );

--- a/src/game-data/effects/cards/2-2-046.ts
+++ b/src/game-data/effects/cards/2-2-046.ts
@@ -1,0 +1,28 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    (stack.processing.owner.field.length <= 4 &&
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.id &&
+      stack.target.catalog.species?.includes('武身') &&
+      stack.processing.owner.deck.some(
+        card =>
+          card instanceof Unit && card.catalog.cost <= 5 && card.catalog.species?.includes('武身')
+      )) ||
+    false,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, '結集セシ化身タチ', 'デッキから【武身】を【特殊召喚】');
+    const [target] = EffectHelper.random(
+      stack.processing.owner.deck.filter(
+        card =>
+          card instanceof Unit && card.catalog.species?.includes('武身') && card.catalog.cost <= 5
+      )
+    );
+    if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
+  },
+};

--- a/src/game-data/effects/cards/2-2-102.ts
+++ b/src/game-data/effects/cards/2-2-102.ts
@@ -43,12 +43,12 @@ export const effects: CardEffects = {
 
     //自分のトリガーゾーンからランダムで1枚破壊
     EffectHelper.random(owner.trigger, 1).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
 
     //相手のトリガーゾーンからランダムで1枚破壊
     EffectHelper.random(opponent.trigger, 1).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
   },
 };

--- a/src/game-data/effects/cards/2-2-105.ts
+++ b/src/game-data/effects/cards/2-2-105.ts
@@ -1,6 +1,6 @@
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Unit } from '@/package/core/class/card';
+import { Intercept, Trigger, Unit } from '@/package/core/class/card';
 import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
@@ -11,12 +11,12 @@ export const effects: CardEffects = {
     const handCards = owner.hand;
     const fieldUnits = owner.field;
 
-    await System.show(stack, '推理とは爆発だァ！', '手札とフィールドのユニットのレベル+1');
+    await System.show(stack, '推理とは爆発だァ！', '手札のカードとフィールドのユニットのレベル+1');
 
     // 手札のカードのレベルを+1する
     for (const card of handCards) {
-      if (card instanceof Unit) {
-        card.lv = Math.min(card.lv + 1, 3);
+      if (card instanceof Unit || card instanceof Intercept || card instanceof Trigger) {
+        Effect.clock(stack, stack.processing, card, 1);
       }
     }
 

--- a/src/game-data/effects/cards/2-2-108.ts
+++ b/src/game-data/effects/cards/2-2-108.ts
@@ -36,7 +36,7 @@ export const effects: CardEffects = {
         cards
           .filter(card => card !== selected)
           .forEach(card => {
-            Effect.move(stack, self, card, 'delete');
+            Effect.delete(stack, self, card);
           });
       }
     }

--- a/src/game-data/effects/cards/2-2-124.ts
+++ b/src/game-data/effects/cards/2-2-124.ts
@@ -38,7 +38,7 @@ export const effects: CardEffects = {
           stack.processing.owner.hand,
           '消滅させるカードを選択して下さい'
         );
-        Effect.move(stack, stack.processing, sacrifice, 'delete');
+        Effect.delete(stack, stack.processing, sacrifice);
         EffectHelper.random(
           stack.processing.owner.trash.filter(card => card.catalog.type === 'trigger'),
           2

--- a/src/game-data/effects/cards/2-2-150.ts
+++ b/src/game-data/effects/cards/2-2-150.ts
@@ -1,0 +1,37 @@
+import { Effect, EffectHelper, System } from '@/game-data/effects';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnEnd: (stack: StackWithCard) => stack.source.id === stack.processing.owner.id,
+  onTurnEnd: async (stack: StackWithCard) => {
+    const choice = await EffectHelper.choice(
+      stack,
+      stack.processing.owner,
+      '選略・ウロボロスの刻印',
+      [
+        { id: '1', description: '紫ゲージ+2' },
+        {
+          id: '2',
+          description: '捨札から2枚回収\n紫ゲージ-1',
+          condition: (stack.processing.owner.purple ?? 0) >= 1,
+        },
+      ]
+    );
+
+    switch (choice) {
+      case '1': {
+        await System.show(stack, '選略・ウロボロスの刻印', '紫ゲージ+2');
+        await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 2);
+        break;
+      }
+      case '2': {
+        await System.show(stack, '選略・ウロボロスの刻印', '捨札から2枚回収\n紫ゲージ-1');
+        EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
+          Effect.move(stack, stack.processing, card, 'hand')
+        );
+        await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
+        break;
+      }
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-2-150.ts
+++ b/src/game-data/effects/cards/2-2-150.ts
@@ -26,9 +26,9 @@ export const effects: CardEffects = {
       }
       case '2': {
         await System.show(stack, '選略・ウロボロスの刻印', '捨札から2枚回収\n紫ゲージ-1');
-        EffectHelper.random(stack.processing.owner.trash, 2).forEach(card =>
-          Effect.move(stack, stack.processing, card, 'hand')
-        );
+        EffectHelper.random(stack.processing.owner.trash, 2).forEach(card => {
+          Effect.move(stack, stack.processing, card, 'hand');
+        });
         await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
         break;
       }

--- a/src/game-data/effects/cards/2-2-150.ts
+++ b/src/game-data/effects/cards/2-2-150.ts
@@ -13,7 +13,8 @@ export const effects: CardEffects = {
         {
           id: '2',
           description: '捨札から2枚回収\n紫ゲージ-1',
-          condition: (stack.processing.owner.purple ?? 0) >= 1,
+          condition:
+            (stack.processing.owner.purple ?? 0) >= 1 && stack.processing.owner.trash.length >= 2,
         },
       ]
     );

--- a/src/game-data/effects/cards/2-3-004.ts
+++ b/src/game-data/effects/cards/2-3-004.ts
@@ -1,8 +1,8 @@
 import { Card, Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
 import { Core } from '@/package/core';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 
 export const effects: CardEffects = {
   // ■起動・アウトレイジ
@@ -31,39 +31,16 @@ export const effects: CardEffects = {
   // ■忍び寄る羽音
   // 手札のこのカードのコストは-［あなたのフィールドの【昆虫】ユニット×1］される。このユニットのコストは4以下にならない。
   handEffect: (_core: Core, self: Card): void => {
-    if (self instanceof Unit) {
-      // プレイヤーのフィールド上の昆虫ユニット数を数える
-      const insectCount = self.owner.field.filter(unit =>
-        unit.catalog.species?.includes('昆虫')
-      ).length;
-
-      // コスト減少量（昆虫の数だけ減少）
-      const costReduction = -Math.min(insectCount, self.catalog.cost - 4); // 最小コストは4
-
-      // 既存のコスト変更Deltaを探す
-      const existingDelta = self.delta.find(
-        d => d.effect.type === 'cost' && d.source?.effectCode === '忍び寄る羽音'
-      );
-
-      if (existingDelta && existingDelta.effect.type === 'cost') {
-        // 既存のDeltaを更新
-        // costタイプのdeltaは'value'を使用
-        existingDelta.effect.value = costReduction;
-      } else if (costReduction < 0) {
-        // 新しいDeltaを追加（コスト減少がある場合のみ）
-        self.delta.push(
-          new Delta(
-            { type: 'cost', value: costReduction },
-            {
-              source: {
-                unit: self.id,
-                effectCode: '忍び寄る羽音',
-              },
-            }
-          )
-        );
-      }
-    }
+    PermanentEffect.mount(self, {
+      effect: (target, source) =>
+        Effect.dynamicCost(target, {
+          source,
+          calculator: self =>
+            -self.owner.field.filter(unit => unit.catalog.species?.includes('昆虫')).length,
+        }),
+      effectCode: '忍び寄る羽音',
+      targets: ['self'],
+    });
   },
 
   // ■鍬獄のカンニバル

--- a/src/game-data/effects/cards/2-3-007.ts
+++ b/src/game-data/effects/cards/2-3-007.ts
@@ -20,7 +20,7 @@ export const effects: CardEffects = {
     const [target] = EffectHelper.random(candidates);
     if (target instanceof Unit) {
       // ← ここで念のため型確認
-      Effect.move(stack, stack.processing, target, 'delete');
+      Effect.delete(stack, stack.processing, target);
     }
   },
 

--- a/src/game-data/effects/cards/2-3-009.ts
+++ b/src/game-data/effects/cards/2-3-009.ts
@@ -66,7 +66,7 @@ export const effects: CardEffects = {
       if (targets.length > 0) {
         await System.show(stack, '次元的アルゴリズム', 'デッキからランダムで3枚消滅');
         for (const card of targets) {
-          Effect.move(stack, stack.processing, card, 'delete');
+          Effect.delete(stack, stack.processing, card);
         }
       }
     }

--- a/src/game-data/effects/cards/2-3-010.ts
+++ b/src/game-data/effects/cards/2-3-010.ts
@@ -34,7 +34,7 @@ export const effects: CardEffects = {
       '【加護】\n【沈黙効果耐性】\nお互いのフィールドと捨札の【ドラゴン】以外を消滅'
     );
     targetUnits.forEach(unit => Effect.delete(stack, stack.processing, unit));
-    targetCards.forEach(card => Effect.move(stack, stack.processing, card, 'delete'));
+    targetCards.forEach(card => Effect.delete(stack, stack.processing, card));
     Effect.keyword(stack, stack.processing, stack.processing, '加護');
     Effect.keyword(stack, stack.processing, stack.processing, '沈黙効果耐性');
   },

--- a/src/game-data/effects/cards/2-3-014.ts
+++ b/src/game-data/effects/cards/2-3-014.ts
@@ -54,7 +54,7 @@ export const effects: CardEffects = {
       );
 
       // Move it to trash
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
     }
   },
 

--- a/src/game-data/effects/cards/2-3-015.ts
+++ b/src/game-data/effects/cards/2-3-015.ts
@@ -57,7 +57,7 @@ export const effects: CardEffects = {
     });
 
     EffectHelper.random(stack.processing.owner.trash, 3).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'delete')
+      Effect.delete(stack, stack.processing, card)
     );
   },
 };

--- a/src/game-data/effects/cards/2-3-021.ts
+++ b/src/game-data/effects/cards/2-3-021.ts
@@ -23,7 +23,7 @@ export const effects: CardEffects = {
     const [target] = EffectHelper.random(stack.processing.owner.opponent.trigger);
     if (stack.option?.type === 'lv' && stack.option.value >= 2 && target) {
       await System.show(stack, 'ネオンアロー', 'トリガーゾーンを1枚破壊');
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
     }
   },
 };

--- a/src/game-data/effects/cards/2-3-032.ts
+++ b/src/game-data/effects/cards/2-3-032.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@/package/core/class/card';
 import { Delta } from '@/package/core/class/delta';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
@@ -39,7 +40,11 @@ export const effects: CardEffects = {
 
   checkDrive: (stack: StackWithCard) => {
     return (
+      stack.target instanceof Unit &&
       stack.source.id === stack.processing.owner.id &&
+      (stack.target.catalog.name === '織女星ベガ' ||
+        stack.target.catalog.name === '牽牛星アルタイル' ||
+        stack.target.catalog.name === '天川星デネブ') &&
       stack.processing.owner.hand.filter(
         unit =>
           unit.catalog.name === '織女星ベガ' ||

--- a/src/game-data/effects/cards/2-3-042.ts
+++ b/src/game-data/effects/cards/2-3-042.ts
@@ -26,7 +26,7 @@ export const effects: CardEffects = {
 
       // デッキのカードを捨札へ
       deckCards.forEach(card => {
-        Effect.move(stack, stack.processing, card, 'trash');
+        Effect.break(stack, stack.processing, card);
       });
 
       // デッキをシャッフル

--- a/src/game-data/effects/cards/2-3-104.ts
+++ b/src/game-data/effects/cards/2-3-104.ts
@@ -1,0 +1,35 @@
+import { Effect } from '../engine/effect';
+import { EffectHelper } from '../engine/helper';
+import { System } from '../engine/system';
+import { EffectTemplate } from '../engine/templates';
+import type { CardEffects, StackWithCard } from '../schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    if (
+      EffectHelper.isVirusInjectable(stack.processing.owner) &&
+      EffectHelper.isVirusInjectable(stack.processing.owner.opponent)
+    ) {
+      await System.show(
+        stack,
+        'Ｗフォース＜ウィルス・炎＞',
+        'お互いのフィールドに＜ウィルス・炎＞を【特殊召喚】'
+      );
+      for (const player of [stack.processing.owner, stack.processing.owner.opponent]) {
+        await EffectTemplate.virusInject(stack, player, 'ウィルス・炎');
+      }
+    }
+  },
+  onDamage: async (stack: StackWithCard) => {
+    if (
+      stack.core.getTurnPlayer().id !== stack.processing.owner.id &&
+      stack.option?.type === 'damage' &&
+      stack.option.cause === 'effect'
+    ) {
+      await System.show(stack, 'アヴェスタ―の残焔', '敵全体に2000ダメージ');
+      stack.processing.owner.opponent.field.forEach(unit =>
+        Effect.damage(stack, stack.processing, unit, 2000)
+      );
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-3-104.ts
+++ b/src/game-data/effects/cards/2-3-104.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@/package/core/class/card';
 import { Effect } from '../engine/effect';
 import { EffectHelper } from '../engine/helper';
 import { System } from '../engine/system';
@@ -23,6 +24,8 @@ export const effects: CardEffects = {
   onDamage: async (stack: StackWithCard) => {
     if (
       stack.core.getTurnPlayer().id !== stack.processing.owner.id &&
+      stack.target instanceof Unit &&
+      stack.target.owner.id === stack.processing.owner.id &&
       stack.option?.type === 'damage' &&
       stack.option.cause === 'effect'
     ) {

--- a/src/game-data/effects/cards/2-3-104.ts
+++ b/src/game-data/effects/cards/2-3-104.ts
@@ -17,7 +17,7 @@ export const effects: CardEffects = {
         'お互いのフィールドに＜ウィルス・炎＞を【特殊召喚】'
       );
       for (const player of [stack.processing.owner, stack.processing.owner.opponent]) {
-        await EffectTemplate.virusInject(stack, player, 'ウィルス・炎');
+        await EffectTemplate.virusInject(stack, player, '＜ウィルス・炎＞');
       }
     }
   },

--- a/src/game-data/effects/cards/2-3-107.ts
+++ b/src/game-data/effects/cards/2-3-107.ts
@@ -68,7 +68,7 @@ export const effects: CardEffects = {
       const cardsToDelete = EffectHelper.random(owner.trash, 10);
 
       cardsToDelete.forEach(card => {
-        Effect.move(stack, stack.processing, card, 'delete');
+        Effect.delete(stack, stack.processing, card);
       });
     }
   },

--- a/src/game-data/effects/cards/2-3-109.ts
+++ b/src/game-data/effects/cards/2-3-109.ts
@@ -29,7 +29,7 @@ export const effects: CardEffects = {
         owner.hand,
         '消滅させるカードを選択'
       );
-      Effect.move(stack, self, card, 'delete');
+      Effect.delete(stack, self, card);
       EffectTemplate.reinforcements(stack, stack.processing.owner, { type: ['trigger'] });
     }
   },

--- a/src/game-data/effects/cards/2-3-113.ts
+++ b/src/game-data/effects/cards/2-3-113.ts
@@ -37,7 +37,7 @@ export const effects: CardEffects = {
         const handCards = [...opponent.hand]; // コピーを作成して操作
         handCards.forEach(card => {
           if (card.catalog.name === selectedName) {
-            Effect.move(stack, stack.processing, card, 'delete');
+            Effect.delete(stack, stack.processing, card);
           }
         });
 
@@ -45,7 +45,7 @@ export const effects: CardEffects = {
         const trashCards = [...opponent.trash]; // コピーを作成して操作
         trashCards.forEach(card => {
           if (card.catalog.name === selectedName) {
-            Effect.move(stack, stack.processing, card, 'delete');
+            Effect.delete(stack, stack.processing, card);
           }
         });
 
@@ -53,7 +53,7 @@ export const effects: CardEffects = {
         const deckCards = [...opponent.deck]; // コピーを作成して操作
         deckCards.forEach(card => {
           if (card.catalog.name === selectedName) {
-            Effect.move(stack, stack.processing, card, 'delete');
+            Effect.delete(stack, stack.processing, card);
           }
         });
       } catch (error) {

--- a/src/game-data/effects/cards/2-3-114.ts
+++ b/src/game-data/effects/cards/2-3-114.ts
@@ -1,3 +1,4 @@
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 import { Unit } from '@/package/core/class/card';
@@ -20,6 +21,7 @@ export const effects: CardEffects = {
         filter,
         '対象のユニットを選択してください'
       );
+
       if (life <= 8) await Effect.clone(stack, stack.processing, target, stack.processing.owner);
       if (life <= 6) Effect.make(stack, stack.processing.owner, target);
       if (life <= 4) Effect.delete(stack, stack.processing, target);
@@ -29,22 +31,19 @@ export const effects: CardEffects = {
   },
 
   fieldEffect: (stack: StackWithCard<Unit>): void => {
-    // BP増加量を計算
-    const bpBoost = (stack.processing.owner.life.max - stack.processing.owner.life.current) * 1000;
-
-    // 既にこのユニットが発行したDeltaが存在するか確認
-    const delta = stack.processing.delta.find(
-      d => d.source?.unit === stack.processing.id && d.source?.effectCode === '悦び'
-    );
-
-    if (delta && delta.effect.type === 'bp') {
-      // Deltaを編集する
-      delta.effect.diff = bpBoost;
-    } else {
-      // 新しいDeltaを追加
-      Effect.modifyBP(stack, stack.processing, stack.processing, bpBoost, {
-        source: { unit: stack.processing.id, effectCode: '悦び' },
-      });
-    }
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit)
+          Effect.dynamicBP(
+            stack,
+            stack.processing,
+            target,
+            self => self.owner.life.current * 1000,
+            { source }
+          );
+      },
+      effectCode: '悦び',
+      targets: ['self'],
+    });
   },
 };

--- a/src/game-data/effects/cards/2-3-114.ts
+++ b/src/game-data/effects/cards/2-3-114.ts
@@ -38,7 +38,7 @@ export const effects: CardEffects = {
             stack,
             stack.processing,
             target,
-            self => self.owner.life.current * 1000,
+            self => (self.owner.life.max - self.owner.life.current) * 1000,
             { source }
           );
       },

--- a/src/game-data/effects/cards/2-3-117.ts
+++ b/src/game-data/effects/cards/2-3-117.ts
@@ -36,7 +36,7 @@ export const effects: CardEffects = {
         // 残りのカードを捨札に送る
         randomCards.forEach(card => {
           if (card.id !== selected.id) {
-            Effect.move(stack, stack.processing, card, 'trash');
+            Effect.break(stack, stack.processing, card);
           }
         });
       } else {
@@ -44,7 +44,7 @@ export const effects: CardEffects = {
 
         // 対象がない場合は全て捨札に送る
         randomCards.forEach(card => {
-          Effect.move(stack, stack.processing, card, 'trash');
+          Effect.break(stack, stack.processing, card);
         });
       }
     }

--- a/src/game-data/effects/cards/2-3-124.ts
+++ b/src/game-data/effects/cards/2-3-124.ts
@@ -1,6 +1,7 @@
 import { Effect } from '@/game-data/effects/engine/effect';
 import { EffectHelper } from '@/game-data/effects/engine/helper';
 import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
 import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
 import type { Unit } from '@/package/core/class/card';
 
@@ -25,5 +26,9 @@ export const effects: CardEffects = {
     );
     Effect.keyword(stack, stack.processing, target, '強制防御');
     Effect.modifyBP(stack, stack.processing, target, 2000, { isBaseBP: true });
+  },
+  onBreakSelf: async (stack: StackWithCard) => {
+    await System.show(stack, 'お茶会への招待状', '【天使】を1枚引く');
+    EffectTemplate.reinforcements(stack, stack.processing.owner, { species: '天使' });
   },
 };

--- a/src/game-data/effects/cards/2-3-124.ts
+++ b/src/game-data/effects/cards/2-3-124.ts
@@ -1,0 +1,29 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+const getAngelFilter = (self: Unit) => (unit: Unit) =>
+  (unit.owner.id === self.owner.id && unit.catalog.species?.includes('天使')) || false;
+
+export const effects: CardEffects = {
+  isBootable: (core, self) => {
+    return EffectHelper.isUnitSelectable(core, getAngelFilter(self), self.owner);
+  },
+  onBootSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(
+      stack,
+      '起動・アフタヌーンブレイカー',
+      '【天使】の基本BP+2000\n【強制防御】を付与'
+    );
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      getAngelFilter(stack.processing),
+      '基本BPを+2000し【強制防御】を付与するユニットを選択'
+    );
+    Effect.keyword(stack, stack.processing, target, '強制防御');
+    Effect.modifyBP(stack, stack.processing, target, 2000, { isBaseBP: true });
+  },
+};

--- a/src/game-data/effects/cards/2-3-130.ts
+++ b/src/game-data/effects/cards/2-3-130.ts
@@ -1,0 +1,24 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(
+      stack,
+      '禁忌の呪法＆泡沫夢幻の刻',
+      'トリガーゾーンのインターセプトカードを使用できない\nデスカウンター[3]を得る'
+    );
+    Effect.death(stack, stack.processing, stack.processing, 3);
+  },
+  fieldEffect: (stack: StackWithCard) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
+      effectCode: '禁忌の呪法',
+      condition: card => stack.core.getTurnPlayer().id !== card.owner.id,
+      targets: ['opponents', 'trigger'],
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-3-130.ts
+++ b/src/game-data/effects/cards/2-3-130.ts
@@ -2,7 +2,7 @@ import { Effect } from '@/game-data/effects/engine/effect';
 import { PermanentEffect } from '@/game-data/effects/engine/permanent';
 import { System } from '@/game-data/effects/engine/system';
 import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
-import type { Unit } from '@/package/core/class/card';
+import { Intercept, type Unit } from '@/package/core/class/card';
 
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard<Unit>) => {
@@ -17,7 +17,8 @@ export const effects: CardEffects = {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       effectCode: '禁忌の呪法',
-      condition: card => stack.core.getTurnPlayer().id !== card.owner.id,
+      condition: card =>
+        stack.core.getTurnPlayer().id !== card.owner.id && card instanceof Intercept,
       targets: ['opponents', 'trigger'],
     });
   },

--- a/src/game-data/effects/cards/2-3-134.ts
+++ b/src/game-data/effects/cards/2-3-134.ts
@@ -14,7 +14,7 @@ export const effects = {
         if (card instanceof Unit && opponent.field.some(unit => unit.id === card.id)) {
           Effect.delete(stack, stack.processing, card);
         } else {
-          Effect.move(stack, stack.processing, card, 'delete');
+          Effect.delete(stack, stack.processing, card);
         }
       });
 

--- a/src/game-data/effects/cards/2-3-144.ts
+++ b/src/game-data/effects/cards/2-3-144.ts
@@ -11,7 +11,7 @@ export const effects: CardEffects = {
       ...stack.processing.owner.field,
       ...stack.processing.owner.hand,
       ...stack.processing.owner.opponent.field,
-      stack.processing.owner.opponent.hand,
+      ...stack.processing.owner.opponent.hand,
     ].forEach(card => {
       if (card instanceof Unit) Effect.clock(stack, stack.processing, card, -2);
     });

--- a/src/game-data/effects/cards/2-3-144.ts
+++ b/src/game-data/effects/cards/2-3-144.ts
@@ -1,0 +1,19 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkTurnEnd: (stack: StackWithCard) => stack.source.id === stack.processing.owner.id,
+  onTurnEnd: async (stack: StackWithCard) => {
+    await System.show(stack, 'すやすやスリーピング', '手札とフィールドのユニットのレベル-2');
+    [
+      ...stack.processing.owner.field,
+      ...stack.processing.owner.hand,
+      ...stack.processing.owner.opponent.field,
+      stack.processing.owner.opponent.hand,
+    ].forEach(card => {
+      if (card instanceof Unit) Effect.clock(stack, stack.processing, card, -2);
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-3-152.ts
+++ b/src/game-data/effects/cards/2-3-152.ts
@@ -1,0 +1,22 @@
+import master from '@/game-data/catalog';
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) => stack.source.id !== stack.processing.owner.id,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, 'アンデッドパレード', 'ランダムな【不死】を3枚作成');
+    [stack.processing.owner, stack.processing.owner.opponent].forEach(player => {
+      EffectHelper.repeat(3, () => {
+        const [card] = EffectHelper.random(
+          Array.from(master.values()).filter(catalog => catalog.species?.includes('不死'))
+        );
+        if (card?.id) {
+          Effect.make(stack, player, card?.id);
+        }
+      });
+    });
+  },
+};

--- a/src/game-data/effects/cards/2-3-152.ts
+++ b/src/game-data/effects/cards/2-3-152.ts
@@ -8,11 +8,12 @@ export const effects: CardEffects = {
   checkTurnStart: (stack: StackWithCard) => stack.source.id !== stack.processing.owner.id,
   onTurnStart: async (stack: StackWithCard) => {
     await System.show(stack, 'アンデッドパレード', 'ランダムな【不死】を3枚作成');
+    const undeads = Array.from(master.values()).filter(catalog =>
+      catalog.species?.includes('不死')
+    );
     [stack.processing.owner, stack.processing.owner.opponent].forEach(player => {
       EffectHelper.repeat(3, () => {
-        const [card] = EffectHelper.random(
-          Array.from(master.values()).filter(catalog => catalog.species?.includes('不死'))
-        );
+        const [card] = EffectHelper.random(undeads);
         if (card?.id) {
           Effect.make(stack, player, card?.id);
         }

--- a/src/game-data/effects/cards/2-3-156.ts
+++ b/src/game-data/effects/cards/2-3-156.ts
@@ -17,20 +17,20 @@ export const effects: CardEffects = {
     const deck = stack.processing.owner.deck.filter(card => card.catalog.type === 'unit');
     switch (stack.processing.lv) {
       case 1: {
-        await System.show(stack, '花いろ日記', 'デッキからコスト2以下を【特殊召喚】');
-        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost <= 2));
+        await System.show(stack, '花いろ日記', 'デッキからコスト2を【特殊召喚】');
+        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost === 2));
         if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
         break;
       }
       case 2: {
-        await System.show(stack, '花いろ日記', 'デッキからコスト3以下を【特殊召喚】');
-        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost <= 3));
+        await System.show(stack, '花いろ日記', 'デッキからコスト3を【特殊召喚】');
+        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost === 3));
         if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
         break;
       }
       case 3: {
-        await System.show(stack, '花いろ日記', 'デッキからコスト5以下を【特殊召喚】');
-        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost <= 5));
+        await System.show(stack, '花いろ日記', 'デッキからコスト5を【特殊召喚】');
+        const [target] = EffectHelper.random(deck.filter(unit => unit.catalog.cost === 5));
         if (target instanceof Unit) await Effect.summon(stack, stack.processing, target);
         break;
       }

--- a/src/game-data/effects/cards/2-3-202.ts
+++ b/src/game-data/effects/cards/2-3-202.ts
@@ -90,7 +90,7 @@ export const effects: CardEffects = {
       );
 
       // 選択したユニットを捨札に送る
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
     }
   },
 };

--- a/src/game-data/effects/cards/2-3-202.ts
+++ b/src/game-data/effects/cards/2-3-202.ts
@@ -90,7 +90,7 @@ export const effects: CardEffects = {
       );
 
       // 選択したユニットを捨札に送る
-      Effect.break(stack, stack.processing, target);
+      Effect.move(stack, stack.processing, target, 'trash');
     }
   },
 };

--- a/src/game-data/effects/cards/2-3-204.ts
+++ b/src/game-data/effects/cards/2-3-204.ts
@@ -106,7 +106,7 @@ async function destroyAllTriggers(
 
     // 全てのトリガーカードを破壊
     allTriggers.forEach(({ card }) => {
-      Effect.move(stack, stack.processing, card, 'trash');
+      Effect.break(stack, stack.processing, card);
     });
 
     if (drive) Effect.keyword(stack, stack.processing, stack.processing, '消滅効果耐性');

--- a/src/game-data/effects/cards/2-3-207.ts
+++ b/src/game-data/effects/cards/2-3-207.ts
@@ -42,7 +42,7 @@ export const effects: CardEffects = {
         fourGodUnits,
         '捨てる【四聖獣】ユニットを選択してください'
       );
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
     }
   },
 };

--- a/src/game-data/effects/cards/2-3-213.ts
+++ b/src/game-data/effects/cards/2-3-213.ts
@@ -1,0 +1,59 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    const bp8000filter = (unit: Unit) =>
+      unit.owner.id === stack.processing.owner.opponent.id && unit.currentBP >= 8000;
+    const choice = await EffectHelper.choice(
+      stack,
+      stack.processing.owner,
+      '選略・究極のしもやけ',
+      [
+        {
+          id: '1',
+          description: 'BP8000以上のユニットを破壊',
+          condition: EffectHelper.isUnitSelectable(
+            stack.core,
+            bp8000filter,
+            stack.processing.owner
+          ),
+        },
+        {
+          id: '2',
+          description: 'CP-3\nユニットを破壊',
+          condition: EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
+        },
+      ]
+    );
+
+    switch (choice) {
+      case '1': {
+        await System.show(stack, '選略・究極のしもやけ', 'BP8000以上のユニットを破壊');
+        const [target] = await EffectHelper.pickUnit(
+          stack,
+          stack.processing.owner,
+          bp8000filter,
+          '破壊するユニットを選択'
+        );
+        Effect.break(stack, stack.processing, target);
+        break;
+      }
+      case '2': {
+        await System.show(stack, '選略・究極のしもやけ', 'CP-3\nユニットを破壊');
+        const [target] = await EffectHelper.pickUnit(
+          stack,
+          stack.processing.owner,
+          'opponents',
+          '破壊するユニットを選択'
+        );
+        Effect.break(stack, stack.processing, target);
+        Effect.modifyCP(stack, stack.processing, stack.processing.owner, -3);
+        break;
+      }
+    }
+  },
+};

--- a/src/game-data/effects/cards/2-3-213.ts
+++ b/src/game-data/effects/cards/2-3-213.ts
@@ -25,7 +25,9 @@ export const effects: CardEffects = {
         {
           id: '2',
           description: 'CP-3\nユニットを破壊',
-          condition: EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
+          condition:
+            stack.processing.owner.cp.current >= 3 &&
+            EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner),
         },
       ]
     );

--- a/src/game-data/effects/cards/2-3-214.ts
+++ b/src/game-data/effects/cards/2-3-214.ts
@@ -23,7 +23,7 @@ export const effects: CardEffects = {
         if (card.id === selected.id) {
           Effect.move(stack, stack.processing, card, 'hand');
         } else {
-          Effect.move(stack, stack.processing, card, 'trash');
+          Effect.break(stack, stack.processing, card);
         }
       }
     }
@@ -95,7 +95,7 @@ export const effects: CardEffects = {
         fourGodUnits,
         '捨てる【四聖獣】ユニットを選択してください'
       );
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
     }
   },
 };

--- a/src/game-data/effects/cards/2-3-219.ts
+++ b/src/game-data/effects/cards/2-3-219.ts
@@ -100,7 +100,7 @@ export const effects: CardEffects = {
         fourGodUnits,
         '捨てる【四聖獣】ユニットを選択してください'
       );
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
     }
   },
 };

--- a/src/game-data/effects/cards/2-3-221.ts
+++ b/src/game-data/effects/cards/2-3-221.ts
@@ -29,11 +29,11 @@ export const effects: CardEffects = {
   },
 
   // 対戦相手は手札からコスト1のユニットをフィールドに出すことができない。
-  fieldEffect: async (stack: StackWithCard): Promise<void> => {
+  fieldEffect: (stack: StackWithCard) => {
     PermanentEffect.mount(stack.processing, {
       effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      condition: card => card.catalog.cost === 1,
+      condition: card => card instanceof Unit && card.catalog.cost === 1,
       effectCode: '翠龍の眼光',
     });
   },

--- a/src/game-data/effects/cards/2-3-221.ts
+++ b/src/game-data/effects/cards/2-3-221.ts
@@ -1,7 +1,6 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
 import { PermanentEffect } from '../engine/permanent';
 import { Color } from '@/submodule/suit/constant';
 
@@ -30,15 +29,11 @@ export const effects: CardEffects = {
   },
 
   // 対戦相手は手札からコスト1のユニットをフィールドに出すことができない。
-  fieldEffect: (stack: StackWithCard<Unit>): void => {
+  fieldEffect: async (stack: StackWithCard): Promise<void> => {
     PermanentEffect.mount(stack.processing, {
+      effect: (card, source) => Effect.ban(stack, stack.processing, card, { source }),
       targets: ['opponents', 'hand'],
-      effect: (unit, source) => {
-        if (unit instanceof Unit) {
-          unit.delta.push(new Delta({ type: 'banned' }, { source }));
-        }
-      },
-      condition: target => target instanceof Unit && target.catalog.cost === 1,
+      condition: card => card.catalog.cost === 1,
       effectCode: '翠龍の眼光',
     });
   },

--- a/src/game-data/effects/cards/2-3-231.ts
+++ b/src/game-data/effects/cards/2-3-231.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
     stack.target.catalog.cost >= 5,
   onDrive: async (stack: StackWithCard) => {
     await System.show(stack, 'LIVEラリー', '[LIVEラリー]を作成\n対戦相手のトリガーゾーンにセット');
-    Effect.make(stack, stack.processing.owner, '2-3-231', 'trigger');
+    Effect.make(stack, stack.processing.owner.opponent, '2-3-231', 'trigger');
   },
   checkTurnEnd: (stack: StackWithCard) => {
     return stack.source.id === stack.processing.owner.id;

--- a/src/game-data/effects/cards/2-3-231.ts
+++ b/src/game-data/effects/cards/2-3-231.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkDrive: (stack: StackWithCard) =>
+    stack.processing.owner.id === stack.source.id &&
+    stack.target instanceof Unit &&
+    stack.target.catalog.cost >= 5,
+  onDrive: async (stack: StackWithCard) => {
+    await System.show(stack, 'LIVEラリー', '[LIVEラリー]を作成\n対戦相手のトリガーゾーンにセット');
+    Effect.make(stack, stack.processing.owner, '2-3-231', 'trigger');
+  },
+  checkTurnEnd: (stack: StackWithCard) => {
+    return stack.source.id === stack.processing.owner.id;
+  },
+  onTurnEnd: async (stack: StackWithCard) => {
+    await System.show(stack, 'LIVEラリー', '1ライフダメージ');
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner, -1);
+  },
+};

--- a/src/game-data/effects/cards/2-3-233.ts
+++ b/src/game-data/effects/cards/2-3-233.ts
@@ -1,4 +1,4 @@
-import { Effect, System } from '..';
+import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
@@ -16,7 +16,26 @@ export const effects: CardEffects = {
   // 実際の効果本体
   // 関数名に self は付かない
   onTurnStart: async (stack: StackWithCard): Promise<void> => {
-    await System.show(stack, 'トリニティ・アステリズム', '3ライフダメージ');
+    const opponent = stack.processing.owner.opponent;
+    // 対戦相手のフィールド、トリガーゾーン、手札のカードをリストアップ
+    const targetCards = [...opponent.field, ...opponent.trigger, ...opponent.hand];
+    if (targetCards.length > 0) {
+      await System.show(
+        stack,
+        'トリニティ・アステリズム',
+        'フィールド/トリガーゾーン/手札から3枚消滅\n3ライフダメージ'
+      );
+
+      // 消滅させる枚数（最大3枚まで）
+      const deleteCount = Math.min(3, targetCards.length);
+      const randomCards = EffectHelper.random(targetCards, deleteCount);
+      // 選択したカードを消滅させる
+      for (const card of randomCards) {
+        Effect.delete(stack, stack.processing, card);
+      }
+    } else {
+      await System.show(stack, 'トリニティ・アステリズム', '3ライフダメージ');
+    }
     Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -3);
   },
 };

--- a/src/game-data/effects/cards/2-3-233.ts
+++ b/src/game-data/effects/cards/2-3-233.ts
@@ -1,4 +1,4 @@
-import { Effect, EffectHelper, System } from '..';
+import { Effect, EffectHelper } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
 export const effects: CardEffects = {
@@ -19,23 +19,27 @@ export const effects: CardEffects = {
     const opponent = stack.processing.owner.opponent;
     // 対戦相手のフィールド、トリガーゾーン、手札のカードをリストアップ
     const targetCards = [...opponent.field, ...opponent.trigger, ...opponent.hand];
-    if (targetCards.length > 0) {
-      await System.show(
-        stack,
-        'トリニティ・アステリズム',
-        'フィールド/トリガーゾーン/手札から3枚消滅\n3ライフダメージ'
-      );
 
-      // 消滅させる枚数（最大3枚まで）
-      const deleteCount = Math.min(3, targetCards.length);
-      const randomCards = EffectHelper.random(targetCards, deleteCount);
-      // 選択したカードを消滅させる
-      for (const card of randomCards) {
-        Effect.delete(stack, stack.processing, card);
-      }
-    } else {
-      await System.show(stack, 'トリニティ・アステリズム', '3ライフダメージ');
-    }
-    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -3);
+    await EffectHelper.combine(stack, [
+      {
+        title: 'トリニティ・アステリズム',
+        description: 'フィールド/トリガーゾーン/手札から3枚消滅',
+        effect: () => {
+          // 消滅させる枚数（最大3枚まで）
+          const randomCards = EffectHelper.random(targetCards, 3);
+          // 選択したカードを消滅させる
+          for (const card of randomCards) {
+            Effect.delete(stack, stack.processing, card);
+          }
+        },
+        condition: targetCards.length > 0,
+      },
+      {
+        title: 'トリニティ・アステリズム',
+        description: '3ライフダメージ',
+        effect: () =>
+          Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -3),
+      },
+    ]);
   },
 };

--- a/src/game-data/effects/cards/2-3-235.ts
+++ b/src/game-data/effects/cards/2-3-235.ts
@@ -1,0 +1,51 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+import { Color } from '@/submodule/suit/constant';
+
+/** colorsの中で最も多い属性を返す。同数の属性が複数ある場合は undefined を返す */
+const getDominantColor = (colors: number[]): number | undefined => {
+  const colorCount = colors.reduce<Record<string, number>>((acc, color) => {
+    acc[color] = (acc[color] ?? 0) + 1;
+    return acc;
+  }, {});
+  const maxCount = Math.max(...Object.values(colorCount));
+  const topColors = Object.entries(colorCount).filter(([, count]) => count === maxCount);
+  if (topColors.length !== 1) return undefined;
+  return Number(topColors[0]?.[0]);
+};
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    stack.processing.owner.field.length <= 4 &&
+    getDominantColor(stack.processing.owner.field.map(unit => unit.catalog.color)) !== undefined,
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, 'フルーツバスケット', '[フルーツガール]を【特殊召喚】');
+    const color = getDominantColor(stack.processing.owner.field.map(unit => unit.catalog.color));
+
+    switch (color) {
+      case Color.RED: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-004'));
+        break;
+      }
+      case Color.YELLOW: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-009'));
+        break;
+      }
+      case Color.BLUE: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-014'));
+        break;
+      }
+      case Color.GREEN: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-019'));
+        break;
+      }
+      case Color.PURPLE: {
+        await Effect.summon(stack, stack.processing, new Unit(stack.processing.owner, '2-1-025'));
+        break;
+      }
+    }
+  },
+};

--- a/src/game-data/effects/cards/PR-024.ts
+++ b/src/game-data/effects/cards/PR-024.ts
@@ -1,0 +1,24 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    const beastFilter = (unit: Unit) =>
+      unit.owner.id !== stack.processing.owner.id && unit.catalog.species?.includes('獣');
+    if (!EffectHelper.isUnitSelectable(stack.core, beastFilter, stack.processing.owner)) return;
+
+    await System.show(stack, '黄金の拳', '【獣】を1体破壊\nカードを1枚引く');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      beastFilter,
+      '破壊する【獣】を選択'
+    );
+    Effect.break(stack, stack.processing, target);
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/game-data/effects/cards/PR-065.ts
+++ b/src/game-data/effects/cards/PR-065.ts
@@ -20,7 +20,7 @@ export const effects: CardEffects = {
     if (stack.processing.owner.delete.length > 0 && stack.processing.owner.id === stack.source.id) {
       await System.show(stack, '禁忌の霊符', '消滅カードを3枚まで捨札に送る');
       EffectHelper.random(stack.processing.owner.delete, 3).forEach(card =>
-        Effect.move(stack, stack.processing, card, 'trash')
+        Effect.break(stack, stack.processing, card)
       );
     }
   },

--- a/src/game-data/effects/cards/PR-067.ts
+++ b/src/game-data/effects/cards/PR-067.ts
@@ -49,7 +49,7 @@ export const effects: CardEffects = {
         if (target) Effect.damage(stack, stack.processing, target, 10000);
         Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -1);
         EffectHelper.random(stack.processing.owner.opponent.trigger).forEach(card =>
-          Effect.move(stack, stack.processing, card, 'trash')
+          Effect.break(stack, stack.processing, card)
         );
         break;
       }
@@ -72,7 +72,7 @@ export const effects: CardEffects = {
         if (target) Effect.damage(stack, stack.processing, target, 10000);
         Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -2);
         EffectHelper.random(stack.processing.owner.opponent.trigger, 2).forEach(card =>
-          Effect.move(stack, stack.processing, card, 'trash')
+          Effect.break(stack, stack.processing, card)
         );
         break;
       }

--- a/src/game-data/effects/cards/PR-096.ts
+++ b/src/game-data/effects/cards/PR-096.ts
@@ -1,0 +1,18 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkAttack: (stack: StackWithCard) =>
+    stack.target instanceof Unit &&
+    stack.target.owner.id === stack.processing.owner.id &&
+    stack.target.owner.field.some(unit => unit.id === stack.target?.id),
+  onAttack: async (stack: StackWithCard) => {
+    await System.show(stack, '幻想の里', 'ブロックされない\nライフ+1');
+    if (stack.target instanceof Unit) {
+      Effect.keyword(stack, stack.processing, stack.target, '次元干渉', { condition: () => true });
+    }
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, 1);
+  },
+};

--- a/src/game-data/effects/cards/PR-102.ts
+++ b/src/game-data/effects/cards/PR-102.ts
@@ -15,7 +15,7 @@ export const effects: CardEffects = {
   onDrive: async (stack: StackWithCard): Promise<void> => {
     await System.show(stack, '微笑の占い師', 'トリガーゾーンを2枚まで破壊');
     EffectHelper.random(stack.processing.owner.opponent.trigger, 2).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
   },
 };

--- a/src/game-data/effects/cards/PR-109.ts
+++ b/src/game-data/effects/cards/PR-109.ts
@@ -57,7 +57,7 @@ export const effects: CardEffects = {
 
       Effect.move(stack, stack.processing, draw, 'hand');
       targets.forEach(card => {
-        if (card.id !== draw.id) Effect.move(stack, stack.processing, card, 'delete');
+        if (card.id !== draw.id) Effect.delete(stack, stack.processing, card);
       });
     }
   },

--- a/src/game-data/effects/cards/PR-111.ts
+++ b/src/game-data/effects/cards/PR-111.ts
@@ -1,0 +1,37 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await EffectHelper.combine(stack, [
+      {
+        title: '貫通',
+        description: 'ブロックを貫通しプレイヤーにダメージを与える',
+        effect: () => Effect.keyword(stack, stack.processing, stack.processing, '貫通'),
+      },
+      {
+        title: '全てを喰らう激流',
+        description: '全ユニットに【強制防御】を付与',
+        effect: () =>
+          [...stack.processing.owner.field, ...stack.processing.owner.opponent.field].forEach(
+            unit => Effect.keyword(stack, stack.processing, unit, '強制防御')
+          ),
+      },
+      {
+        title: '全てを喰らう激流',
+        description: '【スピードムーブ】を得る',
+        effect: () => Effect.speedMove(stack, stack.processing),
+        condition:
+          stack.processing.owner.field.filter(unit => unit.catalog.species?.includes('ドラゴン'))
+            .length >= 3,
+      },
+    ]);
+  },
+  onBreakSelf: async (stack: StackWithCard) => {
+    await System.show(stack, '水竜の至宝', 'CP+2');
+    Effect.modifyCP(stack, stack.processing, stack.processing.owner, 2);
+  },
+};

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -1,0 +1,51 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { PermanentEffect } from '@/game-data/effects/engine/permanent';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+import { Color } from '@/submodule/suit/constant';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard<Unit>) => {
+    await EffectHelper.combine(stack, [
+      {
+        title: 'マイクロバースト',
+        description: '紫属性のインターセプトカードを1枚セット\n紫ゲージ+1',
+        condition: (stack.processing.owner.purple ?? 0) <= 2,
+        effect: async () => {
+          if (stack.processing.owner.trigger.length < stack.core.room.rule.player.max.trigger) {
+            EffectHelper.random(
+              stack.processing.owner.deck.filter(
+                card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
+              )
+            ).forEach(card => Effect.move(stack, stack.processing, card, 'trigger'));
+          }
+          await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
+        },
+      },
+      {
+        title: '栄光の凱歌',
+        description: 'BP+3000\n【不屈】を得る',
+        effect: () => {},
+      },
+    ]);
+  },
+  onAttack: async (stack: StackWithCard) => {
+    if (stack.source.id === stack.processing.owner.id) return;
+    await System.show(stack, 'マイクロバースト', '紫ゲージ+1');
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
+  },
+  fieldEffect: (stack: StackWithCard) => {
+    PermanentEffect.mount(stack.processing, {
+      effect: (target, source) => {
+        if (target instanceof Unit) {
+          Effect.modifyBP(stack, stack.processing, target, 3000, { source });
+          Effect.keyword(stack, stack.processing, target, '不屈', { source });
+        }
+      },
+      effectCode: '栄光の凱歌',
+      targets: ['self'],
+    });
+  },
+};

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -14,15 +14,13 @@ export const effects: CardEffects = {
         description: '紫属性のインターセプトカードを1枚セット\n紫ゲージ+1',
         condition: (stack.processing.owner.purple ?? 0) <= 2,
         effect: async () => {
-          if (stack.processing.owner.trigger.length < stack.core.room.rule.player.max.trigger) {
-            EffectHelper.random(
-              stack.processing.owner.deck.filter(
-                card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
-              )
-            ).forEach(card => {
-              Effect.move(stack, stack.processing, card, 'trigger');
-            });
-          }
+          EffectHelper.random(
+            stack.processing.owner.deck.filter(
+              card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
+            )
+          ).forEach(card => {
+            Effect.move(stack, stack.processing, card, 'trigger');
+          });
           await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
         },
       },

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -44,6 +44,7 @@ export const effects: CardEffects = {
           Effect.keyword(stack, stack.processing, target, '不屈', { source });
         }
       },
+      condition: target => (target.owner.purple ?? 0) >= 3,
       effectCode: '栄光の凱歌',
       targets: ['self'],
     });

--- a/src/game-data/effects/cards/PR-140.ts
+++ b/src/game-data/effects/cards/PR-140.ts
@@ -19,7 +19,9 @@ export const effects: CardEffects = {
               stack.processing.owner.deck.filter(
                 card => card.catalog.type === 'intercept' && card.catalog.color === Color.PURPLE
               )
-            ).forEach(card => Effect.move(stack, stack.processing, card, 'trigger'));
+            ).forEach(card => {
+              Effect.move(stack, stack.processing, card, 'trigger');
+            });
           }
           await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
         },

--- a/src/game-data/effects/cards/PR-149.ts
+++ b/src/game-data/effects/cards/PR-149.ts
@@ -1,0 +1,17 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBreak: (stack: StackWithCard) =>
+    stack.target instanceof Unit &&
+    stack.target.owner.id === stack.processing.owner.id &&
+    (stack.processing.owner.purple ?? 0) >= 3,
+  onBreak: async (stack: StackWithCard) => {
+    await System.show(stack, '丑の刻参り', '1ライフダメージ\nカードを1枚引く');
+    Effect.modifyLife(stack, stack.processing, stack.processing.owner.opponent, -1);
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/game-data/effects/cards/PR-170.ts
+++ b/src/game-data/effects/cards/PR-170.ts
@@ -1,0 +1,25 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    await System.show(stack, 'ダークチャージ', '紫ゲージ+1');
+  },
+  onModifyPurple: async (stack: StackWithCard) => {
+    if (
+      stack.target?.id !== stack.processing.owner.id ||
+      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
+    )
+      return;
+    await System.show(stack, '怪火の機術', '2000ダメージ');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'opponents',
+      'ダメージを与えるユニットを選択'
+    );
+    Effect.damage(stack, stack.processing, target, 2000);
+  },
+};

--- a/src/game-data/effects/cards/PR-170.ts
+++ b/src/game-data/effects/cards/PR-170.ts
@@ -6,6 +6,7 @@ import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/type
 export const effects: CardEffects = {
   onDriveSelf: async (stack: StackWithCard) => {
     await System.show(stack, 'ダークチャージ', '紫ゲージ+1');
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, 1);
   },
   onModifyPurple: async (stack: StackWithCard) => {
     if (

--- a/src/game-data/effects/cards/PR-170.ts
+++ b/src/game-data/effects/cards/PR-170.ts
@@ -10,7 +10,7 @@ export const effects: CardEffects = {
   onModifyPurple: async (stack: StackWithCard) => {
     if (
       stack.target?.id !== stack.processing.owner.id ||
-      EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
+      !EffectHelper.isUnitSelectable(stack.core, 'opponents', stack.processing.owner)
     )
       return;
     await System.show(stack, '怪火の機術', '2000ダメージ');

--- a/src/game-data/effects/cards/PR-180.ts
+++ b/src/game-data/effects/cards/PR-180.ts
@@ -1,0 +1,26 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import type { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  onIntercept: async (stack: StackWithCard<Unit>) => {
+    if (stack.source.id !== stack.processing.owner.id) return;
+    await System.show(stack, '紫電の溢力', '基本BP+2000');
+    Effect.modifyBP(stack, stack.processing, stack.processing, 2000, { isBaseBP: true });
+  },
+  isBootable: (core, self) => {
+    return (
+      self.owner.hand.length < core.room.rule.player.max.hand &&
+      self.owner.trash.some(card => card.catalog.type === 'intercept')
+    );
+  },
+  onBootSelf: async (stack: StackWithCard<Unit>) => {
+    await System.show(stack, '起動・破滅の輪廻', '基本BP-3000\n捨札からインターセプトカードを回収');
+    Effect.modifyBP(stack, stack.processing, stack.processing, -3000, { isBaseBP: true });
+    EffectHelper.random(
+      stack.processing.owner.trash.filter(card => card.catalog.type === 'intercept')
+    ).forEach(card => Effect.move(stack, stack.processing, card, 'hand'));
+  },
+};

--- a/src/game-data/effects/cards/PR-200.ts
+++ b/src/game-data/effects/cards/PR-200.ts
@@ -7,8 +7,8 @@ export const effects: CardEffects = {
     if (stack.processing.owner.opponent.hand.length === 0) return;
 
     await System.show(stack, 'スウィート・リトル・ブレス', '手札のレベル-2');
-    stack.processing.owner.opponent.hand.forEach(card =>
-      Effect.clock(stack, stack.processing, card, -2)
-    );
+    stack.processing.owner.opponent.hand.forEach(card => {
+      Effect.clock(stack, stack.processing, card, -2);
+    });
   },
 };

--- a/src/game-data/effects/cards/PR-200.ts
+++ b/src/game-data/effects/cards/PR-200.ts
@@ -1,0 +1,14 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    if (stack.processing.owner.opponent.hand.length === 0) return;
+
+    await System.show(stack, 'スウィート・リトル・ブレス', '手札のレベル-2');
+    stack.processing.owner.opponent.hand.forEach(card =>
+      Effect.clock(stack, stack.processing, card, -2)
+    );
+  },
+};

--- a/src/game-data/effects/cards/PR-203.ts
+++ b/src/game-data/effects/cards/PR-203.ts
@@ -1,0 +1,33 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  onDriveSelf: async (stack: StackWithCard) => {
+    if (!EffectHelper.isVirusInjectable(stack.processing.owner.opponent)) return;
+    await System.show(stack, 'フォース＜ウィルス・蝕＞', '＜ウィルス・蝕＞を【特殊召喚】');
+    await EffectTemplate.virusInject(stack, stack.processing.owner.opponent, '＜ウィルス・蝕＞');
+  },
+  onTurnEnd: async (stack: StackWithCard) => {
+    const targets = stack.processing.owner.deck.filter(card => card.catalog.type === 'intercept');
+    if (
+      stack.source.id !== stack.processing.owner.id ||
+      stack.processing.owner.hand.length >= stack.core.room.rule.player.max.hand ||
+      (stack.processing.owner.purple ?? 0) < 3 ||
+      targets.length === 0
+    )
+      return;
+
+    await System.show(
+      stack,
+      'マルブリッサの神術',
+      'インターセプトカードを1枚引きレベル+1\n紫ゲージ-1'
+    );
+    EffectHelper.random(targets).forEach(card =>
+      Effect.move(stack, stack.processing, card, 'hand')
+    );
+    await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
+  },
+};

--- a/src/game-data/effects/cards/PR-203.ts
+++ b/src/game-data/effects/cards/PR-203.ts
@@ -25,9 +25,10 @@ export const effects: CardEffects = {
       'マルブリッサの神術',
       'インターセプトカードを1枚引きレベル+1\n紫ゲージ-1'
     );
-    EffectHelper.random(targets).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'hand')
-    );
+    EffectHelper.random(targets).forEach(card => {
+      Effect.move(stack, stack.processing, card, 'hand');
+      Effect.clock(stack, stack.processing, card, 1);
+    });
     await Effect.modifyPurple(stack, stack.processing, stack.processing.owner, -1);
   },
 };

--- a/src/game-data/effects/cards/PR-215.ts
+++ b/src/game-data/effects/cards/PR-215.ts
@@ -25,7 +25,7 @@ export const effects: CardEffects = {
       // ランダムで1枚選んで破壊
       const targetCard = EffectHelper.random(opponent.trigger, 1)[0];
       if (targetCard) {
-        Effect.move(stack, stack.processing, targetCard, 'trash');
+        Effect.break(stack, stack.processing, targetCard);
       }
     }
   },

--- a/src/game-data/effects/cards/PR-218.ts
+++ b/src/game-data/effects/cards/PR-218.ts
@@ -22,7 +22,7 @@ export const effects: CardEffects = {
     const [target] = EffectHelper.random(stack.processing.owner.opponent.trigger);
     if (target) {
       await System.show(stack, '焔に染まる少女の想い', 'トリガーゾーンを1枚破壊');
-      Effect.move(stack, stack.processing, target, 'trash');
+      Effect.break(stack, stack.processing, target);
 
       await onLost(stack);
     }

--- a/src/game-data/effects/cards/PR-234.ts
+++ b/src/game-data/effects/cards/PR-234.ts
@@ -17,6 +17,8 @@ export const effects: CardEffects = {
       stack.source.owner.id === stack.processing.owner.id &&
       stack.target instanceof Unit &&
       stack.target.owner.id !== stack.processing.owner.id &&
+      stack.option?.type === 'damage' &&
+      stack.option?.cause === 'effect' &&
       // 効果発動の条件を確認
       (EffectHelper.isUnitSelectable(stack.core, 'opponents', owner) ||
         owner.trigger.length < stack.core.room.rule.player.max.trigger)

--- a/src/game-data/effects/cards/PR-239.ts
+++ b/src/game-data/effects/cards/PR-239.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { System } from '@/game-data/effects/engine/system';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+import { Unit } from '@/package/core/class/card';
+
+export const effects: CardEffects = {
+  checkBattle: (stack: StackWithCard) =>
+    [stack.source, stack.target].some(
+      object => object instanceof Unit && object.owner.field.some(unit => unit.id === object?.id)
+    ),
+  onBattle: async (stack: StackWithCard) => {
+    await System.show(stack, '望まぬ争い', '【不滅】とデスカウンター[1]を付与');
+    if (stack.target instanceof Unit) {
+      Effect.death(stack, stack.processing, stack.target, 1);
+      Effect.keyword(stack, stack.processing, stack.target, '不滅');
+    }
+    if (stack.source instanceof Unit) {
+      Effect.death(stack, stack.processing, stack.source, 1);
+      Effect.keyword(stack, stack.processing, stack.source, '不滅');
+    }
+  },
+};

--- a/src/game-data/effects/cards/PR-242.ts
+++ b/src/game-data/effects/cards/PR-242.ts
@@ -1,6 +1,5 @@
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
   checkTurnStart: (stack: StackWithCard) => {
@@ -19,9 +18,7 @@ export const effects: CardEffects = {
     );
     stack.processing.owner.opponent.hand
       .filter(card => card.catalog.cost >= 7)
-      .forEach(card =>
-        card.delta.push(new Delta({ type: 'banned' }, { event: 'turnEnd', count: 1 }))
-      );
+      .forEach(card => Effect.ban(stack, stack.processing, card, { event: 'turnEnd', count: 1 }));
 
     if (intercepts.length > 0) {
       const [target] = await EffectHelper.selectCard(

--- a/src/game-data/effects/cards/PR-242.ts
+++ b/src/game-data/effects/cards/PR-242.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@/package/core/class/card';
 import { Effect, EffectHelper, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
 
@@ -17,7 +18,7 @@ export const effects: CardEffects = {
       `コスト7以上をフィールドに出せない${intercepts.length > 0 ? '\nインターセプトカードを選んで引く' : ''}`
     );
     stack.processing.owner.opponent.hand
-      .filter(card => card.catalog.cost >= 7)
+      .filter(card => card.catalog.cost >= 7 && card instanceof Unit)
       .forEach(card => Effect.ban(stack, stack.processing, card, { event: 'turnEnd', count: 1 }));
 
     if (intercepts.length > 0) {

--- a/src/game-data/effects/cards/PR-243.ts
+++ b/src/game-data/effects/cards/PR-243.ts
@@ -1,7 +1,6 @@
 import { Unit } from '@/package/core/class/card';
 import { Effect, EffectTemplate, System } from '..';
 import type { CardEffects, StackWithCard } from '../schema/types';
-import { Delta } from '@/package/core/class/delta';
 
 export const effects: CardEffects = {
   checkTurnStart: (stack: StackWithCard) => {
@@ -18,14 +17,10 @@ export const effects: CardEffects = {
       'コスト2以下のユニットを出せない\nジョーカーゲージ-20%\nCP+2\nトリガーカードを1枚引く'
     );
 
-    // 対戦相手の手札にあるコスト2以下のユニット
-    const bannedUnits = opponent.hand.filter(
-      unit => unit instanceof Unit && unit.catalog.cost <= 2
-    );
-    // ターン終了時までフィールドに出すことができない。
-    bannedUnits.forEach(unit =>
-      unit.delta.push(new Delta({ type: 'banned' }, { event: 'turnEnd', count: 1 }))
-    );
+    // 対戦相手の手札にあるコスト2以下のユニットを使用不能に
+    opponent.hand
+      .filter(unit => unit instanceof Unit && unit.catalog.cost <= 2)
+      .forEach(unit => Effect.ban(stack, stack.processing, unit, { event: 'turnEnd', count: 1 }));
 
     // ジョーカーゲージを20%減少させる
     Effect.modifyJokerGauge(stack, stack.processing, owner, -20);

--- a/src/game-data/effects/cards/SP-052.ts
+++ b/src/game-data/effects/cards/SP-052.ts
@@ -1,0 +1,22 @@
+import { Effect } from '@/game-data/effects/engine/effect';
+import { EffectHelper } from '@/game-data/effects/engine/helper';
+import { System } from '@/game-data/effects/engine/system';
+import { EffectTemplate } from '@/game-data/effects/engine/templates';
+import type { CardEffects, StackWithCard } from '@/game-data/effects/schema/types';
+
+export const effects: CardEffects = {
+  checkTurnStart: (stack: StackWithCard) =>
+    stack.source.id === stack.processing.owner.id &&
+    EffectHelper.isUnitSelectable(stack.core, 'owns', stack.processing.owner),
+  onTurnStart: async (stack: StackWithCard) => {
+    await System.show(stack, '自然の声', '基本BP-5000\nカードを1枚引く');
+    const [target] = await EffectHelper.pickUnit(
+      stack,
+      stack.processing.owner,
+      'owns',
+      '基本BPを-するユニットを選択'
+    );
+    Effect.modifyBP(stack, stack.processing, target, -5000, { isBaseBP: true });
+    EffectTemplate.draw(stack.processing.owner, stack.core);
+  },
+};

--- a/src/game-data/effects/cards/SP-057.ts
+++ b/src/game-data/effects/cards/SP-057.ts
@@ -1,0 +1,1 @@
+export { effects } from './1-1-048';

--- a/src/game-data/effects/engine/effect.ts
+++ b/src/game-data/effects/engine/effect.ts
@@ -296,7 +296,7 @@ export class Effect {
   static clock(
     stack: Stack,
     source: Card,
-    target: Unit,
+    target: Card,
     value: number,
     withoutOverClock: boolean = false
   ): void {

--- a/src/game-data/effects/engine/effect.ts
+++ b/src/game-data/effects/engine/effect.ts
@@ -34,6 +34,7 @@ import {
   type ModifyBPOption,
   type KeywordOptionParams,
 } from './effect/index';
+import { effectBan } from '@/game-data/effects/engine/effect/ban';
 
 export type { ModifyBPOption, KeywordOptionParams };
 
@@ -523,5 +524,18 @@ export class Effect {
     option: { source: DeltaSource } & { calculator: DeltaCalculator }
   ) {
     target.delta.push(new Delta({ type: 'dynamic-cost', diff: option.calculator(target) }, option));
+  }
+
+  /**
+   * 対象のカードを使用不能にする
+   *
+   * @param stack - Stack
+   * @param source - 効果の発生元
+   * @param target - 使用不能にするカード
+   * @param options -
+   * @returns
+   */
+  static ban(stack: Stack, source: Card, target: Card, options: DeltaConstructorOptionParams) {
+    return effectBan(stack, source, target, options);
   }
 }

--- a/src/game-data/effects/engine/effect/ban.ts
+++ b/src/game-data/effects/engine/effect/ban.ts
@@ -1,0 +1,20 @@
+import type { Card } from '@/package/core/class/card';
+import { Delta, type DeltaConstructorOptionParams } from '@/package/core/class/delta';
+import type { Stack } from '@/package/core/class/stack';
+
+export function effectBan(
+  _stack: Stack,
+  _source: Card,
+  target: Card,
+  option?: DeltaConstructorOptionParams
+) {
+  // カードが操作可能領域にあるか
+  const isInOperableArea =
+    target.owner.hand.some(card => card.id === target.id) ||
+    target.owner.trigger.some(card => card.id === target.id);
+  if (!isInOperableArea) return;
+
+  // Deltaを作成
+  const delta = new Delta({ type: 'banned' }, option);
+  target.delta.push(delta);
+}

--- a/src/game-data/effects/engine/effect/bounce.ts
+++ b/src/game-data/effects/engine/effect/bounce.ts
@@ -49,7 +49,10 @@ export function effectBounce(
       return;
     }
     default: {
-      effectMove(stack, source, target, location);
+      const overflow =
+        location !== 'deck' &&
+        target.owner[location].length < stack.core.room.rule.player.max[location];
+      effectMove(stack, source, target, overflow ? 'trash' : location);
     }
   }
 }

--- a/src/game-data/effects/engine/effect/bounce.ts
+++ b/src/game-data/effects/engine/effect/bounce.ts
@@ -51,7 +51,7 @@ export function effectBounce(
     default: {
       const overflow =
         location !== 'deck' &&
-        target.owner[location].length < stack.core.room.rule.player.max[location];
+        target.owner[location].length >= stack.core.room.rule.player.max[location];
       effectMove(stack, source, target, overflow ? 'trash' : location);
     }
   }

--- a/src/game-data/effects/engine/effect/clock.ts
+++ b/src/game-data/effects/engine/effect/clock.ts
@@ -1,12 +1,12 @@
 import type { Stack } from '@/package/core/class/stack';
-import type { Card, Unit } from '@/package/core/class/card';
+import { Unit, type Card } from '@/package/core/class/card';
 import { effectBreak } from './break';
 import { effectKeyword } from './keyword';
 
 export function effectClock(
   stack: Stack,
   source: Card,
-  target: Unit,
+  target: Card,
   value: number,
   withoutOverClock: boolean = false
 ): void {
@@ -16,7 +16,10 @@ export function effectClock(
   if (target.lv > 3) target.lv = 3;
   if (target.lv < 1) target.lv = 1;
 
-  if (target.owner.hand.find(card => card.id === target.id)) {
+  if (
+    target.owner.hand.find(card => card.id === target.id) ||
+    target.owner.trigger.find(card => card.id === target.id)
+  ) {
     if (target.lv !== before) {
       if (value > 0) stack.core.room.soundEffect('clock-up');
       if (value < 0) stack.core.room.soundEffect('trash');
@@ -24,7 +27,7 @@ export function effectClock(
     return;
   }
 
-  if (target.lv !== before) {
+  if (target.lv !== before && target instanceof Unit) {
     if (value > 0) {
       target.delta = target.delta.filter(delta => delta.effect.type !== 'damage');
       stack.core.room.soundEffect('clock-up');

--- a/src/game-data/effects/engine/effect/types.ts
+++ b/src/game-data/effects/engine/effect/types.ts
@@ -1,6 +1,5 @@
-import type { Delta, DeltaSource } from '@/package/core/class/delta';
+import type { Delta, DeltaCondition, DeltaSource } from '@/package/core/class/delta';
 import type { GameEvent } from '../../schema/events';
-import type { Unit } from '@/package/core/class/card';
 
 export interface KeywordOptionParams {
   event?: GameEvent;
@@ -14,7 +13,7 @@ export interface KeywordOptionParams {
    * @param blocker ブロッカーの候補
    * @returns falseでブロック可能、trueでブロック不可能
    */
-  condition?: (self?: Unit, blocker?: Unit) => boolean | unknown;
+  condition?: DeltaCondition;
 }
 
 export type ModifyBPOption =

--- a/src/game-data/effects/engine/effect/types.ts
+++ b/src/game-data/effects/engine/effect/types.ts
@@ -1,5 +1,6 @@
 import type { Delta, DeltaSource } from '@/package/core/class/delta';
 import type { GameEvent } from '../../schema/events';
+import type { Unit } from '@/package/core/class/card';
 
 export interface KeywordOptionParams {
   event?: GameEvent;
@@ -7,6 +8,13 @@ export interface KeywordOptionParams {
   cost?: number;
   onlyForOwnersTurn?: boolean;
   source?: DeltaSource;
+  /**
+   * 次元干渉の特殊条件関数
+   * @param self アタッカー
+   * @param blocker ブロッカーの候補
+   * @returns falseでブロック可能、trueでブロック不可能
+   */
+  condition?: (self?: Unit, blocker?: Unit) => boolean | unknown;
 }
 
 export type ModifyBPOption =

--- a/src/game-data/effects/jokers/the-devil/carnival-dominate.ts
+++ b/src/game-data/effects/jokers/the-devil/carnival-dominate.ts
@@ -22,7 +22,7 @@ export const effects: CardEffects = {
     );
 
     EffectHelper.random(opponent.trigger, 2).forEach(card =>
-      Effect.move(stack, stack.processing, card, 'trash')
+      Effect.break(stack, stack.processing, card)
     );
     EffectHelper.repeat(2, () => EffectTemplate.draw(owner, stack.core));
   },

--- a/src/game-data/effects/jokers/the-devil/guilty-ash.ts
+++ b/src/game-data/effects/jokers/the-devil/guilty-ash.ts
@@ -26,6 +26,6 @@ export const effects: CardEffects = {
       '破壊するカードを選択'
     );
 
-    Effect.move(stack, stack.processing, target, 'trash');
+    Effect.break(stack, stack.processing, target);
   },
 };

--- a/src/package/core/class/delta.ts
+++ b/src/package/core/class/delta.ts
@@ -1,6 +1,6 @@
 import type { DeltaEffect, IDelta, IUnit } from '@/submodule/suit/types';
 import type { StackWithCard } from '@/game-data/effects/schema/types';
-import type { Card } from './card';
+import type { Card, Unit } from './card';
 import type { GameEvent } from '@/game-data/effects/schema/events';
 
 export interface DeltaSource {
@@ -14,12 +14,14 @@ export interface DeltaEvent {
 }
 
 export type DeltaCalculator = (self: Card) => number;
+export type DeltaCondition = (self?: Unit, blocker?: Unit) => boolean | unknown;
 
 export type DeltaConstructorOptionParams = {
   onlyForOwnersTurn?: boolean;
   source?: DeltaSource;
   permanent?: boolean;
   calculator?: DeltaCalculator;
+  condition?: DeltaCondition;
 } & (DeltaEvent | {});
 
 export class Delta implements IDelta {
@@ -30,7 +32,8 @@ export class Delta implements IDelta {
   source?: DeltaSource;
   onlyForOwnersTurn: boolean; // このパラメータが true のとき、eventに合致するイベントが発生しても自分のターン中でない場合はcountを減算しない
   permanent: boolean; // このパラメータが true のとき、unit.reset() しても残す (効果が永続するという意味ではない。その場合はeventにundefiendを設定する。)
-  calculator?: (self: Card) => number; // 数値の変動を動的に計算する
+  calculator?: DeltaCalculator; // 数値の変動を動的に計算する
+  condition?: DeltaCondition; // 特殊条件次元干渉用
 
   constructor(effect: DeltaEffect, options: DeltaConstructorOptionParams | undefined = {}) {
     this.id = crypto.randomUUID();
@@ -45,6 +48,7 @@ export class Delta implements IDelta {
     this.source = options.source;
     this.permanent = options.permanent ?? false;
     this.calculator = options.calculator;
+    this.condition = options.condition;
   }
 
   /**

--- a/src/package/core/class/delta.ts
+++ b/src/package/core/class/delta.ts
@@ -14,7 +14,7 @@ export interface DeltaEvent {
 }
 
 export type DeltaCalculator = (self: Card) => number;
-export type DeltaCondition = (self?: Unit, blocker?: Unit) => boolean | unknown;
+export type DeltaCondition = (self?: Unit, blocker?: Unit) => boolean;
 
 export type DeltaConstructorOptionParams = {
   onlyForOwnersTurn?: boolean;

--- a/src/package/core/class/stack.ts
+++ b/src/package/core/class/stack.ts
@@ -395,15 +395,30 @@ export class Stack implements IStack {
     }
   }
 
-  private moveUnit(target: Unit, destination: CardArrayKeys, sound: string = 'leave') {
+  private moveUnit(target: Unit, destination: CardArrayKeys, sound?: string) {
     const owner = target.owner;
     // ターゲットがフィールドに残留しているかチェック
     const isOnField = owner.field.some(unit => unit.id === target.id);
 
+    // サウンドキーを得る
+    const getSoundKey = () => {
+      switch (destination) {
+        case 'deck':
+        case 'hand':
+          return 'bounce';
+        case 'delete':
+          return 'deleted';
+        case 'trash':
+        case 'trigger':
+        default:
+          return 'leave';
+      }
+    };
+
     // destinationに送る
     if (isOnField) {
       console.log('%s を %s に移動', target.catalog.name, destination);
-      this.core.room.soundEffect(sound);
+      this.core.room.soundEffect(sound ?? getSoundKey());
       owner.field = owner.field.filter(unit => unit.id !== target.id);
       target.reset();
 

--- a/src/package/core/operations/battle.ts
+++ b/src/package/core/operations/battle.ts
@@ -161,8 +161,6 @@ export async function block(core: Core, attacker: Unit): Promise<Unit | undefine
   if (!blockerOwner || !attackerOwner)
     throw new Error('存在しないプレイヤーまたはユニットが指定されました');
 
-  console.log('block');
-
   // ブロック側ユニットのブロック可能ユニットを列挙
   const blockable = blockerOwner.field.filter((unit: Unit) => {
     // 次元干渉／コストN を発動している場合、指定コスト以上のユニットはブロックできない

--- a/src/package/core/operations/battle.ts
+++ b/src/package/core/operations/battle.ts
@@ -161,27 +161,27 @@ export async function block(core: Core, attacker: Unit): Promise<Unit | undefine
   if (!blockerOwner || !attackerOwner)
     throw new Error('存在しないプレイヤーまたはユニットが指定されました');
 
+  console.log('block');
+
   // ブロック側ユニットのブロック可能ユニットを列挙
   const blockable = blockerOwner.field.filter((unit: Unit) => {
-    // 次元干渉を発動している場合、指定コスト以上のユニットはブロックできない
-    const blockableCost = attacker.hasKeyword('次元干渉')
-      ? Math.min(
-          ...attacker.delta
-            .map(delta =>
-              delta.effect.type === 'keyword' && delta.effect.name === '次元干渉'
-                ? delta.effect.cost
-                : undefined
-            )
-            .filter(v => v !== undefined)
-        )
-      : undefined;
-    const isNumber = blockableCost !== undefined && Number.isInteger(blockableCost);
+    // 次元干渉／コストN を発動している場合、指定コスト以上のユニットはブロックできない
+    // Delta内の少なくとも1つがブロック不可能と判定すれば対象のunitにはブロックされない
+    const isUnblockable = attacker.hasKeyword('次元干渉')
+      ? attacker.delta
+          .filter(delta => delta.effect.type === 'keyword' && delta.effect.name === '次元干渉')
+          .some(delta => {
+            if (delta.effect.type === 'keyword' && delta.effect.name === '次元干渉') {
+              if (delta.condition) {
+                return delta.condition(attacker, unit);
+              } else {
+                return delta.effect.cost <= unit.catalog.cost;
+              }
+            }
+          })
+      : false;
 
-    return (
-      unit.active &&
-      !unit.hasKeyword('防御禁止') &&
-      (isNumber ? unit.catalog.cost < blockableCost : true)
-    );
+    return unit.active && !unit.hasKeyword('防御禁止') && !isUnblockable;
   });
 
   const forceBlock = blockable.filter((unit: Unit) => {

--- a/src/package/core/operations/battle.ts
+++ b/src/package/core/operations/battle.ts
@@ -176,6 +176,8 @@ export async function block(core: Core, attacker: Unit): Promise<Unit | undefine
                 return delta.effect.cost <= unit.catalog.cost;
               }
             }
+
+            return false;
           })
       : false;
 

--- a/src/package/core/operations/message-handler.ts
+++ b/src/package/core/operations/message-handler.ts
@@ -157,7 +157,7 @@ export async function handleMessage(core: Core, message: Message) {
         // 軽減前のcostが0でない場合はmitigateをtriggerからtrashに移動させる
         if (card.currentCost > 0 && mitigate) {
           player.trigger = player.trigger.filter(c => c.id !== mitigate.id);
-          mitigate.lv = 1;
+          mitigate.reset(true);
           player.trash.push(mitigate);
         }
 
@@ -382,7 +382,7 @@ export async function handleMessage(core: Core, message: Message) {
 
         if (!(target.card instanceof Joker)) {
           player.trash.push(target.card);
-          target.card.reset();
+          target.card.reset(true);
         }
         core.room.sync();
         core.room.soundEffect('trash');

--- a/src/package/server/room/room.ts
+++ b/src/package/server/room/room.ts
@@ -13,11 +13,10 @@ import { Intercept } from '@/package/core/class/card';
 import { GameLogger } from '@/package/logging';
 import type { MatchingMode } from '@/package/server/matching/types';
 import { PlayCreditService } from '@/package/server/credits';
+import { nanoid } from 'nanoid';
 
 export class Room {
-  id = Math.floor(Math.random() * 99999)
-    .toString()
-    .padStart(5, '0');
+  id = nanoid(6);
   name: string;
   core: Core;
   players: Map<string, Player> = new Map<string, Player>();


### PR DESCRIPTION
## 修正
- 手札に戻す効果・トリガーゾーンにセットする効果において、対象の領域が上限に到達している状況下で効果が発動した場合、捨札に送られるように修正しました。
- 以下のカードの不具合を修正しました。

| カードID | カード名 | 内容 |
| -- | -- | -- |
| 2-0-135 | 神獣の住む秘境 | ユニットが破壊済みでも効果が発動する |
| 2-0-310 | ジンニーヤ | 相手の【精霊】アタック時にも発動する |
| 2-0-311 | ハーピー | 相手のターン終了時にも消滅効果が発動する |
| 2-0-333 | ヘカトンケイル | 相手のインターセプト使用時に効果が発動しない |
| 2-0-338 | パラライズ・フォグ | 空打ちされる |
| 2-0-343 | 鍛冶神の業物 | 空打ちされる |
| 2-0-360 | 不可侵光壁 | 空打ちされる |
| 2-1-004 | ストロベリーガール | ユニットカード以外を使用してもコスト減少効果が終了する |
| 2-1-009 | レモンガール | ユニットカード以外を使用してもコスト減少効果が終了する |
| 2-1-014 | ブルーベリーガール | ユニットカード以外を使用してもコスト減少効果が終了する |
| 2-1-019 | メロンガール | ユニットカード以外を使用してもコスト減少効果が終了する |
| 2-1-025 | グレープガール | ユニットカード以外を使用してもコスト減少効果が終了する |
| 2-3-032 | トライフォース | デネブ／アルタイル／ベガ以外も効果発動の対象となる |
| 2-3-156 | 花いろ日記 | コスト指定が正しくない |
| 2-3-233 | トリニティ・アステリズム | 消滅効果が発動しない |
| PR-234 | 神慌意乱 | 戦闘ダメージでも発動する |

## 追加

- 以下のカードを追加しました。

| カードID | カード名 |
| -- | -- |
| 1-0-052 | ジークフリート |
| 1-0-056 | 不穏な霧 |
| 1-0-136 | 迷子 |
| 1-1-086 | ヘラクレス |
| 1-1-098 | 浮遊術 |
| 1-2-086 | 熾天使の片翼 |
| 1-2-098 | 大いなる世界 |
| 1-3-057 | 神札再生 |
| 1-3-125 | 皆既日食 |
| 1-3-255 | タルンカッペ |
| 1-3-256 | 聖光による庇護 |
| 1-4-258 | 大天使の息吹 |
| 1-4-261 | ペイン・シャドウ |
| 2-0-042 | パイモン |
| 2-0-046 | 受け継がれし英雄譚 |
| 2-0-134 | グランドライブラリ |
| 2-0-220 | 転生・毘沙門 |
| 2-0-302 | 春花のコレー |
| 2-1-056 | オーバードーズ |
| 2-2-046 | 結集セシ化身タチ |
| 2-2-150 | ウロボロスの刻印 |
| 2-3-104 | 暴魔アエーシュマ |
| 2-3-124 | 愛天使アメリア |
| 2-3-130 | 呪法のファラオ |
| 2-3-144 | すやすやスリーピング |
| 2-3-152 | アンデッドパレード |
| 2-3-213 | フリーズロイド |
| 2-3-231 | ＬＩＶＥラリー |
| 2-3-235 | フルーツバスケット |
| PR-024 | ゴッドフィスト |
| PR-096 | 幻想の里 |
| PR-111 | アプスー |
| PR-140 | グローリードラゴン |
| PR-149 | 丑の刻参り |
| PR-170 | ルクス・マキナ |
| PR-180 | レイディアントドラゴン |
| PR-200 | 御使いのテレサ |
| PR-203 | 黒女神パールヴァティー |
| PR-239 | 望まぬ争い |
| SP-052 | 自然の声 |
| SP-057 | 守神・不動明王 |